### PR TITLE
release: Generate release notes

### DIFF
--- a/.release-draft.md
+++ b/.release-draft.md
@@ -1,0 +1,28 @@
+## v0.3.2-alpha
+
+### New Features
+
+- **Configurable release pipeline (`ta release`)**: A new `ta release` command driven by YAML task scripts (`.ta/release.yaml`). Define pipeline steps as TA goals (agent-driven) or shell commands, with optional approval gates. Ships with a built-in default pipeline for version bump, verify, release notes, and tagging — override with your own `.ta/release.yaml`.
+- **Interactive session orchestration (`ta run --interactive`)**: A `SessionChannel` protocol enables humans to observe agent output, inject guidance mid-session, and review drafts inline — all through a unified interaction layer designed to extend to Discord, Slack, and web frontends in future releases.
+- **Configurable plan format parsing**: Plans are no longer locked to TA's own PLAN.md format. A new `.ta/plan-schema.yaml` lets any project describe its plan structure with regex patterns. `ta plan init` auto-detects an existing plan's format; `ta plan create` generates new plans from templates (greenfield, feature, bugfix).
+- **Plan lifecycle automation**: Completing a phase now auto-suggests the next pending phase. New CLI commands: `ta plan next`, `ta plan validate <phase>`, `ta plan history`. Status transitions are recorded to `.ta/plan_history.jsonl` for auditability.
+- **Review sessions with discussion workflow**: Full per-artifact review sessions via `ta draft review start/comment/next/finish/list/show`. Supervisor agent validates dependency graphs with cycle detection, coupled rejection warnings, and broken dependency warnings. Discussion threads from review sessions are injected into follow-up goal context so agents can address reviewer concerns.
+- **Terminology shift from PR to draft**: All user-facing commands now use `ta draft` terminology (`ta draft build`, `ta draft view`, `ta draft apply`, etc.). The old `ta pr` commands remain as hidden aliases for backward compatibility.
+
+### Improvements
+
+- **Consolidated `draft.rs`**: The duplicated `pr.rs` (~2,200 lines) was reduced to a ~160-line shim delegating to `draft.rs`, eliminating ~2,050 lines of duplication.
+- **Richer commit messages**: `ta draft apply` now includes the complete draft summary with per-artifact descriptions in the git commit message.
+- **Per-target summary enforcement**: `ta draft build` warns or errors (configurable via `.ta/workflow.toml`) when artifacts lack a `what` description. Lockfiles and config files are auto-exempt.
+- **Disposition badges in HTML output**: HTML adapter renders color-coded per-artifact disposition badges (pending, approved, rejected, discuss).
+- **Configurable ANSI color output**: Terminal output respects color configuration for better compatibility with different environments.
+- **Updated user experience documentation**: Revised `docs/user-experience.md` with honest TA vs. baseline comparisons.
+- **Restructured long-term roadmap**: PLAN.md v0.5–v1.0 phases reorganized for clarity, with new standards compliance mapping and decision observability roadmap.
+
+### Bug Fixes
+
+- **Fixed `strip_html` eating code placeholders**: The HTML stripping function was incorrectly consuming content that looked like HTML tags in code blocks. Fixed to only strip actual HTML tags.
+- **Fixed garbled terminal output**: `ta draft view` was rendering `ÆpendingÅ` instead of `[pending]` due to HTML `<span>` tags leaking into terminal output. Added `strip_html()` helper in `TerminalAdapter`.
+- **Fixed stale plan markers**: Corrected plan phase status markers that were not updating properly, and fixed the next-phase suggestion logic.
+- **Fixed `ta draft apply` commit summary**: Commit messages now match the summary shown by `ta draft view`, with mid-level detail included.
+- **Fixed partial workflow config parsing**: Added `#[serde(default)]` to `WorkflowConfig.submit` so `.ta/workflow.toml` files work without requiring a `[submit]` section.


### PR DESCRIPTION
## Summary

Changes from goal: release: Generate release notes

