### PR TITLE
release: Generate release notes

### DIFF
--- a/.release-draft.md
+++ b/.release-draft.md
@@ -1,28 +1,23 @@
-## v0.3.2-alpha
+## v0.3.4-alpha
 
 ### New Features
 
-- **Configurable release pipeline (`ta release`)**: A new `ta release` command driven by YAML task scripts (`.ta/release.yaml`). Define pipeline steps as TA goals (agent-driven) or shell commands, with optional approval gates. Ships with a built-in default pipeline for version bump, verify, release notes, and tagging — override with your own `.ta/release.yaml`.
-- **Interactive session orchestration (`ta run --interactive`)**: A `SessionChannel` protocol enables humans to observe agent output, inject guidance mid-session, and review drafts inline — all through a unified interaction layer designed to extend to Discord, Slack, and web frontends in future releases.
-- **Configurable plan format parsing**: Plans are no longer locked to TA's own PLAN.md format. A new `.ta/plan-schema.yaml` lets any project describe its plan structure with regex patterns. `ta plan init` auto-detects an existing plan's format; `ta plan create` generates new plans from templates (greenfield, feature, bugfix).
-- **Plan lifecycle automation**: Completing a phase now auto-suggests the next pending phase. New CLI commands: `ta plan next`, `ta plan validate <phase>`, `ta plan history`. Status transitions are recorded to `.ta/plan_history.jsonl` for auditability.
-- **Review sessions with discussion workflow**: Full per-artifact review sessions via `ta draft review start/comment/next/finish/list/show`. Supervisor agent validates dependency graphs with cycle detection, coupled rejection warnings, and broken dependency warnings. Discussion threads from review sessions are injected into follow-up goal context so agents can address reviewer concerns.
-- **Terminology shift from PR to draft**: All user-facing commands now use `ta draft` terminology (`ta draft build`, `ta draft view`, `ta draft apply`, etc.). The old `ta pr` commands remain as hidden aliases for backward compatibility.
+- **Draft Amendment (`ta draft amend`)** — Correct individual artifacts in a draft without re-running the entire goal. Use `--file` to replace an artifact's content from disk, or `--drop` to remove an artifact entirely. Every amendment is recorded with a full audit trail (who, when, how, why).
+- **Targeted Re-Work (`ta draft fix`)** — Re-run an agent scoped to specific files in an existing draft. The agent sees only the selected artifacts, makes corrections, and the updated content is patched back into the draft with a unified diff.
+- **Decision Observability (`ta audit show`, `ta audit export`)** — Every TA pipeline decision now captures what was considered and why. New `DecisionReasoning`, `EvaluationTrace`, and `ReviewReasoning` types provide structured rationale across policy evaluation, agent alternatives, and human review.
+- **Policy Evaluation Traces** — `PolicyEngine::evaluate_with_trace()` records the full grant evaluation chain so you can inspect exactly which rules fired and why.
 
 ### Improvements
 
-- **Consolidated `draft.rs`**: The duplicated `pr.rs` (~2,200 lines) was reduced to a ~160-line shim delegating to `draft.rs`, eliminating ~2,050 lines of duplication.
-- **Richer commit messages**: `ta draft apply` now includes the complete draft summary with per-artifact descriptions in the git commit message.
-- **Per-target summary enforcement**: `ta draft build` warns or errors (configurable via `.ta/workflow.toml`) when artifacts lack a `what` description. Lockfiles and config files are auto-exempt.
-- **Disposition badges in HTML output**: HTML adapter renders color-coded per-artifact disposition badges (pending, approved, rejected, discuss).
-- **Configurable ANSI color output**: Terminal output respects color configuration for better compatibility with different environments.
-- **Updated user experience documentation**: Revised `docs/user-experience.md` with honest TA vs. baseline comparisons.
-- **Restructured long-term roadmap**: PLAN.md v0.5–v1.0 phases reorganized for clarity, with new standards compliance mapping and decision observability roadmap.
+- `change_summary.json` now supports `alternatives_considered` per entry, letting agents document rejected approaches alongside chosen ones.
+- `ta draft build` automatically extracts decision logs from agent-reported alternatives.
+- `ReviewReasoning` on review comments gives human reviewers a structured way to explain accept/reject rationale.
+- Added WSL2 installation guidance for Windows users in documentation.
+- Added plan phases for v0.3.5 (Draft Lifecycle Hygiene) and v0.4.4 (Interactive Session Completion).
 
 ### Bug Fixes
 
