### PR TITLE
v0.3.3 — Decision Observability & Reasoning Capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.3.2-alpha"
+version = "0.3.3-alpha"
 dependencies = [
  "anyhow",
  "chrono",

--- a/PLAN.md
+++ b/PLAN.md
@@ -618,7 +618,7 @@ A `ta release` command driven by a YAML task script (`.ta/release.yaml`). Each s
 - ✅ **Approval gates**: `requires_approval: true` pauses for human review before proceeding (e.g., before push)
 
 ### v0.3.3 — Decision Observability & Reasoning Capture
-<!-- status: pending -->
+<!-- status: done -->
 **Goal**: Make every decision in the TA pipeline observable — not just *what happened*, but *what was considered and why*. Foundation for drift detection (v0.4.2) and compliance reporting (ISO 42001, IEEE 7001).
 
 > **Research note**: Evaluated [AAP](https://github.com/mnemom/aap) (Agent Alignment Protocol) for this role. AAP provides transparency through self-declared alignment cards and traced decisions, but is a Python/TypeScript decorator-based SDK that can't instrument external agents (Claude Code, Codex). TA's approach is stronger: enforce constraints architecturally, then capture the reasoning of TA's own decision pipeline. The *agent's* internal reasoning is captured via `change_summary.json`; TA's *governance* reasoning is captured here.
@@ -672,6 +672,19 @@ Agents that support it get richer review context; agents that don't still work f
 - **ISO/IEC 42001**: Documented decision processes with rationale (Annex A control A.6.2.3)
 - **IEEE 7001**: Transparent autonomous systems — decisions are explainable to stakeholders
 - **NIST AI RMF**: MAP 1.1 (intended purpose documentation), GOVERN 1.3 (decision documentation)
+
+#### Completed
+- `DecisionReasoning` + `Alternative` structs in `ta-audit` with `reasoning` field on `AuditEvent`
+- `EvaluationTrace` + `EvaluationStep` in `ta-policy` — full trace from `PolicyEngine::evaluate_with_trace()`
+- `AlternativeConsidered` struct and enriched `DecisionLogEntry` in `ta-changeset`
+- Extended `PolicyDecisionRecord` with `grants_checked`, `matching_grant`, `evaluation_steps`
+- `ReviewReasoning` struct on `Comment` — reviewers can document structured reasoning
+- Extended `ChangeSummaryEntry` with `alternatives_considered` (agent-side)
+- Decision log extraction in `ta draft build` — alternatives flow from change_summary.json into draft packages
+- `ta audit show <goal-id>` — display decision trail with reasoning
+- `ta audit export <goal-id> --format json` — structured compliance export
+- 17 new tests across ta-audit, ta-policy, ta-changeset
+- All backward-compatible — old data deserializes correctly
 
 ---
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-cli"
-version = "0.3.2-alpha"
+version = "0.3.3-alpha"
 edition = "2021"
 description = "CLI for goals, PR review, and approvals in Trusted Autonomy"
 license = "Apache-2.0"

--- a/apps/ta-cli/src/commands/audit.rs
+++ b/apps/ta-cli/src/commands/audit.rs
@@ -1,7 +1,7 @@
-// audit.rs — Audit subcommands: verify, tail.
+// audit.rs — Audit subcommands: verify, tail, show, export.
 
 use clap::Subcommand;
-use ta_audit::AuditLog;
+use ta_audit::{AuditEvent, AuditLog};
 use ta_mcp_gateway::GatewayConfig;
 
 #[derive(Subcommand)]
@@ -21,6 +21,30 @@ pub enum AuditCommands {
         #[arg(short, default_value = "10")]
         n: usize,
     },
+    /// Display the decision trail for a goal with reasoning (v0.3.3).
+    Show {
+        /// Goal ID to display decision trail for.
+        goal_id: String,
+        /// Path to audit log (defaults to .ta/audit.jsonl).
+        #[arg(long)]
+        log: Option<String>,
+    },
+    /// Export structured audit data for compliance reporting (v0.3.3).
+    Export {
+        /// Goal ID to export.
+        goal_id: String,
+        /// Output format.
+        #[arg(long, default_value = "json")]
+        format: ExportFormat,
+        /// Path to audit log (defaults to .ta/audit.jsonl).
+        #[arg(long)]
+        log: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum ExportFormat {
+    Json,
 }
 
 pub fn execute(cmd: &AuditCommands, config: &GatewayConfig) -> anyhow::Result<()> {
@@ -97,7 +121,172 @@ pub fn execute(cmd: &AuditCommands, config: &GatewayConfig) -> anyhow::Result<()
                 );
             }
         }
+
+        AuditCommands::Show { goal_id, log } => {
+            show_decision_trail(config, goal_id, log.as_deref())?;
+        }
+
+        AuditCommands::Export {
+            goal_id,
+            format,
+            log,
+        } => {
+            export_audit(config, goal_id, format, log.as_deref())?;
+        }
     }
