### PR TITLE
Implement v0.3.4 — Draft Amendment & Targeted Re-Work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.3.3-alpha"
+version = "0.3.4-alpha"
 dependencies = [
  "anyhow",
  "chrono",

--- a/PLAN.md
+++ b/PLAN.md
@@ -727,6 +727,26 @@ ta draft fix <draft-id> <artifact-uri> --guidance "Consolidate duplicate struct"
   3. **Full re-work**: `ta run --follow-up` (complete re-run with discussion context)
 - Document when to use each: amend for typos/renames, fix for logic changes, follow-up for architectural rework
 
+#### Completed ✅
+- `ta draft amend <id> <uri> --file <path>`: Replace artifact content with corrected file, recompute diff, record `AmendmentRecord` with `amended_by` + timestamp
+- `ta draft amend <id> <uri> --drop`: Remove artifact from draft, record in decision log
+- `AmendmentRecord` type added to `Artifact` struct (audit trail: who, when, how, why)
+- `AmendmentType` enum: `FileReplaced`, `PatchApplied`, `Dropped`
+- URI normalization: shorthand paths (e.g., `src/main.rs`) auto-expand to `fs://workspace/src/main.rs`
+- Disposition reset to `Pending` after amendment (content changed, needs re-review)
+- Decision log entries auto-added for all amendments
+- Corrected files written back to staging workspace for consistency
+- `ta draft fix <id> --guidance "<text>"`: Scoped follow-up goal targeting discuss/amended artifacts
+- `ta draft fix <id> <uri> --guidance "<text>"`: Target a specific artifact
+- Builds on existing `--follow-up` mechanism with focused context injection
+- New draft supersedes the original via `DraftStatus::Superseded`
+- USAGE.md "Correcting a Draft" section updated (removed "planned" markers)
+- 10 new tests: 4 for `AmendmentRecord` serialization, 6 for `amend_package` integration (drop, file replace, state validation, error cases, diff computation)
+
+#### Remaining
+- `--patch fix.patch` mode for `ta draft amend` (deferred — `--file` covers the common case)
+- Minimal staging workspace for `ta draft fix` (currently uses full overlay like `--follow-up`)
+
 #### Existing Infrastructure This Builds On
 - `ReviewSession` comment threads (v0.3.0) — comments + discuss items already tracked
 - `GoalRun.parent_goal_id` + `PRStatus::Superseded` — follow-up chain already works

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-cli"
-version = "0.3.3-alpha"
+version = "0.3.4-alpha"
 edition = "2021"
 description = "CLI for goals, PR review, and approvals in Trusted Autonomy"
 license = "Apache-2.0"

--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -1282,6 +1282,7 @@ pre_launch:
                 related_artifacts: vec![],
             }),
             comments: Some(comment_thread),
+            amendment: None,
         };
 
         let parent_draft = DraftPackage {
@@ -1429,6 +1430,7 @@ pre_launch:
             dependencies: vec![],
             explanation_tiers: None,
             comments: None, // No comments yet
+            amendment: None,
         };
 
         let parent_draft = DraftPackage {

--- a/crates/ta-changeset/src/output_adapters/html.rs
+++ b/crates/ta-changeset/src/output_adapters/html.rs
@@ -273,6 +273,7 @@ mod tests {
                     rationale: Some("test rationale".to_string()),
                     explanation_tiers: None,
                     comments: None,
+                    amendment: None,
                     tests_run: vec![],
                     dependencies: vec![],
                 }],

--- a/crates/ta-changeset/src/output_adapters/terminal.rs
+++ b/crates/ta-changeset/src/output_adapters/terminal.rs
@@ -388,6 +388,7 @@ mod tests {
                         related_artifacts: vec![],
                     }),
                     comments: None,
+                    amendment: None,
                 }],
                 patch_sets: vec![],
             },

--- a/crates/ta-changeset/src/supervisor.rs
+++ b/crates/ta-changeset/src/supervisor.rs
@@ -435,6 +435,7 @@ mod tests {
                 .collect(),
             explanation_tiers: None,
             comments: None,
+            amendment: None,
         }
     }
 

--- a/crates/ta-connectors/fs/src/connector.rs
+++ b/crates/ta-connectors/fs/src/connector.rs
@@ -227,6 +227,7 @@ impl<S: ChangeStore> FsConnector<S> {
                     dependencies: vec![],
                     explanation_tiers: None,
                     comments: None,
+                    amendment: None,
                 }
             })
             .collect();

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -377,24 +377,44 @@ ta draft review finish
 ta run "Rework auth to use JWT per review feedback" --source . --follow-up <draft-id>
 ```
 
-#### 2. Scoped agent fix (planned — v0.3.4)
+#### 2. Scoped agent fix (v0.3.4)
 Use when the issue is clear but needs agent help to implement:
 ```bash
 # Agent targets only the discussed artifacts, not the full source tree
 ta draft fix <draft-id> --guidance "Remove AgentAlternative, reuse AlternativeConsidered directly"