-- **Fixed `strip_html` eating code placeholders**: The HTML stripping function was incorrectly consuming content that looked like HTML tags in code blocks. Fixed to only strip actual HTML tags.
-- **Fixed garbled terminal output**: `ta draft view` was rendering `ÆpendingÅ` instead of `[pending]` due to HTML `<span>` tags leaking into terminal output. Added `strip_html()` helper in `TerminalAdapter`.
-- **Fixed stale plan markers**: Corrected plan phase status markers that were not updating properly, and fixed the next-phase suggestion logic.
-- **Fixed `ta draft apply` commit summary**: Commit messages now match the summary shown by `ta draft view`, with mid-level detail included.
-- **Fixed partial workflow config parsing**: Added `#[serde(default)]` to `WorkflowConfig.submit` so `.ta/workflow.toml` files work without requiring a `[submit]` section.
+- Fixed `ta draft apply` not including PLAN.md status updates in the git commit.
+- Fixed `cargo fmt` failure on post-apply summary output.
+- Suppressed spurious Nix dirty-tree warnings during builds.
+- Fixed release pipeline to auto-approve and apply agent drafts before proceeding to the next step.


### PR DESCRIPTION
## Summary

Changes from goal: release: Generate release notes

**Why**: Synthesize user-facing release notes for version v0.3.4-alpha.
Commits since v0.3.2-alpha:
Bump workspace crate versions to 0.3.4-alpha for release
Fix cargo fmt on post-apply summary + suppress Nix dirty-tree warning
Fix PLAN.md status not included in git commit during ta draft apply
Implement v0.3.4 — Draft Amendment & Targeted Re-Work (#44)
Add v0.3.5 — Draft Lifecycle Hygiene & Stale State Cleanup plan phase
Add v0.3.4 Draft Amendment + v0.4.4 Interactive Session plan phases, document correction workflow (#42)
Implement v0.3.3 — Decision Observability & Reasoning Capture (#41)
Add WSL2 install guidance for Windows users + plan native Windows support at v0.9.1
release: Generate release notes
Fix release pipeline: auto-approve+apply agent drafts before next step

Write the notes to .release-draft.md in this format:
## v0.3.4-alpha
### New Features
- ...
### Improvements
- ...
### Bug Fixes
- ...


**Impact**: 1 file(s) changed

## Changes (1 file(s))

- `~` `fs://workspace/.release-draft.md` — Replaced v0.3.2-alpha release notes with v0.3.4-alpha notes covering new features (draft amend, draft fix, decision observability, evaluation traces), improvements, and bug fixes
  - Release pipeline requires up-to-date release notes for the current version being shipped

## Goal Context

- **Title**: release: Generate release notes
- **Objective**: Synthesize user-facing release notes for version v0.3.4-alpha.
Commits since v0.3.2-alpha:
Bump workspace crate versions to 0.3.4-alpha for release
Fix cargo fmt on post-apply summary + suppress Nix dirty-tree warning
Fix PLAN.md status not included in git commit during ta draft apply
Implement v0.3.4 — Draft Amendment & Targeted Re-Work (#44)
Add v0.3.5 — Draft Lifecycle Hygiene & Stale State Cleanup plan phase
Add v0.3.4 Draft Amendment + v0.4.4 Interactive Session plan phases, document correction workflow (#42)
Implement v0.3.3 — Decision Observability & Reasoning Capture (#41)
Add WSL2 install guidance for Windows users + plan native Windows support at v0.9.1
release: Generate release notes
Fix release pipeline: auto-approve+apply agent drafts before next step

Write the notes to .release-draft.md in this format:
## v0.3.4-alpha
### New Features
- ...
### Improvements
- ...
### Bug Fixes
- ...

- **Goal ID**: `a16863d2-4795-4248-86d4-fb7b05b21113`
- **PR ID**: `471292ed-547d-4364-802c-0510f16e4f1d`
- **Plan Phase**: `N/A`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
