### PR TITLE
Docs overhaul, YAML agent configs, EULA terms gate, release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,17 @@ jobs:
             nix run github:trustedautonomy/ta
             ```
 
+            ### Documentation
+
+            - [USAGE.md](https://github.com/trustedautonomy/ta/blob/main/docs/USAGE.md) — Complete usage guide (also included in binary downloads)
+            - [DISCLAIMER.md](https://github.com/trustedautonomy/ta/blob/main/DISCLAIMER.md) — Terms of use
+            - HTML versions of both documents are available as release assets below
+
             ### Binaries
 
-            Download the appropriate binary for your platform below.
+            Download the appropriate binary for your platform below. Each archive includes the `ta` binary, `USAGE.md`, `DISCLAIMER.md`, and `LICENSE`.
+
+            **Note:** On first run, `ta` will prompt you to review and accept the terms of use.
 
             ---
 
@@ -133,10 +141,15 @@ jobs:
       - name: Create artifact directory
         run: mkdir -p artifacts
 
-      - name: Package binary (Unix)
+      - name: Package binary with docs (Unix)
         run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ../../../artifacts/${{ env.BINARY_NAME }}-${{ needs.create-release.outputs.version }}-${{ matrix.target }}.tar.gz ${{ env.BINARY_NAME }}
+          mkdir -p staging
+          cp target/${{ matrix.target }}/release/${{ env.BINARY_NAME }} staging/
+          cp docs/USAGE.md staging/ 2>/dev/null || true
+          cp DISCLAIMER.md staging/ 2>/dev/null || true
+          cp LICENSE staging/ 2>/dev/null || true
+          cd staging
+          tar czf ../artifacts/${{ env.BINARY_NAME }}-${{ needs.create-release.outputs.version }}-${{ matrix.target }}.tar.gz *
           cd -
 
       - name: Generate SHA256 checksums
@@ -155,7 +168,7 @@ jobs:
           asset_name: ${{ env.BINARY_NAME }}-${{ needs.create-release.outputs.version }}-${{ matrix.target }}.tar.gz
           asset_content_type: application/gzip
 
-      - name: Upload checksums (first job only)
+      - name: Upload checksums and docs (first job only)
         if: matrix.target == 'x86_64-apple-darwin'
         uses: actions/upload-release-asset@v1
         env:
@@ -165,6 +178,50 @@ jobs:
           asset_path: ./artifacts/SHA256SUMS.txt
           asset_name: SHA256SUMS.txt
           asset_content_type: text/plain
+
+      - name: Upload USAGE.md (first job only)
+        if: matrix.target == 'x86_64-apple-darwin'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./docs/USAGE.md
+          asset_name: USAGE.md
+          asset_content_type: text/markdown
+
+      - name: Generate HTML docs (first job only)
+        if: matrix.target == 'x86_64-apple-darwin'
+        run: |
+          brew install pandoc
+          pandoc docs/USAGE.md -s --metadata title="Trusted Autonomy Usage Guide" \
+            -c https://cdn.simplecss.org/simple.min.css \
+            -o docs/USAGE.html
+          pandoc DISCLAIMER.md -s --metadata title="Trusted Autonomy Terms of Use" \
+            -c https://cdn.simplecss.org/simple.min.css \
+            -o docs/DISCLAIMER.html
+
+      - name: Upload USAGE.html (first job only)
+        if: matrix.target == 'x86_64-apple-darwin'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./docs/USAGE.html
+          asset_name: USAGE.html
+          asset_content_type: text/html
+
+      - name: Upload DISCLAIMER.html (first job only)
+        if: matrix.target == 'x86_64-apple-darwin'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ./docs/DISCLAIMER.html
+          asset_name: DISCLAIMER.html
+          asset_content_type: text/html
 
   publish-crate:
     name: Publish to crates.io

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,8 @@ This applies to both manual work and TA-mediated goals. When `ta pr apply --git-
 
 ## Current State
 
