### PR TITLE
implement v0.3.1.2 — Interactive Session Orchestration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.3.1-alpha"
+version = "0.3.2-alpha"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Trusted Autonomy achieves this by:
 
 ---
 
-## Current status: v0.2.2-alpha
+## Current status: v0.3.2-alpha
 
-**208 tests** across 12 crates. Under active development. See [PLAN.md](PLAN.md) for the full roadmap.
+**334 tests** across 12 crates. Under active development. See [PLAN.md](PLAN.md) for the full roadmap.
 
 This is an early alpha release for feedback. Please note:
 
@@ -426,6 +426,8 @@ ta draft apply <package-id> --git-commit
 That's it. The agent never knew it was in a staging workspace.
 
 > **For detailed usage, configuration options, and troubleshooting, see [docs/USAGE.md](docs/USAGE.md)** or run `ta --help`.
+>
+> **New in v0.3.1.2:** Interactive session orchestration — see [docs/interactive-sessions.md](docs/interactive-sessions.md) for the full guide.
 
 ---
 
@@ -898,6 +900,7 @@ cargo fmt --all -- --check
 - **Transparent overlay mediation** — agents work in staging copies using native tools, TA is invisible
 - **Selective approval** — `--approve "src/**" --reject "*.test.rs" --discuss "config/*"` with dependency warnings
 - **Concurrent session conflict detection** — detects source changes during active goals, prevents stale overwrites
+- **Interactive session orchestration** — `ta run --interactive` for tracked human-agent sessions with lifecycle management. See [docs/interactive-sessions.md](docs/interactive-sessions.md)
 - **External diff routing** — route binary/media files to external tools (`*.uasset` to Unreal, `*.png` to image diff, etc.)
 - **YAML agent configs** — discoverable config files for any agent framework (`.ta/agents/`, `~/.config/ta/agents/`)
 - **Settings injection** — auto-configures agent permissions (replaces `--dangerously-skip-permissions`)
@@ -908,7 +911,7 @@ cargo fmt --all -- --check
 - Per-artifact review model (disposition, dependencies, rationale)
 - URI-aware pattern matching (scheme-scoped safety — `src/**` can't match `gmail://`)
 - Real MCP server (rmcp 0.14) with 9 tools and policy enforcement
-- CLI: `goal`, `draft`, `run`, `plan`, `audit`, `adapter`, `serve`
+- CLI: `goal`, `draft`, `run`, `plan`, `audit`, `adapter`, `session`, `serve`
 - Plan tracking (`ta plan list/status`, auto-update on `ta draft apply`)
 
 ---

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-cli"
-version = "0.3.1-alpha"
+version = "0.3.2-alpha"
 edition = "2021"
 description = "CLI for goals, PR review, and approvals in Trusted Autonomy"
 license = "Apache-2.0"

--- a/apps/ta-cli/src/commands/mod.rs
+++ b/apps/ta-cli/src/commands/mod.rs
@@ -6,4 +6,5 @@ pub mod plan;
 pub mod pr;
 pub mod run;
 pub mod serve;
+pub mod session;
 pub mod terms;

--- a/apps/ta-cli/src/commands/session.rs
+++ b/apps/ta-cli/src/commands/session.rs
@@ -1,0 +1,192 @@
+// session.rs — Interactive session management commands.
+//
+// `ta session list` shows active sessions across all channels.
+// `ta session show <id>` displays session details and message history.
+
+use clap::Subcommand;
+use ta_changeset::InteractiveSessionStore;
+use ta_mcp_gateway::GatewayConfig;
+use uuid::Uuid;
+
+#[derive(Subcommand)]
+pub enum SessionCommands {
+    /// List interactive sessions.
+    List {
+        /// Show all sessions (including completed/aborted). Default: alive only.
+        #[arg(long)]
+        all: bool,
+    },
+    /// Show details for a specific session.
+    Show {
+        /// Session ID (full or prefix).
+        id: String,
+    },
+}
+
+pub fn execute(cmd: &SessionCommands, config: &GatewayConfig) -> anyhow::Result<()> {
+    let store = InteractiveSessionStore::new(config.interactive_sessions_dir.clone())?;
+
+    match cmd {
+        SessionCommands::List { all } => list_sessions(&store, *all),
+        SessionCommands::Show { id } => show_session(&store, id),
+    }
+}
+
+fn list_sessions(store: &InteractiveSessionStore, all: bool) -> anyhow::Result<()> {
+    let sessions = if all {
+        store.list()?
+    } else {
+        store.list_alive()?
+    };
+
+    if sessions.is_empty() {
+        if all {
+            println!("No interactive sessions found.");
+        } else {
+            println!("No active interactive sessions. Use --all to see completed sessions.");
+        }
+        return Ok(());
+    }
+
+    println!(
+        "{:<38} {:<38} {:<12} {:<14} {:<10}",
+        "SESSION ID", "GOAL ID", "AGENT", "STATE", "ELAPSED"
+    );
+    println!("{}", "-".repeat(112));
+
+    for s in &sessions {
+        println!(
+            "{:<38} {:<38} {:<12} {:<14} {:<10}",
+            s.session_id,
+            s.goal_id,
+            truncate(&s.agent_id, 10),
+            s.state.to_string(),
+            s.elapsed_display(),
+        );
+    }
+
+    println!("\n{} session(s).", sessions.len());
+    Ok(())
+}
+
+fn show_session(store: &InteractiveSessionStore, id: &str) -> anyhow::Result<()> {
+    // Try exact UUID parse first, then prefix match.
+    let session = if let Ok(uuid) = Uuid::parse_str(id) {
+        store.load(uuid)?
+    } else {
+        let all = store.list()?;
+        let matches: Vec<_> = all
+            .into_iter()
+            .filter(|s| s.session_id.to_string().starts_with(id))
+            .collect();
+        match matches.len() {
+            0 => anyhow::bail!("No session found matching '{}'", id),
+            1 => matches.into_iter().next().unwrap(),
+            n => anyhow::bail!("Ambiguous prefix '{}' matches {} sessions", id, n),
+        }
+    };
+
+    println!("Session:   {}", session.session_id);
+    println!("Goal:      {}", session.goal_id);
+    println!("Channel:   {}", session.channel_id);
+    println!("Agent:     {}", session.agent_id);
+    println!("State:     {}", session.state);
+    println!("Created:   {}", session.created_at.to_rfc3339());
+    println!("Updated:   {}", session.updated_at.to_rfc3339());
+    println!("Elapsed:   {}", session.elapsed_display());
+
+    if !session.draft_ids.is_empty() {
+        println!("Drafts:    {}", session.draft_ids.len());
+        for draft_id in &session.draft_ids {
+            println!("  - {}", draft_id);
+        }
+    }
+
+    if !session.messages.is_empty() {
+        println!("\nMessage log ({} messages):", session.messages.len());
+        println!("{}", "-".repeat(60));
+        for msg in &session.messages {
+            let time = msg.timestamp.format("%H:%M:%S");
+            let preview = truncate(&msg.content, 70);
+            println!("  [{}] {}: {}", time, msg.sender, preview);
+        }
+    }
+
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() > max {
+        format!("{}...", &s[..max - 3])
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ta_changeset::InteractiveSession;
+    use tempfile::TempDir;
+
+    #[test]
+    fn list_empty_sessions() {
+        let temp = TempDir::new().unwrap();
+        let config = GatewayConfig::for_project(temp.path());
+        let store = InteractiveSessionStore::new(config.interactive_sessions_dir.clone()).unwrap();
+
+        // Should not error on empty list.
+        let sessions = store.list().unwrap();
+        assert!(sessions.is_empty());
+    }
+
+    #[test]
+    fn show_session_by_prefix() {
+        let temp = TempDir::new().unwrap();
+        let config = GatewayConfig::for_project(temp.path());
+        let store = InteractiveSessionStore::new(config.interactive_sessions_dir.clone()).unwrap();
+
+        let session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+        let id_prefix = session.session_id.to_string()[..8].to_string();
+        store.save(&session).unwrap();
+
+        // Should find by prefix.
+        let all = store.list().unwrap();
+        let matches: Vec<_> = all
+            .into_iter()
+            .filter(|s| s.session_id.to_string().starts_with(&id_prefix))
+            .collect();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].session_id, session.session_id);
+    }
+
+    #[test]
+    fn session_store_integrates_with_gateway_config() {
+        let temp = TempDir::new().unwrap();
+        let config = GatewayConfig::for_project(temp.path());
+
+        // The interactive_sessions_dir should be under .ta/
+        assert!(config
+            .interactive_sessions_dir
+            .to_str()
+            .unwrap()
+            .contains(".ta"));
+
+        // Store creation should work.
+        let store = InteractiveSessionStore::new(config.interactive_sessions_dir.clone()).unwrap();
+
+        let session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "test-agent".to_string(),
+        );
+        store.save(&session).unwrap();
+
+        let loaded = store.load(session.session_id).unwrap();
+        assert_eq!(loaded.session_id, session.session_id);
+    }
+}