+
+    Ok(())
+}
+
+/// Filter events related to a specific goal.
+fn events_for_goal(events: &[AuditEvent], goal_id: &str) -> Vec<AuditEvent> {
+    events
+        .iter()
+        .filter(|e| {
+            // Check agent_id or metadata for goal reference.
+            e.agent_id.contains(goal_id)
+                || e.target_uri
+                    .as_deref()
+                    .map(|u| u.contains(goal_id))
+                    .unwrap_or(false)
+                || {
+                    // Check metadata for goal_id reference.
+                    let meta = e.metadata.to_string();
+                    meta.contains(goal_id)
+                }
+        })
+        .cloned()
+        .collect()
+}
+
+/// Display the decision trail for a goal with reasoning (v0.3.3).
+fn show_decision_trail(
+    config: &GatewayConfig,
+    goal_id: &str,
+    log_path: Option<&str>,
+) -> anyhow::Result<()> {
+    let path = log_path
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| config.audit_log.clone());
+
+    if !path.exists() {
+        println!("No audit log found at {}", path.display());
+        return Ok(());
+    }
+
+    let all_events = AuditLog::read_all(&path)?;
+    let events = events_for_goal(&all_events, goal_id);
+
+    if events.is_empty() {
+        // Show all events if no goal-specific filter matches — the goal_id
+        // might be a prefix or might match the draft package instead.
+        println!("No events found for goal {}.", goal_id);
+        println!();
+        println!(
+            "Showing all {} events with decision reasoning:",
+            all_events.len()
+        );
+
+        let reasoned: Vec<_> = all_events
+            .iter()
+            .filter(|e| e.reasoning.is_some())
+            .collect();
+        if reasoned.is_empty() {
+            println!("  No events have decision reasoning attached.");
+            println!("  Reasoning is captured during policy evaluation (v0.3.3).");
+        } else {
+            print_events_with_reasoning(&reasoned);
+        }
+        return Ok(());
+    }
+
+    println!("Decision trail for goal {}", goal_id);
+    println!("{}", "=".repeat(60));
+    println!("{} event(s) found", events.len());
+    println!();
+
+    let event_refs: Vec<&AuditEvent> = events.iter().collect();
+    print_events_with_reasoning(&event_refs);
+
+    // Count events with reasoning.
+    let reasoning_count = events.iter().filter(|e| e.reasoning.is_some()).count();
+    println!();
+    println!(
+        "Summary: {} total events, {} with decision reasoning",
+        events.len(),
+        reasoning_count
+    );
+
+    Ok(())
+}
+
+/// Print events with their reasoning details.
+fn print_events_with_reasoning(events: &[&AuditEvent]) {
+    for event in events {
+        println!(
+            "[{}] {:?} by {}",
+            event.timestamp.format("%Y-%m-%d %H:%M:%S"),
+            event.action,
+            event.agent_id,
+        );
+        if let Some(target) = &event.target_uri {
+            println!("  Target: {}", target);
+        }
+        if let Some(reasoning) = &event.reasoning {
+            println!("  Rationale: {}", reasoning.rationale);
+            if !reasoning.applied_principles.is_empty() {
+                println!("  Principles: {}", reasoning.applied_principles.join(", "));
+            }
+            for (i, alt) in reasoning.alternatives.iter().enumerate() {
+                println!(
+                    "  Alternative {}: {} (rejected: {}{})",
+                    i + 1,
+                    alt.description,
+                    alt.rejected_reason,
+                    alt.score
+                        .map(|s| format!(", score: {:.2}", s))
+                        .unwrap_or_default(),
+                );
+            }
+        }
+        println!();
+    }
+}
+
+/// Export audit data for compliance reporting (v0.3.3).
+fn export_audit(
+    config: &GatewayConfig,
+    goal_id: &str,
+    _format: &ExportFormat,
+    log_path: Option<&str>,
+) -> anyhow::Result<()> {
+    let path = log_path
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| config.audit_log.clone());
+
+    if !path.exists() {
+        anyhow::bail!("No audit log found at {}", path.display());
+    }
+
+    let all_events = AuditLog::read_all(&path)?;
+    let events = events_for_goal(&all_events, goal_id);
+
+    // Build structured export.
+    let export = serde_json::json!({
+        "export_version": "1.0.0",
+        "goal_id": goal_id,
+        "exported_at": chrono::Utc::now().to_rfc3339(),
+        "total_events": events.len(),
+        "events_with_reasoning": events.iter().filter(|e| e.reasoning.is_some()).count(),
+        "standards_alignment": {
+            "iso_42001": "Decision processes documented with rationale (A.6.2.3)",
+            "ieee_7001": "Autonomous system decisions explainable to stakeholders",
+            "nist_ai_rmf": "MAP 1.1 (purpose documentation), GOVERN 1.3 (decision documentation)"
+        },
+        "events": events,
+    });
+
+    println!("{}", serde_json::to_string_pretty(&export)?);
 
     Ok(())
 }

