### PR TITLE
Add alpha disclaimers to README, remove outdated selective approval c…

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -80,10 +80,10 @@ Workspace structure with 12 crates under `crates/` and `apps/`. Resource URIs (`
 - **Error messages**: Graceful failures with actionable guidance (not panics or cryptic errors)
 - **.taignore defaults** cover common project types (Rust, Node, Python, Go)
 
-### Disclaimers to include
+### Disclaimers to include (added to README)
 - "Alpha — not production-ready. Do not use for critical/irreversible operations"
 - "The security model is not yet audited. Do not trust it with secrets or sensitive data"
-- "Selective approval (Phase 4b-4c) is not yet implemented — review is all-or-nothing"
+- ~~"Selective approval (Phase 4b-4c) is not yet implemented — review is all-or-nothing"~~ — DONE (Phase 4b-4c complete)
 - "No sandbox isolation yet — agent runs with your permissions in a staging copy"
 - "No conflict detection yet — editing source files while a TA session is active may lose changes on apply (git protects committed work)"
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ Trusted Autonomy achieves this by:
 
 ---
 
+## Current status: v0.1.0-alpha
+
+This is an early alpha release for feedback. Please note:
+
+- **Not production-ready.** Do not use for critical or irreversible operations.
+- **The security model is not yet audited.** Do not trust it with secrets or sensitive data.
+- **No sandbox isolation yet.** The agent runs with your permissions in a staging copy. Defense-in-depth (OCI/gVisor) is planned for Phase 7.
+- **No conflict detection yet.** Editing source files while a TA session is active may lose uncommitted changes on apply. Git protects committed work.
+
+If any of these are blockers for your use case, watch the repo — each is on the [roadmap](PLAN.md).
+
+---
+
 ## Design principles
 - Normal environment illusion: tools feel like standard filesystem/network access, but all effects are mediated.
 - Default collect (staged-by-default): changes accumulate as pending review artifacts (PR package) rather than applying immediately.


### PR DESCRIPTION
…aveat

- README: Add "Current status: v0.1.0-alpha" section with 4 honest disclaimers (not production-ready, unaudited security, no sandbox, no conflict detection). Placed before Design Principles.
- PLAN.md: Strike through the selective approval disclaimer since Phase 4b-4c is complete. Note disclaimers are now in README.