--- a/apps/ta-cli/src/main.rs
+++ b/apps/ta-cli/src/main.rs
@@ -85,6 +85,14 @@ enum Commands {
         /// Don't launch the agent — just set up the workspace.
         #[arg(long)]
         no_launch: bool,
+        /// Run in interactive mode with session orchestration.
+        #[arg(long)]
+        interactive: bool,
+    },
+    /// Manage interactive sessions.
+    Session {
+        #[command(subcommand)]
+        command: commands::session::SessionCommands,
     },
     /// View and track the project development plan.
     Plan {
@@ -166,6 +174,7 @@ fn main() -> anyhow::Result<()> {
             follow_up,
             objective_file,
             no_launch,
+            interactive,
         } => commands::run::execute(
             &config,
             title,
@@ -176,7 +185,9 @@ fn main() -> anyhow::Result<()> {
             follow_up.as_ref(),
             objective_file.as_deref(),
             *no_launch,
+            *interactive,
         ),
+        Commands::Session { command } => commands::session::execute(command, &config),
         Commands::Plan { command } => commands::plan::execute(command, &config),
         Commands::Adapter { command } => commands::adapter::execute(command, &project_root),
         Commands::Serve => commands::serve::execute(&project_root),

--- a/crates/ta-changeset/src/interactive_session_store.rs
+++ b/crates/ta-changeset/src/interactive_session_store.rs
@@ -1,0 +1,241 @@
+// interactive_session_store.rs — Persistent storage for InteractiveSession instances.
+//
+// Stores interactive sessions as JSON files in .ta/interactive_sessions/<session-id>.json
+// Enables multi-invocation interactive workflows where humans can pause and resume sessions.
+
+use std::fs;
+use std::path::PathBuf;
+
+use uuid::Uuid;
+
+use crate::session_channel::{InteractiveSession, InteractiveSessionState};
+use crate::ChangeSetError;
+
+/// Storage backend for InteractiveSession instances.
+pub struct InteractiveSessionStore {
+    sessions_dir: PathBuf,
+}
+
+impl InteractiveSessionStore {
+    /// Create a new store with the given sessions directory.
+    pub fn new(sessions_dir: PathBuf) -> Result<Self, ChangeSetError> {
+        fs::create_dir_all(&sessions_dir)?;
+        Ok(Self { sessions_dir })
+    }
+
+    /// Save an interactive session to disk.
+    pub fn save(&self, session: &InteractiveSession) -> Result<(), ChangeSetError> {
+        let path = self.session_path(session.session_id);
+        let json = serde_json::to_string_pretty(session)?;
+        fs::write(&path, json)?;
+        Ok(())
+    }
+
+    /// Load an interactive session from disk by ID.
+    pub fn load(&self, session_id: Uuid) -> Result<InteractiveSession, ChangeSetError> {
+        let path = self.session_path(session_id);
+        if !path.exists() {
+            return Err(ChangeSetError::InvalidData(format!(
+                "Interactive session not found: {}",
+                session_id
+            )));
+        }
+        let json = fs::read_to_string(&path)?;
+        let session = serde_json::from_str(&json)?;
+        Ok(session)
+    }
+
+    /// List all interactive sessions, sorted by most recently updated.
+    pub fn list(&self) -> Result<Vec<InteractiveSession>, ChangeSetError> {
+        let mut sessions = Vec::new();
+        if !self.sessions_dir.exists() {
+            return Ok(sessions);
+        }
+
+        for entry in fs::read_dir(&self.sessions_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "json") {
+                if let Ok(json) = fs::read_to_string(&path) {
+                    if let Ok(session) = serde_json::from_str::<InteractiveSession>(&json) {
+                        sessions.push(session);
+                    }
+                }
+            }
+        }
+
+        sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        Ok(sessions)
+    }
+
+    /// List only active/paused (alive) sessions.
+    pub fn list_alive(&self) -> Result<Vec<InteractiveSession>, ChangeSetError> {
+        Ok(self.list()?.into_iter().filter(|s| s.is_alive()).collect())
+    }
+
+    /// Find the active interactive session for a goal (if any).
+    pub fn find_active_for_goal(
+        &self,
+        goal_id: Uuid,
+    ) -> Result<Option<InteractiveSession>, ChangeSetError> {
+        let sessions = self.list()?;
+        Ok(sessions
+            .into_iter()
+            .find(|s| s.goal_id == goal_id && s.state == InteractiveSessionState::Active))
+    }
+
+    /// Delete an interactive session from disk.
+    pub fn delete(&self, session_id: Uuid) -> Result<(), ChangeSetError> {
+        let path = self.session_path(session_id);
+        if path.exists() {
+            fs::remove_file(&path)?;
+        }
+        Ok(())
+    }
+
+    /// Check if a session exists.
+    pub fn exists(&self, session_id: Uuid) -> bool {
+        self.session_path(session_id).exists()
+    }
+
+    /// Get the file path for a session ID.
+    fn session_path(&self, session_id: Uuid) -> PathBuf {
+        self.sessions_dir.join(format!("{}.json", session_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn save_and_load_session() {
+        let temp = TempDir::new().unwrap();
+        let store = InteractiveSessionStore::new(temp.path().to_path_buf()).unwrap();
+
+        let mut session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+        session.log_message("human", "Test guidance");
+
+        store.save(&session).unwrap();
+
+        let loaded = store.load(session.session_id).unwrap();
+        assert_eq!(loaded.session_id, session.session_id);
+        assert_eq!(loaded.channel_id, "cli:tty0");
+        assert_eq!(loaded.messages.len(), 1);
+    }
+
+    #[test]
+    fn list_sessions_returns_all() {
+        let temp = TempDir::new().unwrap();
+        let store = InteractiveSessionStore::new(temp.path().to_path_buf()).unwrap();
+
+        let session1 = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+        let session2 =
+            InteractiveSession::new(Uuid::new_v4(), "cli:tty1".to_string(), "codex".to_string());
+
+        store.save(&session1).unwrap();
+        store.save(&session2).unwrap();
+
+        let sessions = store.list().unwrap();
+        assert_eq!(sessions.len(), 2);
+    }
+
+    #[test]
+    fn list_alive_filters_completed() {
+        let temp = TempDir::new().unwrap();
+        let store = InteractiveSessionStore::new(temp.path().to_path_buf()).unwrap();
+
+        let session1 = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+        let mut session2 =
+            InteractiveSession::new(Uuid::new_v4(), "cli:tty1".to_string(), "codex".to_string());
+        session2
+            .transition(InteractiveSessionState::Completed)
+            .unwrap();
+
+        store.save(&session1).unwrap();
+        store.save(&session2).unwrap();
+
+        let alive = store.list_alive().unwrap();
+        assert_eq!(alive.len(), 1);
+        assert_eq!(alive[0].session_id, session1.session_id);
+    }
+
+    #[test]
+    fn find_active_for_goal_returns_matching() {
+        let temp = TempDir::new().unwrap();
+        let store = InteractiveSessionStore::new(temp.path().to_path_buf()).unwrap();
+
+        let goal_id = Uuid::new_v4();
+        let session =
+            InteractiveSession::new(goal_id, "cli:tty0".to_string(), "claude-code".to_string());
+        store.save(&session).unwrap();
+
+        let found = store.find_active_for_goal(goal_id).unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().goal_id, goal_id);
+    }
+
+    #[test]
+    fn find_active_for_goal_returns_none_when_completed() {
+        let temp = TempDir::new().unwrap();
+        let store = InteractiveSessionStore::new(temp.path().to_path_buf()).unwrap();
+
+        let goal_id = Uuid::new_v4();
+        let mut session =
+            InteractiveSession::new(goal_id, "cli:tty0".to_string(), "claude-code".to_string());
+        session
+            .transition(InteractiveSessionState::Completed)
+            .unwrap();
+        store.save(&session).unwrap();
+
+        let found = store.find_active_for_goal(goal_id).unwrap();
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn delete_removes_session() {
+        let temp = TempDir::new().unwrap();
+        let store = InteractiveSessionStore::new(temp.path().to_path_buf()).unwrap();
+
+        let session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+        let session_id = session.session_id;
+
+        store.save(&session).unwrap();
+        assert!(store.exists(session_id));
+
+        store.delete(session_id).unwrap();
+        assert!(!store.exists(session_id));
+    }
+
+    #[test]
+    fn exists_returns_false_for_nonexistent() {
+        let temp = TempDir::new().unwrap();
+        let store = InteractiveSessionStore::new(temp.path().to_path_buf()).unwrap();
+        assert!(!store.exists(Uuid::new_v4()));
+    }
+
+    #[test]
+    fn load_nonexistent_returns_error() {
+        let temp = TempDir::new().unwrap();
+        let store = InteractiveSessionStore::new(temp.path().to_path_buf()).unwrap();
+        let result = store.load(Uuid::new_v4());
+        assert!(result.is_err());
+    }
+}

--- a/crates/ta-changeset/src/lib.rs
+++ b/crates/ta-changeset/src/lib.rs
@@ -14,10 +14,12 @@ pub mod diff_handlers;
 pub mod draft_package;
 pub mod error;
 pub mod explanation;
+pub mod interactive_session_store;
 pub mod output_adapters;
 pub mod pr_package;
 pub mod review_session;
 pub mod review_session_store;
+pub mod session_channel;
 pub mod supervisor;
 pub mod uri_pattern;
 
@@ -27,12 +29,17 @@ pub use diff_handlers::{DiffHandlerError, DiffHandlersConfig, HandlerRule};
 pub use draft_package::{DraftPackage, DraftStatus, ExplanationTiers};
 pub use error::ChangeSetError;
 pub use explanation::ExplanationSidecar;
+pub use interactive_session_store::InteractiveSessionStore;
 pub use output_adapters::{DetailLevel, OutputAdapter, OutputFormat, RenderContext};
 pub use review_session::{
     ArtifactReview, Comment, CommentThread, DispositionCounts, ReviewSession, ReviewState,
     SessionNote,
 };
 pub use review_session_store::ReviewSessionStore;
+pub use session_channel::{
+    HumanInput, InteractiveConfig, InteractiveSession, InteractiveSessionState, OutputStream,
+    SessionChannel, SessionChannelError, SessionEvent, SessionMessage,
+};
 pub use supervisor::{
     DependencyGraph, SupervisorAgent, ValidationError, ValidationResult, ValidationWarning,
 };

--- a/crates/ta-changeset/src/session_channel.rs
+++ b/crates/ta-changeset/src/session_channel.rs
@@ -1,0 +1,623 @@
+// session_channel.rs — Session interaction protocol for human-agent communication.
+//
+// A `SessionChannel` trait that any frontend implements — CLI, Discord, Slack,
+// email, or web app. The protocol is the same: TA doesn't care where the message
+// came from, only that it's authenticated and routed to the right session.
+//
+// This is the core abstraction for Phase v0.3.1.2 (Interactive Session Orchestration).
+
+use std::fmt;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// A bidirectional channel between a human and a TA-mediated agent session.
+///
+/// Every interaction between human and TA is a message on a channel.
+/// The CLI is one channel. A Discord thread is another. The protocol is the same.
+pub trait SessionChannel: Send + Sync {
+    /// Display agent output to the human (streaming).
+    fn emit(&self, event: &SessionEvent) -> Result<(), SessionChannelError>;
+
+    /// Receive human input (blocks until available or timeout).
+    /// Returns `None` on timeout.
+    fn receive(&self, timeout: Duration) -> Result<Option<HumanInput>, SessionChannelError>;
+
+    /// Channel identity (for audit trail).
+    /// e.g., "cli:tty0", "discord:thread:123", "slack:C04:1234567890"
+    fn channel_id(&self) -> &str;
+}
+
+/// Events emitted from TA/agent to the human.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event_type", rename_all = "snake_case")]
+pub enum SessionEvent {
+    /// Agent output (stdout or stderr).
+    AgentOutput {
+        stream: OutputStream,
+        content: String,
+    },
+
+    /// A draft is ready for review (checkpoint).
+    DraftReady {
+        draft_id: Uuid,
+        summary: String,
+        artifact_count: usize,
+    },
+
+    /// The goal is complete.
+    GoalComplete { goal_id: Uuid },
+
+    /// Agent is waiting for human guidance.
+    WaitingForInput { prompt: String },
+
+    /// Session status update (informational).
+    StatusUpdate { message: String },
+}
+
+impl fmt::Display for SessionEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SessionEvent::AgentOutput { stream, content } => {
+                write!(f, "[{}] {}", stream, content)
+            }
+            SessionEvent::DraftReady {
+                draft_id,
+                summary,
+                artifact_count,
+            } => {
+                write!(
+                    f,
+                    "Draft ready: {} ({} artifacts) — {}",
+                    draft_id, artifact_count, summary
+                )
+            }
+            SessionEvent::GoalComplete { goal_id } => {
+                write!(f, "Goal complete: {}", goal_id)
+            }
+            SessionEvent::WaitingForInput { prompt } => {
+                write!(f, "Waiting for input: {}", prompt)
+            }
+            SessionEvent::StatusUpdate { message } => {
+                write!(f, "Status: {}", message)
+            }
+        }
+    }
+}
+
+/// Output stream identifier (stdout vs stderr).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputStream {
+    StdOut,
+    StdErr,
+}
+
+impl fmt::Display for OutputStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OutputStream::StdOut => write!(f, "stdout"),
+            OutputStream::StdErr => write!(f, "stderr"),
+        }
+    }
+}
+
+/// Input from a human to the session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "input_type", rename_all = "snake_case")]
+pub enum HumanInput {
+    /// Free-form guidance message injected into agent context.
+    Message { text: String },
+
+    /// Inline review: approve a draft artifact.
+    Approve {
+        draft_id: Uuid,
+        artifact_uri: Option<String>,
+    },
+
+    /// Inline review: reject a draft artifact with reason.
+    Reject {
+        draft_id: Uuid,
+        artifact_uri: Option<String>,
+        reason: String,
+    },
+
+    /// Abort the session.
+    Abort,
+}
+
+impl fmt::Display for HumanInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HumanInput::Message { text } => write!(f, "Message: {}", text),
+            HumanInput::Approve {
+                draft_id,
+                artifact_uri,
+            } => {
+                if let Some(uri) = artifact_uri {
+                    write!(f, "Approve {} in draft {}", uri, draft_id)
+                } else {
+                    write!(f, "Approve draft {}", draft_id)
+                }
+            }
+            HumanInput::Reject {
+                draft_id,
+                artifact_uri,
+                reason,
+            } => {
+                if let Some(uri) = artifact_uri {
+                    write!(f, "Reject {} in draft {}: {}", uri, draft_id, reason)
+                } else {
+                    write!(f, "Reject draft {}: {}", draft_id, reason)
+                }
+            }
+            HumanInput::Abort => write!(f, "Abort session"),
+        }
+    }
+}
+
+/// Errors from session channel operations.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionChannelError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("channel closed")]
+    ChannelClosed,
+
+    #[error("session error: {0}")]
+    Other(String),
+}
+
+/// A persistent interactive session record linking a goal to channel state.
+///
+/// Tracks the lifecycle of a human-agent interactive session across CLI invocations.
+/// Serialized to JSON for persistence (same pattern as ReviewSession).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InteractiveSession {
+    /// Unique session identifier.
+    pub session_id: Uuid,
+
+    /// The GoalRun this session is attached to.
+    pub goal_id: Uuid,
+
+    /// Channel identity (e.g., "cli:tty0").
+    pub channel_id: String,
+
+    /// Agent identity (e.g., "claude-code").
+    pub agent_id: String,
+
+    /// Session lifecycle state.
+    pub state: InteractiveSessionState,
+
+    /// Session creation time.
+    pub created_at: DateTime<Utc>,
+
+    /// Last activity time.
+    pub updated_at: DateTime<Utc>,
+
+    /// Message log (persisted for audit and resume).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub messages: Vec<SessionMessage>,
+
+    /// Associated draft IDs (drafts reviewed inline during this session).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub draft_ids: Vec<Uuid>,
+}
+
+/// Session lifecycle states.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractiveSessionState {
+    /// Session is active (agent running, human connected).
+    Active,
+    /// Session is paused (agent suspended, can be resumed).
+    Paused,
+    /// Session completed successfully.
+    Completed,
+    /// Session was aborted by the human.
+    Aborted,
+}
+
+impl fmt::Display for InteractiveSessionState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InteractiveSessionState::Active => write!(f, "active"),
+            InteractiveSessionState::Paused => write!(f, "paused"),
+            InteractiveSessionState::Completed => write!(f, "completed"),
+            InteractiveSessionState::Aborted => write!(f, "aborted"),
+        }
+    }
+}
+
+/// A logged message in a session (for audit and replay).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMessage {
+    /// Who sent the message ("human", "agent", "ta-system").
+    pub sender: String,
+    /// Message content.
+    pub content: String,
+    /// When the message was sent.
+    pub timestamp: DateTime<Utc>,
+}
+
+impl InteractiveSession {
+    /// Create a new interactive session for a goal.
+    pub fn new(goal_id: Uuid, channel_id: String, agent_id: String) -> Self {
+        let now = Utc::now();
+        Self {
+            session_id: Uuid::new_v4(),
+            goal_id,
+            channel_id,
+            agent_id,
+            state: InteractiveSessionState::Active,
+            created_at: now,
+            updated_at: now,
+            messages: Vec::new(),
+            draft_ids: Vec::new(),
+        }
+    }
+
+    /// Record a message in the session log.
+    pub fn log_message(&mut self, sender: &str, content: &str) {
+        self.messages.push(SessionMessage {
+            sender: sender.to_string(),
+            content: content.to_string(),
+            timestamp: Utc::now(),
+        });
+        self.updated_at = Utc::now();
+    }
+
+    /// Record that a draft was reviewed inline during this session.
+    pub fn add_draft(&mut self, draft_id: Uuid) {
+        if !self.draft_ids.contains(&draft_id) {
+            self.draft_ids.push(draft_id);
+        }
+        self.updated_at = Utc::now();
+    }
+
+    /// Transition to a new state.
+    pub fn transition(
+        &mut self,
+        new_state: InteractiveSessionState,
+    ) -> Result<(), SessionChannelError> {
+        let valid = matches!(
+            (&self.state, &new_state),
+            (
+                InteractiveSessionState::Active,
+                InteractiveSessionState::Paused
+            ) | (
+                InteractiveSessionState::Active,
+                InteractiveSessionState::Completed
+            ) | (
+                InteractiveSessionState::Active,
+                InteractiveSessionState::Aborted
+            ) | (
+                InteractiveSessionState::Paused,
+                InteractiveSessionState::Active
+            ) | (
+                InteractiveSessionState::Paused,
+                InteractiveSessionState::Aborted
+            )
+        );
+
+        if !valid {
+            return Err(SessionChannelError::Other(format!(
+                "invalid session transition from {} to {}",
+                self.state, new_state
+            )));
+        }
+
+        self.state = new_state;
+        self.updated_at = Utc::now();
+        Ok(())
+    }
+
+    /// Check if the session is in an active or paused state (can still be used).
+    pub fn is_alive(&self) -> bool {
+        matches!(
+            self.state,
+            InteractiveSessionState::Active | InteractiveSessionState::Paused
+        )
+    }
+
+    /// Get elapsed time since session start.
+    pub fn elapsed(&self) -> chrono::Duration {
+        Utc::now() - self.created_at
+    }
+
+    /// Format elapsed time as a human-readable string.
+    pub fn elapsed_display(&self) -> String {
+        let dur = self.elapsed();
+        let secs = dur.num_seconds();
+        if secs < 60 {
+            format!("{}s", secs)
+        } else if secs < 3600 {
+            format!("{}m {}s", secs / 60, secs % 60)
+        } else {
+            format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+        }
+    }
+}
+
+/// Per-agent interactive configuration (loaded from YAML).
+///
+/// Extends the AgentLaunchConfig with interactive session settings.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct InteractiveConfig {
+    /// Whether interactive mode is available for this agent.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Output capture mode: "pty", "pipe", or "log".
+    #[serde(default = "default_output_capture")]
+    pub output_capture: String,
+
+    /// Whether to allow human input injection during agent execution.
+    #[serde(default = "default_true")]
+    pub allow_human_input: bool,
+
+    /// Auto-exit condition: "idle_timeout: 300s" or "goal_complete".
+    #[serde(default)]
+    pub auto_exit_on: Option<String>,
+
+    /// Override launch command for resume (e.g., "claude --resume {session_id}").
+    #[serde(default)]
+    pub resume_cmd: Option<String>,
+}
+
+fn default_output_capture() -> String {
+    "pipe".to_string()
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_interactive_session_is_active() {
+        let session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+        assert_eq!(session.state, InteractiveSessionState::Active);
+        assert!(session.messages.is_empty());
+        assert!(session.draft_ids.is_empty());
+        assert!(session.is_alive());
+    }
+
+    #[test]
+    fn log_message_adds_to_history() {
+        let mut session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+
+        session.log_message("human", "Focus on the auth module");
+        session.log_message("agent", "Understood, working on auth");
+
+        assert_eq!(session.messages.len(), 2);
+        assert_eq!(session.messages[0].sender, "human");
+        assert_eq!(session.messages[1].sender, "agent");
+    }
+
+    #[test]
+    fn add_draft_deduplicates() {
+        let mut session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+        let draft_id = Uuid::new_v4();
+
+        session.add_draft(draft_id);
+        session.add_draft(draft_id);
+
+        assert_eq!(session.draft_ids.len(), 1);
+    }
+
+    #[test]
+    fn valid_transitions() {
+        let mut session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+
+        // Active → Paused
+        session.transition(InteractiveSessionState::Paused).unwrap();
+        assert_eq!(session.state, InteractiveSessionState::Paused);
+
+        // Paused → Active
+        session.transition(InteractiveSessionState::Active).unwrap();
+        assert_eq!(session.state, InteractiveSessionState::Active);
+
+        // Active → Completed
+        session
+            .transition(InteractiveSessionState::Completed)
+            .unwrap();
+        assert_eq!(session.state, InteractiveSessionState::Completed);
+    }
+
+    #[test]
+    fn invalid_transition_returns_error() {
+        let mut session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+        session
+            .transition(InteractiveSessionState::Completed)
+            .unwrap();
+
+        // Completed → Active should fail
+        let result = session.transition(InteractiveSessionState::Active);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn abort_from_active() {
+        let mut session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+        session
+            .transition(InteractiveSessionState::Aborted)
+            .unwrap();
+        assert!(!session.is_alive());
+    }
+
+    #[test]
+    fn abort_from_paused() {
+        let mut session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+        session.transition(InteractiveSessionState::Paused).unwrap();
+        session
+            .transition(InteractiveSessionState::Aborted)
+            .unwrap();
+        assert!(!session.is_alive());
+    }
+
+    #[test]
+    fn session_serialization_round_trip() {
+        let mut session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+        session.log_message("human", "Test message");
+        session.add_draft(Uuid::new_v4());
+
+        let json = serde_json::to_string(&session).unwrap();
+        let restored: InteractiveSession = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.session_id, session.session_id);
+        assert_eq!(restored.goal_id, session.goal_id);
+        assert_eq!(restored.channel_id, session.channel_id);
+        assert_eq!(restored.agent_id, session.agent_id);
+        assert_eq!(restored.messages.len(), 1);
+        assert_eq!(restored.draft_ids.len(), 1);
+    }
+
+    #[test]
+    fn session_event_display() {
+        let event = SessionEvent::AgentOutput {
+            stream: OutputStream::StdOut,
+            content: "Hello world".to_string(),
+        };
+        assert_eq!(format!("{}", event), "[stdout] Hello world");
+
+        let event = SessionEvent::WaitingForInput {
+            prompt: "What next?".to_string(),
+        };
+        assert_eq!(format!("{}", event), "Waiting for input: What next?");
+    }
+
+    #[test]
+    fn human_input_display() {
+        let input = HumanInput::Message {
+            text: "Focus on auth".to_string(),
+        };
+        assert_eq!(format!("{}", input), "Message: Focus on auth");
+
+        let input = HumanInput::Abort;
+        assert_eq!(format!("{}", input), "Abort session");
+    }
+
+    #[test]
+    fn output_stream_display() {
+        assert_eq!(format!("{}", OutputStream::StdOut), "stdout");
+        assert_eq!(format!("{}", OutputStream::StdErr), "stderr");
+    }
+
+    #[test]
+    fn interactive_config_defaults() {
+        let config: InteractiveConfig = serde_json::from_str("{}").unwrap();
+        assert!(!config.enabled);
+        assert_eq!(config.output_capture, "pipe");
+        assert!(config.allow_human_input);
+        assert!(config.auto_exit_on.is_none());
+        assert!(config.resume_cmd.is_none());
+    }
+
+    #[test]
+    fn interactive_config_from_yaml() {
+        let yaml = r#"
+enabled: true
+output_capture: pty
+allow_human_input: true
+auto_exit_on: "idle_timeout: 300s"
+resume_cmd: "claude --resume {session_id}"
+"#;
+        let config: InteractiveConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.output_capture, "pty");
+        assert!(config.allow_human_input);
+        assert_eq!(config.auto_exit_on.as_deref(), Some("idle_timeout: 300s"));
+        assert_eq!(
+            config.resume_cmd.as_deref(),
+            Some("claude --resume {session_id}")
+        );
+    }
+
+    #[test]
+    fn elapsed_display_formatting() {
+        let mut session = InteractiveSession::new(
+            Uuid::new_v4(),
+            "cli:tty0".to_string(),
+            "claude-code".to_string(),
+        );
+        // Just created — should show a very small duration.
+        let display = session.elapsed_display();
+        assert!(display.ends_with('s'));
+
+        // Manually set created_at to the past for testing.
+        session.created_at = Utc::now() - chrono::Duration::minutes(5);
+        let display = session.elapsed_display();
+        assert!(display.contains('m'));
+    }
+
+    #[test]
+    fn session_event_serialization_round_trip() {
+        let event = SessionEvent::DraftReady {
+            draft_id: Uuid::new_v4(),
+            summary: "Test draft".to_string(),
+            artifact_count: 3,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let restored: SessionEvent = serde_json::from_str(&json).unwrap();
+        if let SessionEvent::DraftReady { artifact_count, .. } = restored {
+            assert_eq!(artifact_count, 3);
+        } else {
+            panic!("Expected DraftReady variant");
+        }
+    }
+
+    #[test]
+    fn human_input_serialization_round_trip() {
+        let input = HumanInput::Reject {
+            draft_id: Uuid::new_v4(),
+            artifact_uri: Some("fs://workspace/main.rs".to_string()),
+            reason: "needs error handling".to_string(),
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        let restored: HumanInput = serde_json::from_str(&json).unwrap();
+        if let HumanInput::Reject { reason, .. } = restored {
+            assert_eq!(reason, "needs error handling");
+        } else {
+            panic!("Expected Reject variant");
+        }
+    }
+}

--- a/crates/ta-goal/src/events.rs
+++ b/crates/ta-goal/src/events.rs
@@ -88,6 +88,31 @@ pub enum TaEvent {
         target_uri: String,
         timestamp: DateTime<Utc>,
     },
+
+    /// An interactive session was started (v0.3.1.2).
+    SessionStarted {
+        goal_run_id: Uuid,
+        session_id: Uuid,
+        channel_id: String,
+        agent_id: String,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// An interactive session state changed (v0.3.1.2).
+    SessionStateChanged {
+        session_id: Uuid,
+        from_state: String,
+        to_state: String,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// Human sent a message in an interactive session (v0.3.1.2).
+    SessionMessage {
+        session_id: Uuid,
+        sender: String,
+        content_preview: String,
+        timestamp: DateTime<Utc>,
+    },
 }
 
 impl TaEvent {
@@ -101,6 +126,9 @@ impl TaEvent {
             TaEvent::PrDenied { .. } => "pr_denied",
             TaEvent::ChangesApplied { .. } => "changes_applied",
             TaEvent::ChangesetCreated { .. } => "changeset_created",
+            TaEvent::SessionStarted { .. } => "session_started",
+            TaEvent::SessionStateChanged { .. } => "session_state_changed",
+            TaEvent::SessionMessage { .. } => "session_message",
         }
     }
 

--- a/crates/ta-mcp-gateway/src/config.rs
+++ b/crates/ta-mcp-gateway/src/config.rs
@@ -32,6 +32,9 @@ pub struct GatewayConfig {
 
     /// Directory for PR package JSON files.
     pub pr_packages_dir: PathBuf,
+
+    /// Directory for interactive session records (v0.3.1.2).
+    pub interactive_sessions_dir: PathBuf,
 }
 
 impl GatewayConfig {
@@ -47,6 +50,7 @@ impl GatewayConfig {
             audit_log: ta_dir.join("audit.jsonl"),
             events_log: ta_dir.join("events.jsonl"),
             pr_packages_dir: ta_dir.join("pr_packages"),
+            interactive_sessions_dir: ta_dir.join("interactive_sessions"),
         }
     }
 }

--- a/docs/interactive-sessions.md
+++ b/docs/interactive-sessions.md
@@ -1,0 +1,442 @@
+# Interactive Session Orchestration
+
+**Version**: v0.3.1.2+
+
+This guide walks through the interactive session capabilities introduced in v0.3.1.2. Interactive sessions let you observe agent work, inject guidance, review drafts inline, and manage multiple concurrent sessions through a unified protocol.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Quick Example](#quick-example)
+3. [Session Lifecycle](#session-lifecycle)
+4. [Managing Sessions](#managing-sessions)
+5. [Multi-Session Workflows](#multi-session-workflows)
+6. [Per-Agent Configuration](#per-agent-configuration)
+7. [Integration with Review Sessions](#integration-with-review-sessions)
+8. [Architecture: SessionChannel Protocol](#architecture-sessionchannel-protocol)
+9. [Future: Multi-Platform Channels](#future-multi-platform-channels)
+
+---
+
+## Overview
+
+Without `--interactive`, `ta run` launches an agent, waits for it to exit, and builds a draft. The human only sees the result.
+
+With `--interactive`, TA wraps the agent execution in a **session** that:
+- Tracks the human-agent relationship (who launched what, when, on which channel)
+- Records a message log for audit and replay
+- Links inline draft reviews back to the session
+- Persists across CLI invocations (you can inspect sessions from a separate terminal)
+- Supports multiple concurrent sessions for different goals
+
+The session protocol is designed so that future frontends (Discord, Slack, web app) implement the same `SessionChannel` trait and get the full TA experience without changes to core logic.
+
+---
+
+## Quick Example
+
+### Start an interactive session
+
+```bash
+cd your-project/
+ta run "Add input validation to the API" --source . --interactive
+```
+
+Output:
+```
+Goal started: a1b2c3d4-5678-9abc-def0-123456789abc
+  Title:   Add input validation to the API
+  Staging: /path/to/.ta/staging/a1b2c3d4-5678-9abc-def0-123456789abc
+
+Interactive session: f9e8d7c6-5432-1fed-cba0-987654321fed
+  Channel: cli:48291
+
+Launching claude in staging workspace...
+  Working dir: /path/to/.ta/staging/a1b2c3d4-5678-9abc-def0-123456789abc
+  Mode: interactive (session orchestration enabled)
+```
+
+The agent launches and works normally. TA tracks the session in the background.
+
+### Check on it from another terminal
+
+```bash
+ta session list
+```
+
+```
+SESSION ID                             GOAL ID                                AGENT        STATE          ELAPSED
+f9e8d7c6-5432-1fed-cba0-987654321fed   a1b2c3d4-5678-9abc-def0-123456789abc   claude-code  active         5m 23s
+
+1 session(s).
+```
+
+### View session details
+
+```bash
+ta session show f9e8d7c6
+```
+
+```
+Session:   f9e8d7c6-5432-1fed-cba0-987654321fed
+Goal:      a1b2c3d4-5678-9abc-def0-123456789abc
+Channel:   cli:48291
+Agent:     claude-code
+State:     active
+Created:   2026-02-24T23:45:00Z
+Updated:   2026-02-24T23:50:23Z
+Elapsed:   5m 23s
+```
+
+### After the agent exits
+
+TA builds the draft and marks the session completed:
+
+```
+Agent exited. Building draft...
+Draft built: 3 artifacts, 142 lines changed
+
+Next steps:
+  ta draft list
+  ta draft view <draft-id>
+  ta draft approve <draft-id>
+  ta draft apply <draft-id> --git-commit
+  ta session list
+```
+
+```bash
+ta session list --all
+```
+
+```
+SESSION ID                             GOAL ID                                AGENT        STATE          ELAPSED
+f9e8d7c6-5432-1fed-cba0-987654321fed   a1b2c3d4-5678-9abc-def0-123456789abc   claude-code  completed      12m 34s
+
+1 session(s).
+```
+
+---
+
+## Session Lifecycle
+
+Interactive sessions follow a state machine:
+
+```
+                +-----------+
+                |  Active   |
+                +-----+-----+
+                      |
+            +---------+---------+
+            |         |         |
+            v         v         v
+       +---------+ +-------+ +-------+
+       | Paused  | | Comp- | | Abor- |
+       |         | | leted | | ted   |
+       +----+----+ +-------+ +-------+
+            |                     ^
+            +---------------------+
+            (can abort from paused)
+```
+
+| State | Meaning |
+|-------|---------|
+| **Active** | Agent is running, human is connected |
+| **Paused** | Agent suspended, session can be resumed |
+| **Completed** | Agent exited successfully, draft built |
+| **Aborted** | Session killed (agent crash, user abort, or launch failure) |
+
+Transitions:
+- Active -> Paused, Completed, or Aborted
+- Paused -> Active (resume) or Aborted
+- Completed and Aborted are terminal states
+
+---
+
+## Managing Sessions
+
+### List sessions
+
+```bash
+# Active and paused sessions only (default)
+ta session list
+
+# Include completed and aborted sessions
+ta session list --all
+```
+
+### Inspect a session
+
+```bash
+# Full UUID
+ta session show f9e8d7c6-5432-1fed-cba0-987654321fed
+
+# Prefix matching (any unique prefix works)
+ta session show f9e8
+```
+
+The detail view shows:
+- Session and goal IDs
+- Channel identity (e.g., `cli:48291`)
+- Agent and state
+- Timestamps and elapsed time
+- Associated draft IDs (if drafts were reviewed inline)
+- Message log with timestamps
+
+### Message log
+
+Every session records a timestamped message log for audit:
+
+```
+Message log (3 messages):
+------------------------------------------------------------
+  [23:45:00] ta-system: Session started
+  [23:50:23] ta-system: Agent output captured (142 lines)
+  [23:57:45] ta-system: Agent exited, draft built
+```
+
+---
+
+## Multi-Session Workflows
+
+You can run multiple interactive sessions simultaneously for different goals or agents:
+
+```bash
+# Terminal 1: Feature implementation
+ta run "Implement OAuth2 login" --source . --interactive --agent claude-code
+
+# Terminal 2: Test writing (different goal, same project)
+ta run "Write integration tests for auth" --source . --interactive --agent codex
+
+# Terminal 3: Monitor both
+ta session list
+```
+
+```
+SESSION ID                             GOAL ID                                AGENT        STATE          ELAPSED
+8a7b6c5d-1234-5678-9abc-def012345678   f1e2d3c4-5678-9abc-def0-123456789abc   claude-code  active         12m 34s
+4b5a6c7d-9876-5432-1fed-cba098765432   a1b2c3d4-5678-9abc-def0-987654321fed   codex        active         5m 18s
+
+2 session(s).
+```
+
+Each session has its own staging workspace (via the goal system), so there's no interference between concurrent agents.
+
+### Sequential sessions for iterative work
+
+```bash
+# Round 1: Initial implementation
+ta run "Build the search API" --source . --interactive
+# Review and partially approve...
+ta draft apply <id> --approve "src/search/**" --discuss "src/config/*"
+
+# Round 2: Address feedback with follow-up
+ta run "Fix search config issues" --source . --interactive --follow-up
+# Agent receives parent goal context including discuss items
+```
+
+---
+
+## Per-Agent Configuration
+
+Each agent can declare interactive session settings in its YAML config file. Config files are loaded from (in priority order):
+
+1. `.ta/agents/<agent-id>.yaml` (project override)
+2. `~/.config/ta/agents/<agent-id>.yaml` (user override)
+3. Built-in defaults
+
+### Example: `.ta/agents/claude-code.yaml`
+
+```yaml
+command: claude
+args_template: ["{prompt}"]
+injects_context_file: true
+injects_settings: true
+
+interactive:
+  enabled: true
+  output_capture: pipe       # pipe (default), pty, or log
+  allow_human_input: true    # enable guidance injection
+  auto_exit_on: "idle_timeout: 300s"
+  resume_cmd: "claude --resume {session_id}"
+```
+
+### Configuration fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Whether interactive mode is available |
+| `output_capture` | string | `"pipe"` | How to capture agent output: `pipe`, `pty`, or `log` |
+| `allow_human_input` | bool | `true` | Allow human message injection during execution |
+| `auto_exit_on` | string | none | Auto-exit condition (e.g., `"idle_timeout: 300s"`) |
+| `resume_cmd` | string | none | Command template for session resume |
+
+### Output capture modes
+
+| Mode | Description | Use case |
+|------|-------------|----------|
+| `pipe` | Standard stdout/stderr piping | Default, works with all agents |
+| `pty` | Pseudo-terminal wrapping | Preserves ANSI colors, interactive prompts |
+| `log` | Write-to-file only | Headless/CI runs, no terminal output |
+
+---
+
+## Integration with Review Sessions
+
+Interactive sessions complement the existing review session system (from v0.3.0):
+
+```bash
+# Start an interactive run
+ta run "Implement feature X" --source . --interactive
+
+# ... agent works and exits, draft is built ...
+
+# Start a review session for the draft
+ta draft review start <draft-id> --reviewer "alice"
+
+# Review artifacts one by one
+ta draft review next
+ta draft review comment "fs://workspace/src/main.rs" "Needs error handling"
+ta draft review next
+
+# Finish review
+ta draft review finish
+```
+
+The interactive session and review session are linked through the goal — `ta session show` displays associated draft IDs, and draft review commands show which goal/session produced the draft.
+
+### Inline review (planned)
+
+A future enhancement will allow reviewing drafts from within the interactive session, without switching to separate `ta draft review` commands. The protocol already supports this via `HumanInput::Approve` and `HumanInput::Reject` messages.
+
+---
+
+## Architecture: SessionChannel Protocol
+
+The interactive session system is built on a trait-based protocol that separates the communication channel from the session logic:
+
+```rust
+/// A bidirectional channel between a human and a TA-mediated agent session.
+pub trait SessionChannel: Send + Sync {
+    /// Display agent output to the human (streaming).
+    fn emit(&self, event: &SessionEvent) -> Result<(), SessionChannelError>;
+
+    /// Receive human input (blocks until available or timeout).
+    fn receive(&self, timeout: Duration) -> Result<Option<HumanInput>, SessionChannelError>;
+
+    /// Channel identity (for audit trail).
+    fn channel_id(&self) -> &str;
+}
+```
+
+### SessionEvent (TA -> Human)
+
+| Variant | Description |
+|---------|-------------|
+| `AgentOutput { stream, content }` | Agent stdout/stderr output |
+| `DraftReady { draft_id, summary, artifact_count }` | Draft checkpoint ready for review |
+| `GoalComplete { goal_id }` | Goal finished |
+| `WaitingForInput { prompt }` | Agent needs human guidance |
+| `StatusUpdate { message }` | Informational status |
+
+### HumanInput (Human -> TA)
+
+| Variant | Description |
+|---------|-------------|
+| `Message { text }` | Free-form guidance injected into agent context |
+| `Approve { draft_id, artifact_uri }` | Approve a draft or specific artifact |
+| `Reject { draft_id, artifact_uri, reason }` | Reject with reason |
+| `Abort` | Kill the session |
+
+### TaEvent integration
+
+Three new event types are emitted for audit compliance:
+
+| Event | Payload | When |
+|-------|---------|------|
+| `SessionStarted` | goal_id, session_id, channel_id, agent_id | `ta run --interactive` creates session |
+| `SessionStateChanged` | session_id, from_state, to_state | Any state transition |
+| `SessionMessage` | session_id, sender, content_preview | Human or agent message logged |
+
+These integrate with the existing tamper-evident audit trail (ta-audit) for compliance with ISO/IEC 42001 and IEEE 7001.
+
+---
+
+## Future: Multi-Platform Channels
+
+The `SessionChannel` trait is designed so that messaging platform integrations are thin adapters, not new features. Each platform maps its primitives to `SessionEvent` / `HumanInput`:
+
+| Platform | `emit()` | `receive()` | Channel identity | Status |
+|----------|----------|-------------|-----------------|--------|
+| **CLI** | Terminal stdout | stdin | `cli:{pid}` | Implemented |
+| **Discord** | Thread message | Thread reply | `discord:{thread_id}` | Planned |
+| **Slack** | Channel message | Thread reply | `slack:{channel}:{ts}` | Planned |
+| **Email** | Reply email | Incoming email | `email:{thread_id}` | Planned |
+| **Web app** | WebSocket push | WebSocket message | `web:{session_id}` | Planned |
+
+Each adapter is expected to be ~100-200 lines: authenticate, map to `SessionChannel`, route to the correct TA session. All governance (draft review, audit, policy) is handled by TA core — the channel just carries messages.
+
+### Example: What a Discord adapter would look like
+
+```
+Human posts in Discord thread: "Fix the auth bug"
+  -> Discord adapter receives message
+  -> Creates InteractiveSession with channel_id: "discord:thread:123456"
+  -> Launches agent via ta run
+  -> Agent output streamed back to Discord thread
+  -> Draft ready notification posted as embed
+  -> Human replies "approve" -> HumanInput::Approve
+  -> Applied, result posted to thread
+```
+
+The protocol ensures every interaction is audited, regardless of which channel it originates from.
+
+---
+
+## Command Reference
+
+### `ta run --interactive`
+
+```bash
+ta run "goal title" --source . --interactive [--agent claude-code]
+```
+
+Creates a goal with an interactive session, launches the agent, and tracks the session lifecycle. On agent exit, builds the draft and marks the session completed.
+
+### `ta session list`
+
+```bash
+ta session list [--all]
+```
+
+Lists interactive sessions. By default shows only active/paused sessions. Use `--all` to include completed and aborted sessions.
+
+### `ta session show`
+
+```bash
+ta session show <session-id>
+```
+
+Displays detailed session information including goal link, channel identity, state, timestamps, associated drafts, and message history. Accepts full UUID or any unique prefix.
+
+---
+
+## Troubleshooting
+
+### "No active interactive sessions"
+
+This means no sessions are in Active or Paused state. Use `ta session list --all` to see completed/aborted sessions, or start a new one with `ta run --interactive`.
+
+### Session shows "aborted" after agent crash
+
+If the agent process crashes (non-zero exit or launch failure), the session is automatically marked as aborted. The draft build still runs if possible. Check the session message log for details:
+
+```bash
+ta session show <id>
+# Look for: [ta-system] Agent launch failed: ...
+```
+
+### Multiple sessions for the same goal
+
+Each `ta run --interactive` invocation creates a new session, even for the same goal. This is by design — each launch represents a distinct human-agent interaction. Use `ta session list` to find the relevant session.

--- a/docs/user-experience.md
+++ b/docs/user-experience.md
@@ -1,23 +1,27 @@
 # Trusted Autonomy v1.0 — User Experience Walkthrough
 
-> Based on PLAN.md phases v0.1–v1.0. Written to stress-test the product plan from five real user perspectives. Identifies gaps, over-engineering, and workflow rigidity.
+> Based on PLAN.md phases v0.1–v1.0. Written to stress-test the product plan from five real user perspectives. Each persona includes an honest comparison: what can you already do with Claude/Codex/Claude Desktop alone, and what does TA specifically add?
 >
 > See also: `docs/enterprise-state-intercept.md` for the deep containment model (network-level capture for enterprise/regulated environments).
 
 ---
 
-## How TA Changes the Supervision Model
+## The Core Question: Why Not Just Use Claude Directly?
 
-Before diving into user types, the key shift:
+Claude Code, Codex, Claude Desktop, and Claude Teams are already powerful. A home user can ask Claude Desktop to categorize transactions from a CSV. A developer can use Codex to generate PRs. A business person can use Claude Teams to draft emails. **TA must earn its place on top of tools that already work.**
 
-| Mode | Standard Claude/Codex | TA-mediated |
-|------|----------------------|-------------|
-| **Active coding** | Continuous back-and-forth. ~100% attention. | `ta run` launches agent. Check back when draft ready. ~10-20% attention. |
-| **Overnight/batch** | Not possible — session closes. | Agent works in background. Review next morning. 0% during execution. |
-| **Auto-approved** | N/A | Supervisor reviews within constitutional bounds. User sees summary. ~1% attention. |
-| **Virtual office** | N/A | Roles run on triggers. Review when notified. Minutes per day. |
+TA's value proposition is not "make AI possible" — it's **"make AI autonomous."** The shift from synchronous conversation to asynchronous delegation:
 
-**The shift**: Standard agents demand synchronous attention. TA shifts to asynchronous review. Trust escalates over time — the more the supervisor proves reliable, the less the human needs to intervene.
+| Mode | Agent alone (Claude/Codex/etc.) | TA-mediated |
+|------|--------------------------------|-------------|
+| **Active work** | You drive the conversation. ~100% attention. Agent does what you ask, one turn at a time. | `ta run` launches agent. Check back when draft ready. ~10-20% attention. |
+| **Batch/overnight** | Session closes when you leave. You start over tomorrow. | Agent works in background. Review next morning. 0% during execution. |
+| **Recurring tasks** | You re-prompt every time. Copy-paste results manually. | Workflow runs on triggers. Agent drafts, you review when notified. |
+| **Multi-step external actions** | Agent calls APIs in real-time — you approve each one synchronously, or trust blindly. | All external actions held as drafts. Review batch. Approve/reject selectively. |
+| **Credentials** | You paste API keys into the conversation, or configure per-agent. | TA brokers all credentials. Agents never see raw secrets. |
+| **Audit & compliance** | No record beyond chat history. | Hash-verified audit trail with provenance, auto-generated compliance evidence. |
+
+**If you're happy with synchronous, one-off conversations — you don't need TA.** TA is for when you want agents running autonomously on your behalf, with governance you can trust and escalate over time.
 
 ---
 
@@ -59,26 +63,47 @@ ta audit drift claude-code          # any unusual behavior? No drift detected.
 - Review model: every change is a "draft" you approve/reject, like a PR but richer
 - Zero-config path works: `ta run "fix the login bug" --source .` needs nothing pre-configured
 
-### What problems TA solves
+### What you already get without TA
 
-1. **AI changes without review**: 40-file change with structured diffs and per-file explanations, not a mystery commit
-2. **Wasted tokens on re-learning**: Session resume preserves context via agent-native mechanisms
-3. **Multi-agent chaos**: Alignment profiles prevent agents stepping on each other
-4. **"What did the agent do?"**: Hash-verified audit trail with provenance
-5. **Compliance as byproduct**: ISO/EU AI Act evidence generated automatically
-6. **Credential safety**: Agents never see raw API keys or OAuth tokens — TA brokers all access
+| Capability | Claude Code | Codex | Cursor |
+|-----------|------------|-------|--------|
+| Edit files from natural language | Yes — direct edits, you review in terminal | Yes — creates git commits/PRs | Yes — inline suggestions |
+| Multi-file refactors | Yes — but you watch the whole session | Yes — headless, creates a PR | Limited |
+| Code review of changes | Git diff after the fact | GitHub PR diff | Inline diff |
+| Overnight/batch work | No — session closes | Yes — but all-or-nothing PR | No |
+| Plan/roadmap tracking | No | No | No |
+| Audit trail | Chat history (ephemeral) | Git history | None |
+| Multi-agent coordination | Manual | N/A | N/A |
+
+**Key insight**: Codex already provides headless execution + PR-based review. Claude Code already provides interactive editing. For a developer, TA's competition isn't "no AI" — it's the native workflows these tools already provide.
+
+### What TA adds on top
+
+1. **Structured review of large changes**: Codex gives you a git diff. TA gives you per-file explanations, disposition tracking (approve this file, reject that one), and impact summaries. For a 40-file change, the diff is noise — the structured review is signal.
+2. **Selective approval**: Codex PRs are all-or-nothing (merge or close). TA lets you approve 38 files, reject 2, and ask the agent to revise just those 2. No re-running the whole job.
+3. **Batch async with trust escalation**: Codex can run overnight, but you still review every PR manually. TA's supervisor agent auto-approves routine changes within constitutional bounds — you only see escalations. This is the difference between reviewing 20 PRs/day vs 2.
+4. **Agent-agnostic governance**: Same review workflow whether the agent is Claude Code, Codex, Cursor, or a custom script. Switch agents without switching governance.
+5. **Plan-integrated execution**: `ta run --phase 0.8.2` ties work to a roadmap. Agent knows what to build next. No re-explaining context each session.
+6. **Compliance as byproduct**: If you're in a regulated environment, TA's audit trail and provenance hashes are already ISO/EU AI Act compliant. Without TA, you'd build this yourself.
+
+### When TA isn't worth it
+
+- Quick one-off fixes: `claude "fix the typo in README"` is faster than `ta run`. Don't add governance overhead to trivial tasks.
+- Solo developer on a small project with no compliance needs: git history + Codex PRs may be sufficient.
+- Exploratory prototyping where you want the agent to just go: TA's review-before-apply model slows down "let it rip" development.
 
 ### Supervision frequency
 
 - **Starting out**: Review every draft manually. ~15 min/day for a typical project.
 - **After trust builds**: Set up constitutional auto-approval. Review only escalations and daily summary. ~5 min/day.
 - **Mature usage**: Supervisor handles routine, human handles strategy. Drafts per week: 20+ agent-reviewed, 2-3 human-reviewed.
+- **Comparison**: Codex requires reviewing every PR (~15 min/day indefinitely). Claude Code requires full attention during session (~hours/day). TA's supervision cost decreases over time as trust escalates.
 
 ### Remaining friction
 
-- Must learn TA vocabulary (goals, drafts, phases, dispositions) on top of git
+- Must learn TA vocabulary (goals, drafts, phases, dispositions) on top of git — needs to feel like a natural extension, not a second system
 - Staging copy doubles disk for large repos (COW planned for future)
-- Ad-hoc `ta run "fix bug"` with no plan must feel as frictionless as `claude "fix bug"`
+- `ta run "fix bug"` must feel as frictionless as `claude "fix bug"` — if it doesn't, developers will skip TA for small tasks and lose the audit trail
 
 ---
 
@@ -133,25 +158,46 @@ ta setup --template email-assistant
 - How to give feedback when agent gets something wrong (comment on draft)
 - Setup wizard handles everything else — no YAML, no CLI
 
-### What problems TA solves
+### What you already get without TA
 
-1. **Fear of AI sending bad emails**: Every outbound action held for review. See exactly what goes out.
-2. **Black box automation**: See agent's reasoning alongside the output
-3. **Trust escalation**: Start manual, gradually auto-approve low-risk actions
-4. **Credential safety**: Agent never has your Gmail password or OAuth token. TA brokers all access.
-5. **Consistency**: Agent constrained by constitution, not just prompted
+| Capability | Claude Desktop / Teams | Zapier / Make | Custom GPT |
+|-----------|----------------------|--------------|------------|
+| Draft emails from prompts | Yes — paste context, get draft, copy to Gmail | Yes — trigger-based, template-driven | Yes — conversational |
+| Weekly status reports | Yes — paste data, get report each time | Yes — automated but rigid templates | Yes — but manual each time |
+| Multi-channel (email + Slack + Docs) | One channel at a time, you orchestrate | Yes — multi-step zaps | No |
+| Review before sending | You read the output and copy-paste | No — fires automatically or not at all | You copy-paste |
+| Credential safety | Paste into conversation or connect via integration | OAuth per-zap, platform holds credentials | Via platform |
+| Learns your preferences | Within conversation context window | No — template-based | Somewhat via instructions |
+
+**Key insight**: Claude Desktop/Teams already drafts great emails. The UX is polished. For a single-channel, one-at-a-time workflow, Claude Desktop is easier than TA. TA's competition here isn't "no AI" — it's Claude's own consumer products, plus automation platforms like Zapier/Make.
+
+### What TA adds on top
+
+1. **Batch review, not one-at-a-time**: Claude Desktop drafts one email per conversation turn. TA's agent drafts 10 emails overnight, categorized and prioritized. You review the batch in one sitting. This is the difference between "AI as writing assistant" and "AI as delegation."
+2. **Hold-before-send for external actions**: Zapier fires actions automatically — you trust it or you don't. Claude Desktop gives you text to copy-paste — safe but manual. TA holds every outbound action (email send, Slack post, doc update) in a draft queue. You see exactly what will happen, approve selectively, and TA executes. No copy-paste, no blind automation.
+3. **Persistent workflows without programming**: Zapier requires building zaps with triggers and actions. TA's setup wizard is conversational — describe what you want, agent proposes the config, you approve. The workflow persists and runs on schedule, not per-conversation.
+4. **Trust escalation**: Start with manual review of everything. After the agent proves reliable for routine emails, set constitutional auto-approval for low-risk actions. You gradually reduce supervision without all-or-nothing trust. Neither Claude Desktop (always manual) nor Zapier (always automatic) offers this gradient.
+5. **Credential isolation**: Claude Desktop conversations may see sensitive content you paste in. Zapier holds OAuth tokens on their servers. TA stores credentials locally in an encrypted vault — the agent never sees raw tokens, and nothing leaves your machine.
+
+### When TA isn't worth it
+
+- Occasional email drafting: Opening Claude Desktop and saying "draft a reply to this" is faster for one-off tasks.
+- Simple, predictable automations: If a Zapier zap does what you need and you trust it, the governance overhead of TA is unnecessary.
+- Teams already using Claude Teams with built-in sharing: TA's web UI would need to match that polish, and it may not at v1.0.
 
 ### Supervision frequency
 
 - **Week 1**: Review every draft. ~20 min/day. Learning what the agent does well.
 - **Month 1**: Constitutional auto-approval for routine emails. Review only new contacts, complex threads. ~5 min/day.
 - **Mature**: Daily summary notification. Handle 2-3 escalations per day. ~3 min/day.
+- **Comparison**: Claude Desktop requires full attention per task (~minutes each, unbounded daily total). Zapier requires zero attention but offers zero review. TA starts like Claude Desktop (review everything) and trends toward Zapier (auto-approve routine) while maintaining the ability to intervene.
 
 ### Remaining friction
 
-- Web review UI must be polished enough for non-technical users (v0.5.2 is minimal)
+- Web review UI must be polished enough for non-technical users — Claude Desktop sets the bar high
 - MCP server health/connectivity issues need clear error messages, not stack traces
 - Multi-user (team) workflows not addressed until v1.0 virtual office
+- **Honest question**: Is a non-technical user going to install and run a localhost service? The distribution/onboarding story (v0.9) is critical for this persona.
 
 ---
 
@@ -207,25 +253,49 @@ ta setup --template email-assistant
 - How to give feedback when the agent gets it wrong
 - Where to adjust preferences ("don't post before 10am")
 
-### What problems TA solves
+### What you already get without TA
 
-1. **Fear of AI acting on their behalf**: Nothing happens without approval
-2. **Social media burnout**: Agent handles routine, human handles creative
-3. **Email overwhelm**: Agent triages and drafts, human handles judgment calls
-4. **Privacy**: Local-first — data stays on their machine
-5. **Cost visibility**: See exactly what the AI costs each week
+| Capability | Claude Desktop / ChatGPT | Buffer / Hootsuite | IFTTT / Shortcuts |
+|-----------|-------------------------|-------------------|------------------|
+| Draft social posts | Yes — describe what you want, get captions | No — you write, they schedule | No |
+| Draft email replies | Yes — paste email, get reply | N/A | N/A |
+| Schedule posts | No — you copy-paste to the platform | Yes — core feature, calendar UI | Limited triggers |
+| Manage across platforms | One at a time, you orchestrate | Yes — multi-platform dashboard | Trigger-based |
+| Review before posting | You read the output | Yes — queue with preview | No — fires automatically |
+| Learns your voice/style | Within context window | No | No |
+| Privacy | Data goes to Anthropic/OpenAI servers | Data on their servers | Local (Shortcuts) or cloud (IFTTT) |
+
+**Key insight**: For social media, the real competitors are Buffer/Hootsuite (scheduling) and Claude Desktop (drafting). A home user already has good options. For email, Claude Desktop + manual copy-paste works. TA needs to be significantly easier than the combination of these existing tools.
+
+### What TA adds on top
+
+1. **Unified AI + execution in one place**: Today you'd use Claude Desktop to draft, then copy to Buffer to schedule, then manually check Gmail for replies. TA's agent drafts posts, schedules them, and handles email replies — all in one workflow with one review queue. The value is eliminating the orchestration between 3-4 separate tools.
+2. **Review queue, not copy-paste**: Claude Desktop gives you text to copy somewhere. TA shows you "here's what I want to post to Instagram and here's the email I want to send" — approve and it happens. No clipboard, no switching apps.
+3. **Persistent automation without Zapier complexity**: IFTTT/Zapier can automate posting but require building trigger-action chains. TA's setup wizard lets you say "post 3 times a week from my photos" in plain language. The agent proposes a workflow; you approve.
+4. **Privacy (local-first)**: Claude Desktop sends your data to Anthropic's servers. Buffer/Hootsuite store your content on their servers. TA runs locally — your photos, emails, and social content stay on your machine. The agent calls APIs through TA's credential broker, but your data isn't stored in someone else's cloud.
+5. **Trust escalation**: Start reviewing every post. After a month, auto-approve routine posts that match your style guide. Neither Claude Desktop (always manual) nor Buffer (no AI review) offers this middle ground.
+6. **Cost visibility**: See exactly what AI costs per week. Claude Desktop Pro is $20/month flat. TA's per-token cost may be lower for light usage or higher for heavy usage — transparent either way.
+
+### When TA isn't worth it
+
+- Casual social media use: If you post 2-3 times a week manually, the setup cost of TA exceeds the time saved.
+- Already happy with Buffer + ChatGPT: If the copy-paste workflow works for you, TA adds complexity for marginal improvement.
+- Privacy isn't a concern: If you're fine with cloud services, the local-first advantage doesn't matter.
+- **Honest assessment**: This is TA's hardest sell. A non-technical home user is being asked to install a localhost service, understand "drafts" and "approvals," and manage API costs — when Claude Desktop's chat interface "just works" for one-off tasks. TA's value only kicks in when the user wants persistent automation, not just occasional AI help.
 
 ### Supervision frequency
 
 - **Week 1**: Review everything. ~15 min/day.
 - **Month 1**: Auto-approve routine email replies (low risk, familiar contacts). ~5 min/day.
 - **Mature**: Glance at daily digest. Handle 1-2 items. ~2 min/day.
+- **Comparison**: Claude Desktop requires active engagement per task (~5 min each, as needed). Buffer/Hootsuite require queue management (~10 min/day). TA's supervision cost starts higher but decreases as trust escalates — break-even vs. manual tools at ~month 2 if you have enough volume.
 
 ### Remaining friction
 
 - No mobile native app (PWA must work well on phone)
 - Onboarding must be conversational, never show YAML or terminal
 - Cost must be predictable — "this month will cost ~$15" not surprises
+- **Distribution gap**: This user won't `cargo install` or run a CLI. Desktop installer + browser-based setup is minimum bar. Even that may be too much — compare to downloading the Claude Desktop app.
 
 ---
 
@@ -293,23 +363,59 @@ ta setup --template family-office
 # All access logged in audit trail
 ```
 
-### What problems TA solves
+### What you already get without TA
 
-1. **Spreadsheet drudgery**: Agent categorizes, tracks, reports. Human reviews and decides.
-2. **Financial data security**: Local-first, credentials in encrypted vault, agents have read-only access
-3. **Audit trail**: Every agent access to financial data is logged — who, what, when
-4. **Family office complexity**: Multi-account, tiered access without building a custom app
-5. **Tax prep**: Agent does the collection and organization; human reviews before sharing with accountant
+| Capability | Claude Desktop / ChatGPT | Mint / YNAB / Copilot | Excel + Claude |
+|-----------|-------------------------|----------------------|----------------|
+| Categorize transactions | Yes — paste CSV, get categories | Yes — auto-categorize from bank feed | Claude categorizes, you update sheet |
+| Monthly dashboard | Yes — ask for charts from data | Built-in dashboards | Claude generates charts from sheet |
+| Budget tracking | Yes — if you provide the data each time | Yes — core feature, auto-updated | Manual + Claude analysis |
+| Bill monitoring | No — no persistent access | Some — alerts for unusual charges | No |
+| Investment tracking | Limited — no real-time data | Copilot does some, Mint limited | Manual data entry + Claude analysis |
+| Tax prep | Yes — paste transactions, get summaries | Limited export features | Claude organizes, you verify |
+| Bank connection | No — you export CSV manually | Yes — Plaid/bank feeds built-in | No |
+| Privacy | Data goes to AI provider's servers | Data on their servers | Local (Excel) + AI servers (Claude) |
+| Multi-user/family | Within conversation | Yes — shared accounts | Shared file |
+
+**Key insight**: Dedicated finance apps (Mint, YNAB, Monarch, Copilot) already solve categorization, dashboards, and bank connectivity. Claude Desktop can analyze any financial data you paste in. The combination of "finance app for data + Claude for analysis" covers most needs. TA's competition is this existing stack, not "doing it manually."
+
+### What TA adds on top
+
+1. **AI-powered analysis with persistent bank access**: Mint/YNAB categorize but don't analyze or explain. Claude analyzes but you re-paste data every time. TA connects to your bank via Plaid (once), and the agent analyzes weekly — automatically, with persistent context. "Your grocery spending is up 22% this month, mostly from Whole Foods" without you lifting a finger.
+2. **Local-first with real bank data**: Claude Desktop requires pasting sensitive financial data into a cloud conversation. Mint/Copilot store your financial data on their servers (and Mint was shut down). TA runs locally — bank credentials in an encrypted vault, transaction data on your machine. The agent accesses data through TA's credential broker with read-only scope.
+3. **Review before any action**: YNAB/Copilot update automatically — you trust or you don't. Claude Desktop gives you text to copy. TA holds every output (dashboard, email to spouse, tax summary for accountant) as a draft. You review before anything is shared or published.
+4. **Custom reports beyond templates**: Mint/YNAB give you their dashboards. Claude can build custom reports but you re-prompt each time. TA's agent builds the reports you actually want (because you described them in setup), regenerates them on schedule, and you just review.
+5. **Family office tiered access**: No consumer finance app handles "principal sees everything, advisor sees portfolio only, accountant sees tax-relevant transactions during tax season." TA's credential broker + constitutional configs make this possible without building a custom application.
+6. **Audit trail for financial data access**: Every time the agent reads your transactions, it's logged — who (which agent), what (which accounts), when. Required for family office governance, useful for personal peace of mind.
+
+### When TA isn't worth it
+
+- Simple budgeting: YNAB or Monarch already does 90% of what you need with zero setup complexity.
+- No bank API needs: If you're happy exporting CSV and pasting into Claude Desktop monthly, the Plaid integration overhead isn't worth it.
+- Single person, simple finances: TA's tiered access, audit trails, and constitutional configs are overkill. Use Claude Desktop + a spreadsheet.
+- **Honest assessment**: For household budgets, the primary value is "persistent automated analysis with local privacy." For family office, it's "tiered access + audit trail without building custom software." The household use case is a nice-to-have; the family office use case is where TA solves a real gap.
 
 ### Supervision frequency
 
 - **Weekly**: 5-10 min reviewing categorizations and flagged items
 - **Monthly**: 10 min reviewing dashboard and report before sharing
 - **Tax season**: 30 min reviewing collected documents before sending to accountant
+- **Comparison**: Mint/YNAB require ~5 min/week to verify categories (similar). Claude Desktop requires ~15 min/month to re-paste data and re-prompt for reports (TA eliminates this). Family office: without TA, you'd spend hours managing separate logins and manually restricting what each person sees.
 
 ---
 
 ## 5. Areas to Examine Before Going Too Far
+
+### Where TA's value is strongest vs weakest (honest summary)
+
+| Persona | Without TA baseline | TA's incremental value | Strength |
+|---------|--------------------|-----------------------|----------|
+| **SW Engineer** | Codex PRs + Claude Code interactive | Selective approval, trust escalation, multi-agent governance, compliance | **Strong** — real gaps in batch review + trust escalation |
+| **Product Person** | Claude Teams/Desktop + Zapier | Unified review queue, hold-before-send, credential isolation | **Medium** — competing against polished UIs; TA's value is delegation + governance |
+| **Home User** | Claude Desktop + Buffer/Hootsuite | Unified automation, local privacy, trust escalation | **Weak** — hardest onboarding, most competition from consumer tools |
+| **Home Finance** | YNAB/Mint + Claude Desktop | Persistent analysis, local privacy, family office tiered access | **Medium** (household) / **Strong** (family office) — consumer apps cover basics |
+
+**Takeaway**: TA's strongest differentiation is for users who want **autonomous, persistent, governed agent workflows** — not one-off AI conversations. The developer persona is the clearest fit. Non-technical personas require significant UX investment to compete with existing consumer AI products.
 
 ### Critical path validation (do these spikes before committing)
 
@@ -318,6 +424,7 @@ ta setup --template family-office
 3. **Web UI spike**: Serve one HTML page from `ta daemon`, render one draft, approve it. If the daemon architecture doesn't support this cleanly, v0.5.2 is harder than expected.
 4. **Plaid integration spike**: Connect one bank account, fetch transactions, display in `ta draft view`. Validates the finance use case isn't blocked by API complexity.
 5. **Auto-approval spike**: Supervisor agent evaluates one draft against a constitutional config. If the LLM-based verification is unreliable, v0.6.0 needs a different approach (rule-based only).
+6. **Onboarding comparison spike**: Install TA, set up one workflow, complete one task — time it. Compare to the same task in Claude Desktop. If TA takes 3x longer to first value, the non-dev personas won't convert.
 
 ### Workflow openness checklist
 
@@ -340,6 +447,8 @@ ta setup --template family-office
 - An LLM model — use Claude/GPT/local models via agent framework
 - A cloud hosting platform — let users self-host; cloud can be a wrapper later
 - Accounting software — TA generates reports, doesn't replace QuickBooks
+- A consumer chat UI to compete with Claude Desktop — TA's UI is for review/governance, not conversation
+- Social media scheduling features — defer to MCP servers wrapping existing platforms
 
 ### Suggested priority order
 
@@ -351,3 +460,14 @@ The current plan phases are mostly in the right order. Key reorderings already m
 5. **Network intercept** extracted to enterprise doc (not blocking v1.0)
 6. **Sandbox** becomes optional hardening at v0.9.1 (not a prerequisite)
 7. **Setup wizard + templates** becomes v0.7 (enables non-dev onboarding)
+
+### Strategic positioning
+
+TA is not a replacement for Claude Desktop, Codex, or any specific AI tool. It's a **governance and orchestration layer** that wraps whatever agents the user already prefers. The pitch:
+
+- **To developers**: "Keep using Claude Code / Codex / Cursor. TA adds the review, trust, and compliance layer you'd otherwise build yourself."
+- **To business users**: "Keep using Claude for drafting. TA makes it persistent, automated, and safe to delegate — with a review queue instead of copy-paste."
+- **To home users**: "TA turns AI assistants into AI staff — they work while you sleep, and you review in the morning."
+- **To enterprises**: "TA provides the audit, compliance, and containment evidence your security and legal teams require."
+
+The developer persona should drive v0.3–v0.6. Non-dev personas unlock at v0.7+ (setup wizard, web UI, templates). Don't optimize for non-dev UX before the governance model is proven with developers.


### PR DESCRIPTION
Phase v0.3.1.2 — Interactive Session Orchestration is complete. Here's a summary of what was implemented:

  Summary

  New Core Protocol (ta-changeset)

  - SessionChannel trait — bidirectional emit()/receive()/channel_id() interface that CLI, Discord, Slack, email, and web adapters can implement
  - SessionEvent enum — AgentOutput, DraftReady, GoalComplete, WaitingForInput, StatusUpdate
  - HumanInput enum — Message, Approve, Reject, Abort
  - InteractiveSession struct — lifecycle state machine (Active/Paused/Completed/Aborted) with message logging and draft tracking
  - InteractiveConfig — per-agent YAML config (output_capture, allow_human_input, auto_exit_on, resume_cmd)
  - InteractiveSessionStore — JSON file persistence (same pattern as ReviewSessionStore)

  New CLI Commands

  - ta run --interactive — creates an interactive session tied to the goal, tracks lifecycle
  - ta session list Æ--allÅ — shows active sessions across all channels
  - ta session show <id> — session details with message history (supports prefix matching)

  Event System Extension (ta-goal)

  - Three new TaEvent variants: SessionStarted, SessionStateChanged, SessionMessage

  Verification

  - 334 tests passing (27 new), all clippy/format checks clean
  - Version bumped to 0.3.2-alpha
  - docs/USAGE.md updated with Interactive Sessions section

Goal Context

- **Goal ID**: `e40d2b7c-66ec-4856-9c4a-7ae000b73114`
- **PR ID**: `0e7f9c69-cdf9-4504-a84f-c276f625ac7e`


---

🤖 Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)