-- **Current version**: `0.1.2-alpha`
-- **161 tests passing** across 12 crates (run `ta plan list` for full status)
+- **Current version**: `0.2.2-alpha`
+- **208 tests passing** across 12 crates (run `ta plan list` for full status)
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --source . --phase 4b`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +907,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1018,6 +1037,8 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "sha2",
  "ta-audit",
  "ta-changeset",
  "ta-connector-fs",
@@ -1392,6 +1413,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,8 @@ rmcp = { version = "0.14", features = ["server", "transport-io"] }
 # JSON Schema generation — used by rmcp for MCP tool parameter schemas.
 schemars = "1"
 
+# YAML configuration parsing — used for agent launch configs.
+serde_yaml = "0.9"
+
 # Testing utilities
 tempfile = "3"

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,106 @@
+# Trusted Autonomy — Terms of Use & Disclaimer
+
+**Version**: 1.0 (2026-02-11)
+
+By using, installing, or running Trusted Autonomy ("the Software"), you acknowledge
+and agree to the following terms. If you do not agree, do not use the Software.
+
+---
+
+## 1. Alpha Software Disclaimer
+
+This Software is provided in **alpha** state. It is under active development
+and has **not been audited for security, correctness, or reliability**.
+
+- **Do not** use this Software for critical, production, or irreversible operations.
+- **Do not** trust this Software with secrets, credentials, or sensitive data.
+- **Do not** rely on this Software as a sole security control.
+
+The staging and review model is designed to reduce risk but does not eliminate it.
+Agents run with your system permissions inside a staging directory copy. There is
+no sandbox isolation in the current release.
+
+## 2. No Warranty
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT.
+
+THE AUTHORS AND COPYRIGHT HOLDERS MAKE NO REPRESENTATIONS OR WARRANTIES
+REGARDING THE ACCURACY, RELIABILITY, COMPLETENESS, OR TIMELINESS OF THE
+SOFTWARE OR ITS OUTPUT.
+
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR
+OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## 3. Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL THE
+AUTHORS, CONTRIBUTORS, OR COPYRIGHT HOLDERS BE LIABLE FOR ANY INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, CONSEQUENTIAL, OR PUNITIVE DAMAGES
+(INCLUDING BUT NOT LIMITED TO LOSS OF DATA, LOSS OF PROFITS, BUSINESS
+INTERRUPTION, OR LOSS OF GOODWILL), REGARDLESS OF THE CAUSE OF ACTION OR
+THE THEORY OF LIABILITY, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+THE AGGREGATE LIABILITY OF THE AUTHORS AND CONTRIBUTORS FOR ALL CLAIMS
+ARISING FROM OR RELATED TO THE SOFTWARE SHALL NOT EXCEED THE AMOUNT YOU
+PAID FOR THE SOFTWARE (WHICH MAY BE ZERO).
+
+## 4. Indemnification
+
+You agree to indemnify, defend, and hold harmless the authors, contributors,
+and copyright holders of the Software from and against any and all claims,
+damages, losses, costs, and expenses (including reasonable legal fees) arising
+from or related to:
+
+- Your use of the Software
+- Any output, actions, or effects produced by AI agents operating under the Software
+- Your violation of these terms
+- Your violation of any applicable law or regulation
+
+## 5. AI Agent Conduct
+
+The Software mediates AI agent actions through staging and review workflows.
+However:
+
+- You are solely responsible for the actions you approve and apply.
+- The Software does not guarantee that AI agents will behave as intended.
+- Review all proposed changes carefully before approval.
+- The staging model reduces but does not eliminate the risk of unintended effects.
+
+## 6. Data and Privacy
+
+The Software operates locally on your machine. It does not transmit data to
+the authors or any third party. However:
+
+- AI agents invoked by the Software (Claude, Codex, etc.) are subject to their
+  own providers' terms of service and privacy policies.
+- API keys and credentials you provide are used to authenticate with those
+  third-party services.
+- The Software does not store, transmit, or access your API keys beyond the
+  local process environment.
+
+## 7. Acceptance
+
+By running `ta` (the CLI) or any component of the Software, you confirm that
+you have read, understood, and agree to these terms.
+
+First-time users will be prompted to accept these terms before the Software
+will operate. Acceptance is recorded locally at `~/.config/ta/terms.json`.
+If these terms are updated in a future release, you will be prompted to
+re-accept before continuing.
+
+## 8. Governing License
+
+This Software is licensed under the **Apache License, Version 2.0**. These
+terms supplement (and do not replace) the Apache 2.0 license. In case of
+conflict, the Apache 2.0 license governs for licensing purposes; these terms
+govern for use and liability purposes.
+
+See the [LICENSE](LICENSE) file for the full Apache 2.0 license text.
+
+---
+
+**By proceeding, you agree to these terms.**

--- a/PLAN.md
+++ b/PLAN.md
@@ -83,7 +83,7 @@ Workspace structure with 12 crates under `crates/` and `apps/`. Resource URIs (`
 ### Required for v0.1
 - [x] **Version info**: `ta --version` shows `0.1.0-alpha (git-hash date)`, build.rs embeds git metadata
 - **Simple install**: `cargo install ta-cli` or single binary download (cross-compile for macOS/Linux)
