### PR TITLE
Configurable ANSI color output + macro goal plan

### DIFF
--- a/apps/ta-cli/src/commands/pr.rs
+++ b/apps/ta-cli/src/commands/pr.rs
@@ -69,6 +69,9 @@ pub enum PrCommands {
         /// Output format: terminal (default), markdown, json, html.
         #[arg(long, default_value = "terminal")]
         format: String,
+        /// Enable ANSI color output (terminal format only). Default: off.
+        #[arg(long)]
+        color: bool,
     },
     /// Approve a PR package for application.
     Approve {
@@ -138,6 +141,7 @@ pub fn execute(cmd: &PrCommands, config: &GatewayConfig) -> anyhow::Result<()> {
             open_external,
             detail,
             format,
+            color,
         } => view_package(
             config,
             id,
@@ -146,6 +150,7 @@ pub fn execute(cmd: &PrCommands, config: &GatewayConfig) -> anyhow::Result<()> {
             open_external,
             detail,
             format,
+            *color,
         ),
         PrCommands::Approve { id, reviewer } => approve_package(config, id, reviewer),
         PrCommands::Deny {
@@ -689,6 +694,7 @@ impl DiffProvider for StagingDiffProvider {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn view_package(
     config: &GatewayConfig,
     id: &str,
@@ -697,6 +703,7 @@ fn view_package(
     open_external: &Option<bool>,
     detail_str: &str,
     format_str: &str,
+    color: bool,
 ) -> anyhow::Result<()> {
     let package_id = Uuid::parse_str(id)?;
     let pkg = load_package(config, package_id)?;
@@ -759,8 +766,18 @@ fn view_package(
         diff_provider: None, // TODO: Wire up StagingWorkspace diff provider in follow-up
     };
 
+    // Resolve color: CLI --color overrides config default.
+    let effective_color = if color {
+        true
+    } else {
+        let workflow_config = ta_submit::WorkflowConfig::load_or_default(
+            &config.workspace_root.join(".ta/workflow.toml"),
+        );
+        workflow_config.display.color
+    };
+
     // Get the adapter and render.
-    let adapter = get_adapter(output_format);
+    let adapter = get_adapter(output_format, effective_color);
     let output = adapter.render(&ctx).map_err(|e| anyhow::anyhow!("{}", e))?;
 
     println!("{}", output);

--- a/crates/ta-changeset/src/output_adapters/mod.rs
+++ b/crates/ta-changeset/src/output_adapters/mod.rs
@@ -155,9 +155,12 @@ pub fn default_summary<'a>(uri: &str, change_type: &crate::pr_package::ChangeTyp
 }
 
 /// Get an adapter instance for the given format.
-pub fn get_adapter(format: OutputFormat) -> Box<dyn OutputAdapter> {
+///
+/// The `color` parameter controls ANSI color output for the terminal adapter.
+/// It is ignored for other formats.
+pub fn get_adapter(format: OutputFormat, color: bool) -> Box<dyn OutputAdapter> {
     match format {
-        OutputFormat::Terminal => Box::new(terminal::TerminalAdapter::new()),
+        OutputFormat::Terminal => Box::new(terminal::TerminalAdapter::with_color(color)),
         OutputFormat::Markdown => Box::new(markdown::MarkdownAdapter::new()),
         OutputFormat::Json => Box::new(json::JsonAdapter::new()),
         OutputFormat::Html => Box::new(html::HtmlAdapter::new()),

--- a/crates/ta-submit/src/config.rs
+++ b/crates/ta-submit/src/config.rs
@@ -12,6 +12,10 @@ pub struct WorkflowConfig {
     /// Diff viewing configuration
     #[serde(default)]
     pub diff: DiffConfig,
+
+    /// Display / output configuration
+    #[serde(default)]
+    pub display: DisplayConfig,
 }
 
 /// Submit adapter configuration
@@ -128,6 +132,15 @@ impl Default for DiffConfig {
 
 fn default_open_external() -> bool {
     true
+}
+
+/// Display / output configuration
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DisplayConfig {
+    /// Enable ANSI color output in terminal adapter. Default: false.
+    /// Override per-command with `--color`.
+    #[serde(default)]
+    pub color: bool,
 }
 
 impl WorkflowConfig {


### PR DESCRIPTION
## Summary
- **Configurable color**: Terminal output adapter defaults to no ANSI codes (fixes garbled `ÆpendingÅ` characters). Enable with `--color` flag or `[display] color = true` in `.ta/workflow.toml`.
- **Display config**: New `DisplayConfig` struct in `WorkflowConfig` — project-level default for color output.
- **Macro goals (PLAN.md)**: Added v0.4.1 phase — agents stay in-session, decompose work into sub-goals, submit drafts via MCP tools that mirror CLI structure (`ta_draft`, `ta_goal`, `ta_plan` with action params, not one tool per subcommand).

## Files changed
| File | Change |
|---|---|
| `crates/ta-changeset/src/output_adapters/terminal.rs` | Rewrite: `color: bool` field, ANSI helpers, `#[derive(Default)]` |
| `crates/ta-changeset/src/output_adapters/mod.rs` | `get_adapter()` takes `color` param |
| `apps/ta-cli/src/commands/draft.rs` | `--color` flag on View, config fallback |
| `apps/ta-cli/src/commands/pr.rs` | Same `--color` flag and config fallback |
| `crates/ta-submit/src/config.rs` | `DisplayConfig { color: bool }` in `WorkflowConfig` |
| `PLAN.md` | v0.4.1 Macro Goals & Inner-Loop Iteration |

## Config example
```toml
# .ta/workflow.toml
[display]
color = true   # default: false
```

## Test plan
- [x] 273 tests passing
- [x] clippy clean
- [x] fmt clean
- [ ] Manual: `ta draft view <id>` shows plain text (no ANSI)
- [ ] Manual: `ta draft view <id> --color` shows colored output
- [ ] Manual: Set `[display] color = true` in `.ta/workflow.toml`, verify color without `--color` flag

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)