### PR TITLE
Unify PLAN.md phase numbering with version-based naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,11 +59,22 @@ This applies to both manual work and TA-mediated goals. When `ta pr apply --git-
 
 ## Current State
 
+- **Current version**: `0.1.2-alpha`
 - **161 tests passing** across 12 crates (run `ta plan list` for full status)
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --source . --phase 4b`
 - `ta pr apply` auto-updates PLAN.md when a phase completes
+
+## Version Management
+
+When completing a phase, you MUST update versions as part of the work:
+
+1. **`apps/ta-cli/Cargo.toml`**: Update `version` to the phase's target version (e.g., `"0.2.0-alpha"`)
+2. **This file (`CLAUDE.md`)**: Update "Current version" above to match
+3. **`PLAN.md`**: Mark the phase `<!-- status: done -->` (done automatically by `ta pr apply --phase`)
+
+Version format: `MAJOR.MINOR.PATCH-alpha` (semver). See `PLAN.md` "Versioning & Release Policy" for the full mapping of phases to versions.
 
 ### How It Works (Phase 3 Overlay Flow)
 1. `ta goal start "title" --source . --phase 4b` → copies project to `.ta/staging/`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.1.0-alpha"
+version = "0.1.2-alpha"
 dependencies = [
  "anyhow",
  "chrono",

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-cli"
-version = "0.1.0-alpha"
+version = "0.1.2-alpha"
 edition = "2021"
 description = "CLI for goals, PR review, and approvals in Trusted Autonomy"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Renumber all future phases from v0.2 onward with consistent version-to-release mapping
- Add "Versioning & Release Policy" section to PLAN.md with agent instructions for version updates
- Bump ta-cli from `0.1.0-alpha` to `0.1.2-alpha`
- Add version management instructions to CLAUDE.md so agents update versions when completing phases
- Each major version (v0.2.0, v0.3.0, etc.) is a release point with git tag

## Test plan
- [x] `cargo build -p ta-cli` shows `ta-cli v0.1.2-alpha`
- [ ] CI passes (clippy, fmt, test)
- [ ] Verify PLAN.md phase numbering is consistent from v0.2 through v1.0