-- **Agent launch configs as YAML**: Replace hard-coded `AgentLaunchConfig` match arms with discoverable YAML files (e.g., `agents/claude-code.yaml`, `agents/claude-flow.yaml`). Ship built-in defaults, allow user overrides in `.ta/agents/` or `~/.config/ta/agents/`. Schema: command, args_template (`{prompt}` substitution), injects_context_file, env vars, description.
+- [x] **Agent launch configs as YAML**: YAML files in `agents/` (claude-code.yaml, codex.yaml, claude-flow.yaml, generic.yaml). Config search: `.ta/agents/` (project) → `~/.config/ta/agents/` (user) → shipped defaults → hard-coded fallback. Schema: command, args_template (`{prompt}`), injects_context_file, injects_settings, pre_launch, env. Added `serde_yaml` dep, 2 tests.
 - **Agent setup guides**: Step-by-step for Claude Code, Claude Flow (when available), Codex/similar
 - **README rewrite**: Quick-start in <5 minutes, architecture overview, what works / what doesn't
 - **`ta adapter install claude-code`** works end-to-end (already partially implemented)

--- a/README.md
+++ b/README.md
@@ -65,14 +65,15 @@ Trusted Autonomy achieves this by:
 
 ---
 
-## Current status: v0.1.1-alpha
+## Current status: v0.2.2-alpha
+
+**208 tests** across 12 crates. Under active development. See [PLAN.md](PLAN.md) for the full roadmap.
 
 This is an early alpha release for feedback. Please note:
 
 - **Not production-ready.** Do not use for critical or irreversible operations.
 - **The security model is not yet audited.** Do not trust it with secrets or sensitive data.
 - **No sandbox isolation yet.** The agent runs with your permissions in a staging copy. Defense-in-depth (OCI/gVisor) is planned for Phase 7.
-- **No conflict detection yet.** Editing source files while a TA session is active may lose uncommitted changes on apply. Git protects committed work.
 
 If any of these are blockers for your use case, watch the repo — each is on the [roadmap](PLAN.md).
 
@@ -80,31 +81,7 @@ If any of these are blockers for your use case, watch the repo — each is on th
 
 ## Quick Start
 