**Why**: Synthesize user-facing release notes for version v0.3.2-alpha.
Commits since v0.2.4-alpha:
Fix stale plan markers, add ruvector memory integration plan, fix next-phase suggestion
Implament v0.3.2 — Configurable Release Pipeline
Mark v0.3.1.2 done in PLAN.md
Revise user-experience.md with honest TA vs baseline comparisons
Fix strip_html eating code placeholders + enrich PR body with artifact detail
implement v0.3.1.2 — Interactive Session Orchestration
Restructure PLAN.md v0.5-v1.0 phases + add user experience docs
Fix the ta draft apply commit summary message to match ta draft view summary with mid-leel details
Implement v0.3.1.1 — Configurable Plan Format Parsing
split 0.3.1.1 into two parts for more granular development
updated plan for reusable plan parsing for different plan formats, minor bug fixes
implement v0.3.1 — Plan Lifecycle Automation
v0.3.0.1 — Consolidate  into
Implemented review session enhancements
improve arch image formatting
fixing aspect ratio
replace PR with draft terminology. add vision and working now arch diagrams
Add standards compliance mapping + decision observability roadmap to PLAN.md
Configurable ANSI color output + macro goal plan (v0.4.1)
v0.3.0 Discussion workflow implementation for discuss items
implement v0.3.0 supervisor agent
Add PLAN.md update instructions to agent injection template
shifting terminology to the draft from pr
v0.3.0: Implement ta draft review CLI commands
v0.3.0 — Review Sessions
added cost optimization goal into v0.4.0 objectives

Write the notes to .release-draft.md in this format:
## v0.3.2-alpha
### New Features
- ...
### Improvements
- ...
### Bug Fixes
- ...


**Impact**: 1 file(s) changed

## Changes (1 file(s))

- `+` `fs://workspace/.release-draft.md` — Release notes for v0.3.2-alpha organized into New Features (6), Improvements (7), and Bug Fixes (5) sections
  - The ta release pipeline requested synthesized release notes from the commit history between v0.2.4-alpha and v0.3.2-alpha

## Goal Context

- **Title**: release: Generate release notes
- **Objective**: Synthesize user-facing release notes for version v0.3.2-alpha.
Commits since v0.2.4-alpha:
Fix stale plan markers, add ruvector memory integration plan, fix next-phase suggestion
Implament v0.3.2 — Configurable Release Pipeline
Mark v0.3.1.2 done in PLAN.md
Revise user-experience.md with honest TA vs baseline comparisons
Fix strip_html eating code placeholders + enrich PR body with artifact detail
implement v0.3.1.2 — Interactive Session Orchestration
Restructure PLAN.md v0.5-v1.0 phases + add user experience docs
Fix the ta draft apply commit summary message to match ta draft view summary with mid-leel details
Implement v0.3.1.1 — Configurable Plan Format Parsing
split 0.3.1.1 into two parts for more granular development
updated plan for reusable plan parsing for different plan formats, minor bug fixes
implement v0.3.1 — Plan Lifecycle Automation
v0.3.0.1 — Consolidate  into
Implemented review session enhancements
improve arch image formatting
fixing aspect ratio
replace PR with draft terminology. add vision and working now arch diagrams
Add standards compliance mapping + decision observability roadmap to PLAN.md
Configurable ANSI color output + macro goal plan (v0.4.1)
v0.3.0 Discussion workflow implementation for discuss items
implement v0.3.0 supervisor agent
Add PLAN.md update instructions to agent injection template
shifting terminology to the draft from pr
v0.3.0: Implement ta draft review CLI commands
v0.3.0 — Review Sessions
added cost optimization goal into v0.4.0 objectives

Write the notes to .release-draft.md in this format:
## v0.3.2-alpha
### New Features
- ...
### Improvements
- ...
### Bug Fixes
- ...

- **Goal ID**: `348e8cec-e0ef-4455-a613-89f99debc1ed`
- **PR ID**: `cfc68bfe-6618-4f4c-b053-0bd7fa353bc6`
- **Plan Phase**: `N/A`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