--- a/crates/ta-audit/src/lib.rs
+++ b/crates/ta-audit/src/lib.rs
@@ -28,5 +28,5 @@ pub mod log;
 // Re-export the main types at the crate root for convenience.
 // Users can write `use ta_audit::AuditLog` instead of `use ta_audit::log::AuditLog`.
 pub use error::AuditError;
-pub use event::{AuditAction, AuditEvent};
+pub use event::{Alternative, AuditAction, AuditEvent, DecisionReasoning};
 pub use log::AuditLog;

--- a/crates/ta-changeset/src/lib.rs
+++ b/crates/ta-changeset/src/lib.rs
@@ -32,8 +32,8 @@ pub use explanation::ExplanationSidecar;
 pub use interactive_session_store::InteractiveSessionStore;
 pub use output_adapters::{DetailLevel, OutputAdapter, OutputFormat, RenderContext};
 pub use review_session::{
-    ArtifactReview, Comment, CommentThread, DispositionCounts, ReviewSession, ReviewState,
-    SessionNote,
+    ArtifactReview, Comment, CommentThread, DispositionCounts, ReviewReasoning, ReviewSession,
+    ReviewState, SessionNote,
 };
 pub use review_session_store::ReviewSessionStore;
 pub use session_channel::{

--- a/crates/ta-policy/src/lib.rs
+++ b/crates/ta-policy/src/lib.rs
@@ -19,5 +19,5 @@ pub mod engine;
 pub mod error;
 
 pub use capability::{CapabilityGrant, CapabilityManifest};
-pub use engine::{PolicyDecision, PolicyEngine, PolicyRequest};
+pub use engine::{EvaluationStep, EvaluationTrace, PolicyDecision, PolicyEngine, PolicyRequest};
 pub use error::PolicyError;

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -799,12 +799,27 @@ ta pr apply <frontend-pr-id>
 ### Audit Trail
 
 ```bash
-# View audit log
-ta audit list
+# Verify audit log integrity (hash chain)
+ta audit verify
 
-# Export for compliance
-ta audit export audit.jsonl
+# Show recent audit events
+ta audit tail -n 20
+
+# Display decision trail for a goal with reasoning (v0.3.3)
+ta audit show <goal-id>
+
+# Export structured audit data for compliance reporting (v0.3.3)
+ta audit export <goal-id> --format json
 ```
+
+#### Decision Observability (v0.3.3)
+
+Every decision in the TA pipeline is now observable — not just *what happened*, but *what was considered and why*:
+
+- **Policy decisions** capture which grants were checked, which matched, and why Allow/Deny/RequireApproval was chosen
+- **Agent decisions** can include `alternatives_considered` in `change_summary.json` to document rejected approaches
+- **Review decisions** support structured `reasoning` with rationale, alternatives, and applied principles
+- **Compliance export** includes ISO 42001, IEEE 7001, and NIST AI RMF alignment metadata
 
 ---
 


### PR DESCRIPTION
## Summary
- Every decision in the TA pipeline is now observable with structured reasoning
- New types: `DecisionReasoning`, `Alternative`, `EvaluationTrace`, `AlternativeConsidered`, `ReviewReasoning`
- `ta audit show/export` commands for decision trail inspection and compliance reporting
- Agent `change_summary.json` gains `alternatives_considered` for documenting rejected approaches
- 17 new tests (367 total), all backward-compatible
- Cleanup: eliminated duplicate `AgentAlternative` struct, reuses `AlternativeConsidered` directly

## Test plan
- [x] 367 tests passing
- [x] Clippy clean, fmt clean
- [ ] Verify `ta audit show` renders decision trail
- [ ] Verify backward compat with old draft packages

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)