-### Install
-
-```bash
-# From source (current alpha)
-git clone https://github.com/trustedautonomy/ta
-cd ta
-cargo build --release
-export PATH="$PWD/target/release:$PATH"
-```
-
-### Run Your First Goal
-
-```bash
-# Start an agent-mediated goal
-ta run "Add README badge for build status" --source .
-
-# Review the changes
-ta pr view <pr-id>
-
-# Approve and apply
-ta pr approve <pr-id>
-ta pr apply <pr-id>
-```
-
-**📖 For detailed usage, configuration, and workflows, see [docs/USAGE.md](docs/USAGE.md)**
+See the [detailed Quick Start](#quick-start-5-minutes) below for full install + agent setup instructions, or jump to [docs/USAGE.md](docs/USAGE.md) for comprehensive usage guidance. Run `ta --help` for CLI reference.
 
 ---
 
@@ -115,13 +92,6 @@ ta pr apply <pr-id>
 - Single chokepoint: all reads/writes and external effects flow through an MCP Gateway with policy enforcement and audit.
 - PR-per-milestone workflow: complex goals are decomposed into major steps, each producing a PR package for approval.
 - Replaceable orchestration: the substrate is the trust layer; planners/swarms are pluggable.
-
-## “default deny” vs “default collect”
-Trusted Autonomy uses two distinct defaults:
-1. Capability default (security boundary): default deny. If an agent lacks an explicit capability, the gateway rejects it.
-2.  Mutation default (operational workflow): default collect. If the agent is allowed to write, the gateway routes writes into staging (patches/drafts) and queues them for review. Commit/send/post are gated.
-
-Result: within the agent’s charter, work “just happens” and produces a PR package. Human review occurs at major milestones.
 
 ## Why MCP is the abstraction boundary
 
@@ -452,6 +422,8 @@ ta pr apply <package-id> --git-commit
 ```
 
 That's it. The agent never knew it was in a staging workspace.
+
+> **For detailed usage, configuration options, and troubleshooting, see [docs/USAGE.md](docs/USAGE.md)** or run `ta --help`.
 
 ---
 
@@ -919,38 +891,23 @@ cargo fmt --all -- --check
 
 ---
 
-## Status
+## What's Implemented
 
-Trusted Autonomy is under active development. **176 tests** across 12 crates. See [PLAN.md](PLAN.md) for the full roadmap.
-
-### Implemented
 - **Transparent overlay mediation** — agents work in staging copies using native tools, TA is invisible
 - **Selective approval** — `--approve "src/**" --reject "*.test.rs" --discuss "config/*"` with dependency warnings
+- **Concurrent session conflict detection** — detects source changes during active goals, prevents stale overwrites
+- **External diff routing** — route binary/media files to external tools (`*.uasset` to Unreal, `*.png` to image diff, etc.)
+- **YAML agent configs** — discoverable config files for any agent framework (`.ta/agents/`, `~/.config/ta/agents/`)
 - **Settings injection** — auto-configures agent permissions (replaces `--dangerously-skip-permissions`)
-- **Community forbidden-tools deny list** — `.ta-forbidden-tools` for patterns that should never be allowed
+- **Follow-up goals** — `--follow-up` to iterate on review feedback with full parent context injection
+- **Submit adapters** — pluggable VCS integration (git commit/push/PR, or no-VCS file copy)
 - Append-only audit log with SHA-256 hash chain
 - Default-deny capability engine with glob pattern matching
-- ChangeSet + PR Package data model (aligned with JSON schema)
 - Per-artifact review model (disposition, dependencies, rationale)
 - URI-aware pattern matching (scheme-scoped safety — `src/**` can't match `gmail://`)
-- Overlay workspace with exclude patterns (`.taignore`) + agent infra dir filtering
-- Binary file detection in PR view (`--summary`, `--file` flags)
-- GoalRun lifecycle state machine with event dispatch and plan tracking
 - Real MCP server (rmcp 0.14) with 9 tools and policy enforcement
 - CLI: `goal`, `pr`, `run`, `plan`, `audit`, `adapter`, `serve`
-- Agent adapter framework (Claude Code, Claude Flow, Codex, generic MCP)
-- Git integration (`ta pr apply --git-commit`)
 - Plan tracking (`ta plan list/status`, auto-update on `ta pr apply`)
-
-### Coming next
-- Agent launch configs as YAML (replace hard-coded agent configs)
-- Event system and orchestration API (`--json` output, webhooks on state transitions)
-- Notification connectors (email/Slack/Discord PR summaries + approve-from-anywhere)
-- Real connectors: Gmail, Drive, databases (same staging model, new resource types)
-- OCI/gVisor sandbox runner (defense-in-depth with TA's semantic review)
-- Virtual office runtime (role-based agent teams, event-driven triggers)
-- V2: Lazy copy-on-write VFS (reflinks/FUSE) — replaces full copy
-- Web UI for review/approval
 
 ---
 

--- a/agents/claude-code.yaml
+++ b/agents/claude-code.yaml
@@ -1,0 +1,15 @@
+# Agent launch configuration for Claude Code (Anthropic).
+# Docs: https://docs.anthropic.com/en/docs/claude-code
+#
+# Override per-project: .ta/agents/claude-code.yaml
+# Override per-user:    ~/.config/ta/agents/claude-code.yaml
+
+name: claude-code
+description: "Anthropic's Claude Code CLI — interactive coding agent"
+command: claude
+args_template:
+  - "{prompt}"
+injects_context_file: true
+injects_settings: true
+pre_launch: null
+env: {}

--- a/agents/claude-flow.yaml
+++ b/agents/claude-flow.yaml
@@ -1,0 +1,24 @@
+# Agent launch configuration for Claude Flow (multi-agent orchestration).
+# Docs: https://github.com/ruvnet/claude-flow
+#
+# Override per-project: .ta/agents/claude-flow.yaml
+# Override per-user:    ~/.config/ta/agents/claude-flow.yaml
+
+name: claude-flow
+description: "Claude Flow — multi-agent orchestration via hive-mind"
+command: npx
+args_template:
+  - "claude-flow@alpha"
+  - "hive-mind"
+  - "spawn"
+  - "{prompt}"
+  - "--claude"
+injects_context_file: true
+injects_settings: true
+pre_launch:
+  command: npx
+  args:
+    - "claude-flow@alpha"
+    - "hive-mind"
+    - "init"
+env: {}

--- a/agents/codex.yaml
+++ b/agents/codex.yaml
@@ -1,0 +1,17 @@
+# Agent launch configuration for OpenAI Codex CLI.
+# Docs: https://github.com/openai/codex
+#
+# Override per-project: .ta/agents/codex.yaml
+# Override per-user:    ~/.config/ta/agents/codex.yaml
+
+name: codex
+description: "OpenAI's Codex CLI agent with full-auto approval"
+command: codex
+args_template:
+  - "--approval-mode"
+  - "full-auto"
+  - "{prompt}"
+injects_context_file: false
+injects_settings: false
+pre_launch: null
+env: {}

--- a/agents/generic.yaml
+++ b/agents/generic.yaml
@@ -1,0 +1,47 @@
+# Template for adding a custom agent to Trusted Autonomy.
+#
+# Copy this file to one of:
+#   .ta/agents/<agent-name>.yaml      (project-specific override)
+#   ~/.config/ta/agents/<agent-name>.yaml  (user-wide override)
+#
+# Then use: ta run "task" --agent <agent-name> --source .
+#
+# TA searches for agent configs in this order:
+#   1. .ta/agents/<agent-name>.yaml       (project override)
+#   2. ~/.config/ta/agents/<agent-name>.yaml  (user override)
+#   3. <ta-install>/agents/<agent-name>.yaml  (built-in defaults)
+#   4. Hard-coded fallback (launches command with no args)
+
+name: my-agent
+description: "Description of what this agent does"
+
+# The command to execute (must be on PATH or absolute path).
+command: my-agent-cli
+
+# Arguments passed to the command. Use {prompt} as a placeholder —
+# TA replaces it with the goal title + objective text.
+args_template:
+  - "{prompt}"
+
+# If true, TA injects goal context into CLAUDE.md before launch.
+# Enable for agents that read CLAUDE.md for instructions.
+injects_context_file: false
+
+# If true, TA injects .claude/settings.local.json with permissions.
+# Enable for Claude Code-compatible agents.
+injects_settings: false
+
+# Optional command to run before the main agent launch.
+# Set to null if no pre-launch step is needed.
+pre_launch: null
+# Example:
+# pre_launch:
+#   command: my-agent-cli
+#   args: ["init", "--workspace"]
+
+# Environment variables to set for the agent process.
+env: {}
+# Example:
+# env:
+#   MY_AGENT_MODE: "autonomous"
+#   MY_AGENT_LOG_LEVEL: "info"

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -22,6 +22,8 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 rmcp = { workspace = true }
+serde_yaml = { workspace = true }
+sha2 = { workspace = true }
 tokio = { workspace = true }
 
 # Internal crates

--- a/apps/ta-cli/src/commands/mod.rs
+++ b/apps/ta-cli/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod plan;
 pub mod pr;
 pub mod run;
 pub mod serve;
+pub mod terms;

--- a/apps/ta-cli/src/commands/terms.rs
+++ b/apps/ta-cli/src/commands/terms.rs
@@ -1,0 +1,201 @@
+// terms.rs — First-run terms acceptance gate.
+//
+// On first run (or when DISCLAIMER.md changes), the user must accept the terms.
+// Acceptance state is stored at ~/.config/ta/terms.json with a SHA-256 hash
+// of the disclaimer text, so updated terms trigger re-acceptance.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+/// The disclaimer text, embedded at compile time.
+const DISCLAIMER: &str = include_str!("../../../../DISCLAIMER.md");
+
+/// Where acceptance state is stored.
+fn terms_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))?;
+    Some(
+        PathBuf::from(home)
+            .join(".config")
+            .join("ta")
+            .join("terms.json"),
+    )
+}
+
+/// Compute SHA-256 hash of the disclaimer (first 16 hex chars for brevity).
+fn disclaimer_hash() -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(DISCLAIMER.as_bytes());
+    let result = hasher.finalize();
+    hex_encode(&result[..8])
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct TermsAcceptance {
+    accepted: bool,
+    disclaimer_hash: String,
+    accepted_at: String,
+    version: String,
+}
+
+/// Check if terms have been accepted for the current disclaimer version.
+/// Returns Ok(()) if accepted, Err with message if not.
+pub fn check_accepted() -> anyhow::Result<()> {
+    let path = match terms_path() {
+        Some(p) => p,
+        None => return Ok(()), // Can't determine home dir — skip check.
+    };
+
+    if !path.exists() {
+        return Err(anyhow::anyhow!(
+            "Terms not yet accepted. Run `ta accept-terms` or use `ta --accept-terms <command>`."
+        ));
+    }
+
+    let content = std::fs::read_to_string(&path)?;
+    let acceptance: TermsAcceptance = serde_json::from_str(&content)?;
+
+    if !acceptance.accepted || acceptance.disclaimer_hash != disclaimer_hash() {
+        return Err(anyhow::anyhow!(
+            "Terms have been updated since your last acceptance. Run `ta accept-terms` to review and accept."
+        ));
+    }
+
+    Ok(())
+}
+
+/// Display the disclaimer and prompt the user for interactive acceptance.
+pub fn prompt_and_accept() -> anyhow::Result<()> {
+    // Print the disclaimer.
+    println!("{}", DISCLAIMER);
+    println!("─────────────────────────────────────────────────────");
+    print!("Do you accept these terms? [y/N] ");
+    std::io::stdout().flush()?;
+
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+
+    let answer = input.trim().to_lowercase();
+    if answer != "y" && answer != "yes" {
+        return Err(anyhow::anyhow!(
+            "Terms not accepted. Cannot continue without accepting the terms of use."
+        ));
+    }
+
+    record_acceptance()?;
+    println!("\nTerms accepted. You can now use ta.");
+    Ok(())
+}
+
+/// Accept terms non-interactively (for CI / scripted usage).
+pub fn accept_non_interactive() -> anyhow::Result<()> {
+    record_acceptance()?;
+    println!("Terms accepted (non-interactive).");
+    Ok(())
+}
+
+/// Write the acceptance record to disk.
+fn record_acceptance() -> anyhow::Result<()> {
+    let path = terms_path()
+        .ok_or_else(|| anyhow::anyhow!("Cannot determine home directory for terms storage"))?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let acceptance = TermsAcceptance {
+        accepted: true,
+        disclaimer_hash: disclaimer_hash(),
+        accepted_at: chrono::Utc::now().to_rfc3339(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+
+    let json = serde_json::to_string_pretty(&acceptance)?;
+    std::fs::write(&path, json)?;
+    Ok(())
+}
+
+/// Show the current acceptance status.
+pub fn show_status() -> anyhow::Result<()> {
+    let path = match terms_path() {
+        Some(p) => p,
+        None => {
+            println!("Cannot determine terms file location.");
+            return Ok(());
+        }
+    };
+
+    if !path.exists() {
+        println!("Terms have not been accepted yet.");
+        println!("Run `ta accept-terms` to review and accept.");
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(&path)?;
+    let acceptance: TermsAcceptance = serde_json::from_str(&content)?;
+    let current_hash = disclaimer_hash();
+
+    if acceptance.disclaimer_hash == current_hash {
+        println!("Terms accepted: {}", acceptance.accepted_at);
+        println!("Version: {}", acceptance.version);
+        println!("Status: current");
+    } else {
+        println!("Terms were accepted for a previous version.");
+        println!("Last accepted: {}", acceptance.accepted_at);
+        println!("Run `ta accept-terms` to accept the updated terms.");
+    }
+
+    Ok(())
+}
+
+/// View the full disclaimer text.
+pub fn view_terms() {
+    println!("{}", DISCLAIMER);
+}
+
+// ── Tests ──────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disclaimer_hash_is_stable() {
+        let h1 = disclaimer_hash();
+        let h2 = disclaimer_hash();
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 16); // 8 bytes = 16 hex chars
+    }
+
+    #[test]
+    fn disclaimer_is_not_empty() {
+        assert!(!DISCLAIMER.is_empty());
+        assert!(DISCLAIMER.contains("Trusted Autonomy"));
+        assert!(DISCLAIMER.contains("WITHOUT WARRANTY"));
+    }
+
+    #[test]
+    fn acceptance_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("terms.json");
+
+        let acceptance = TermsAcceptance {
+            accepted: true,
+            disclaimer_hash: disclaimer_hash(),
+            accepted_at: "2026-02-11T00:00:00Z".to_string(),
+            version: "0.2.2-alpha".to_string(),
+        };
+
+        let json = serde_json::to_string_pretty(&acceptance).unwrap();
+        std::fs::write(&path, &json).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let loaded: TermsAcceptance = serde_json::from_str(&content).unwrap();
+        assert!(loaded.accepted);
+        assert_eq!(loaded.disclaimer_hash, disclaimer_hash());
+    }
+}

--- a/examples/claude-settings.json
+++ b/examples/claude-settings.json
@@ -1,0 +1,49 @@
+{
+  "_comment": "Optimized Claude Flow settings for Trusted Autonomy. Copy to .claude/settings.json in your project.",
+  "permissions": {
+    "allow": [
+      "Bash(npx @claude-flow*)",
+      "Bash(npx claude-flow*)",
+      "mcp__claude-flow__:*"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)"
+    ]
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_FLOW_V3_ENABLED": "true"
+  },
+  "claudeFlow": {
+    "version": "3.0.0",
+    "enabled": true,
+    "modelPreferences": {
+      "default": "claude-opus-4-6",
+      "routing": "claude-haiku-4-5-20251001"
+    },
+    "agentTeams": {
+      "enabled": true,
+      "teammateMode": "auto",
+      "taskListEnabled": true,
+      "coordination": {
+        "autoAssignOnIdle": true,
+        "trainPatternsOnComplete": true,
+        "notifyLeadOnComplete": true
+      }
+    },
+    "swarm": {
+      "topology": "hierarchical-mesh",
+      "maxAgents": 15
+    },
+    "memory": {
+      "backend": "hybrid",
+      "enableHNSW": true
+    },
+    "learning": {
+      "enabled": true,
+      "autoTrain": true,
+      "patterns": ["coordination", "optimization", "prediction"]
+    }
+  }
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# scripts/release.sh — Automate the TA release process.
+#
+# Usage:
+#   ./scripts/release.sh <version>
+#
+# Examples:
+#   ./scripts/release.sh 0.3.0-alpha    # Pre-release (alpha/beta → GitHub marks as prerelease)
+#   ./scripts/release.sh 1.0.0          # Stable release
+#
+# What this script does:
+#   1. Validates the version format
+#   2. Updates version in all Cargo.toml files
+#   3. Runs the full verification suite (build, test, clippy, fmt)
+#   4. Updates Cargo.lock
+#   5. Commits the version bump
+#   6. Creates a git tag
+#   7. Pushes the tag (which triggers the GitHub Actions release workflow)
+#
+# Prerequisites:
+#   - Clean working tree (no uncommitted changes)
+#   - Nix devShell available (./dev script)
+#   - gh CLI installed (for optional PR creation)
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*"; exit 1; }
+
+# ── Argument validation ─────────────────────────────────────
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+    echo "Usage: $0 <version>"
+    echo ""
+    echo "Examples:"
+    echo "  $0 0.3.0-alpha"
+    echo "  $0 1.0.0"
+    exit 1
+fi
+
+# Validate semver-ish format (allows -alpha, -beta, -rc.1, etc.)
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+    error "Invalid version format: '$VERSION'. Expected semver (e.g., 0.3.0-alpha, 1.0.0)"
+fi
+
+TAG="v${VERSION}"
+
+# ── Pre-flight checks ───────────────────────────────────────
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+info "Release ${BOLD}${TAG}${NC} from ${REPO_ROOT}"
+
+# Check for clean working tree
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    error "Working tree is not clean. Commit or stash changes first."
+fi
+
+# Check we're on main
+BRANCH="$(git branch --show-current)"
+if [ "$BRANCH" != "main" ]; then
+    warn "Not on 'main' branch (current: ${BRANCH}). Continue? [y/N]"
+    read -r answer
+    if [ "$answer" != "y" ] && [ "$answer" != "Y" ]; then
+        error "Aborted."
+    fi
+fi
+
+# Check tag doesn't already exist
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+    error "Tag '$TAG' already exists."
+fi
+
+# ── Version bump ─────────────────────────────────────────────
+
+info "Bumping version to ${VERSION} in all Cargo.toml files..."
+
+# Workspace root Cargo.toml — update the workspace.package.version
+sed -i.bak "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+rm -f Cargo.toml.bak
+
+# All member crate Cargo.toml files
+for cargo_toml in crates/*/Cargo.toml apps/*/Cargo.toml; do
+    if [ -f "$cargo_toml" ]; then
+        # Only update the [package] version, not dependency versions
+        sed -i.bak "/^\[package\]/,/^\[/{s/^version = \".*\"/version = \"${VERSION}\"/}" "$cargo_toml"
+        rm -f "${cargo_toml}.bak"
+    fi
+done
+
+# Update Cargo.lock
+info "Updating Cargo.lock..."
+./dev "cargo update --workspace"
+
+# ── Verification ─────────────────────────────────────────────
+
+info "Running verification suite..."
+
+info "  Building..."
+./dev "cargo build --workspace"
+
+info "  Testing..."
+./dev "cargo test --workspace"
+
+info "  Clippy..."
+./dev "cargo clippy --workspace --all-targets -- -D warnings"
+
+info "  Format check..."
+./dev "cargo fmt --all -- --check"
+
+info "${GREEN}All checks passed.${NC}"
+
+# ── Commit and tag ───────────────────────────────────────────
+
+info "Committing version bump..."
+git add -A
+git commit -m "Release ${TAG}
+
+Bump all crate versions to ${VERSION}.
+
+Co-Authored-By: claude-flow <ruv@ruv.net>"
+
+info "Creating tag ${TAG}..."
+git tag -a "$TAG" -m "Release ${TAG}"
+
+# ── Push ─────────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}Ready to push.${NC} This will:"
+echo "  1. Push the commit to origin/${BRANCH}"
+echo "  2. Push tag ${TAG} (triggers the GitHub Actions release workflow)"
+echo ""
+echo -n "Push now? [y/N] "
+read -r answer
+if [ "$answer" != "y" ] && [ "$answer" != "Y" ]; then
+    warn "Tag created locally but not pushed. To push later:"
+    echo "  git push origin ${BRANCH} && git push origin ${TAG}"
+    exit 0
+fi
+
+git push origin "$BRANCH"
+git push origin "$TAG"
+
+info "${GREEN}${BOLD}Release ${TAG} pushed!${NC}"
+info "GitHub Actions will now build binaries and create the release."
+info "Monitor at: https://github.com/trustedautonomy/ta/actions"


### PR DESCRIPTION
## Summary

- **README.md**: Fix version to v0.2.2-alpha, consolidate duplicate Quick Start and Status sections, link USAGE.md prominently, remove stale "no conflict detection" disclaimer
- **docs/USAGE.md**: Update to v0.2.2-alpha with new consumer-ready sections: installation (binary downloads), agent configuration (YAML schema), Claude Flow optimization (prompt caching, model selection, swarm config)
- **YAML agent configs** (`agents/*.yaml`): Replace hard-coded `AgentLaunchConfig` match arms with discoverable YAML files. 3-tier search order: `.ta/agents/` (project) > `~/.config/ta/agents/` (user) > built-in fallback. Includes configs for claude-code, codex, claude-flow, and a generic template.
- **DISCLAIMER.md + terms gate**: Comprehensive 8-section terms of use. First-run acceptance prompt with SHA-256 hash-based versioning — updated terms trigger re-acceptance. Supports interactive and non-interactive (`--accept-terms`) modes. New subcommands: `accept-terms`, `view-terms`, `terms-status`.
- **Release workflow**: Add pandoc HTML doc generation (USAGE.html, DISCLAIMER.html), include DISCLAIMER.md in binary tarballs and as release asset
- **scripts/release.sh**: Automated release process — version bump across all Cargo.toml files, full verification suite, git tag, push (triggers GitHub Actions)
- **CLAUDE.md injection**: Agents now instructed to update docs/USAGE.md when changing user-facing behavior
- **examples/claude-settings.json**: Optimized Claude Flow defaults for new users

211 tests passing, clippy clean, fmt clean.

## Test plan

- [x] `cargo build --workspace` compiles
- [x] `cargo test --workspace` — 211 tests pass (was 208, +3 terms tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual: `ta accept-terms` interactive flow
- [ ] Manual: `ta --accept-terms run "test" --source . --no-launch` non-interactive flow
- [ ] Manual: `ta terms-status` shows acceptance state
- [ ] Manual: `ta run "test" --agent claude-code --no-launch` with/without YAML config files
- [ ] Manual: Verify release.sh dry-run on a test tag

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)