-```
 
-#### 3. Direct amendment (planned — v0.3.4)
+# Target a specific artifact
+ta draft fix <draft-id> "fs://workspace/src/draft.rs" --guidance "Consolidate duplicate struct"
+
+# Set up workspace without launching agent (manual mode)
+ta draft fix <draft-id> --guidance "Fix the issue" --no-launch
+```
+- Creates a scoped follow-up goal with your guidance injected into the agent context
+- Agent sees the discuss items, comment threads, and your guidance — nothing else
+- New draft supersedes the original — review and apply as normal
+
+#### 3. Direct amendment (v0.3.4)
 Use for typos, renames, and small fixes you can make yourself:
 ```bash
-# Replace an artifact's content
+# Replace an artifact's content with a corrected file
 ta draft amend <draft-id> "fs://workspace/src/draft.rs" --file corrected_draft.rs
+
+# Shorthand: paths without fs://workspace/ prefix also work
+ta draft amend <draft-id> src/draft.rs --file corrected_draft.rs
 
 # Drop an artifact from the draft entirely
 ta draft amend <draft-id> "fs://workspace/config.toml" --drop
-```
 
-> **Today**: Use option 1 (full re-work via follow-up). Options 2 and 3 are planned for v0.3.4.
+# Include a reason for the audit trail
+ta draft amend <draft-id> src/main.rs --file fixed_main.rs --reason "Fixed typo in function name"
+```
+- Amends the draft in-place (no new goal or agent run needed)
+- Records who amended it, when, and why in the artifact's `amendment` field
+- Disposition resets to `pending` (content changed, needs re-review)
+- Decision log entry auto-added for every amendment
+- Corrected file is written back to the staging workspace for consistency
+
+> **When to use each**: `amend` for typos, renames, and small fixes you can make yourself. `fix` for logic changes that need agent help. Full re-work for architectural rework.
 
 ---
 


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.3.4 — Draft Amendment & Targeted Re-Work

**Why**: Implement v0.3.4 — Draft Amendment & Targeted Re-Work

**Impact**: 11 file(s) changed

## Changes (11 file(s))

- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/PLAN.md` — Added Completed section to v0.3.4 phase with all implemented items and Remaining section for deferred work
  - Plan lifecycle: mark completed work items as done so progress is visible
- `~` `fs://workspace/apps/ta-cli/Cargo.toml` — Bumped version from 0.3.3-alpha to 0.3.4-alpha
  - Version management: each plan phase gets its own version per PLAN.md versioning policy
- `~` `fs://workspace/apps/ta-cli/src/commands/draft.rs` — Added Amend and Fix subcommands to DraftCommands enum; implemented amend_package() for --file and --drop modes, fix_package() for scoped agent re-work, compute_unified_diff() helper, and 6 integration tests
  - Core v0.3.4 feature: users need to correct draft issues inline (amend) or with targeted agent help (fix) without a full re-run cycle
- `~` `fs://workspace/apps/ta-cli/src/commands/run.rs` — Added amendment: None field to Artifact constructions in test helpers
  - Artifact struct gained a new optional field; all construction sites need the field for compilation
- `~` `fs://workspace/crates/ta-changeset/src/draft_package.rs` — Added AmendmentRecord and AmendmentType types to Artifact struct for tracking amendments, plus 4 serialization tests
  - Artifacts need audit trail metadata when humans amend them (who, when, how, why) to maintain provenance and reviewability
- `~` `fs://workspace/crates/ta-changeset/src/output_adapters/html.rs` — Added amendment: None to Artifact construction in test helper
  - Artifact struct gained a new optional field
- `~` `fs://workspace/crates/ta-changeset/src/output_adapters/terminal.rs` — Added amendment: None to Artifact construction in test helper
  - Artifact struct gained a new optional field
- `~` `fs://workspace/crates/ta-changeset/src/supervisor.rs` — Added amendment: None to test helper make_artifact() function
  - Artifact struct gained a new optional field
- `~` `fs://workspace/crates/ta-connectors/fs/src/connector.rs` — Added amendment: None to Artifact construction in FsConnector
  - Artifact struct gained a new optional field
- `~` `fs://workspace/docs/USAGE.md` — Updated 'Correcting a Draft' section: removed '(planned — v0.3.4)' markers, added full documentation for ta draft amend and ta draft fix with examples and usage guidance
  - Features are now implemented and need consumer-facing documentation

## Goal Context

- **Title**: Implement v0.3.4 — Draft Amendment & Targeted Re-Work
- **Objective**: Implement v0.3.4 — Draft Amendment & Targeted Re-Work
- **Goal ID**: `7a444a4d-d086-41de-8329-f7bcc33579e3`
- **PR ID**: `a57f668a-97dc-4228-9fb0-409b4f0635cd`
- **Plan Phase**: `0.3.4`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
