### PR TITLE
Implement v0.3.6 — Draft Lifecycle Hygiene

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.3.5-alpha"
+version = "0.3.6-alpha"
 dependencies = [
  "anyhow",
  "chrono",

--- a/PLAN.md
+++ b/PLAN.md
@@ -770,14 +770,14 @@ ta draft fix <draft-id> <artifact-uri> --guidance "Consolidate duplicate struct"
 <!-- status: pending -->
 **Goal**: Automated and manual cleanup of stale draft state so TA stays consistent without manual intervention.
 
-- **`ta draft close <id> [--reason <text>]`**: Manually mark a draft as closed/superseded without applying it. For drafts that were hand-merged, abandoned, or made obsolete by later work. Records reason + timestamp in audit log.
-- **`ta draft gc`**: Garbage-collect stale drafts and staging directories.
+- ✅ **`ta draft close <id> [--reason <text>]`**: Manually mark a draft as closed/superseded without applying it. For drafts that were hand-merged, abandoned, or made obsolete by later work. Records reason + timestamp in audit log.
+- ✅ **`ta draft gc`**: Garbage-collect stale drafts and staging directories.
   - Remove staging dirs for drafts in terminal states (Applied, Denied, closed) older than N days (default 7, configurable in `.ta/workflow.toml`)
   - List what would be removed with `--dry-run`
   - Optionally archive to `.ta/archive/` instead of deleting (`--archive`)
-- **`ta draft list --stale`**: Show drafts that are in non-terminal states (Approved, PendingReview) but whose staging dirs are older than a threshold — likely forgotten or hand-applied.
-- **Auto-close on follow-up**: When `ta run --follow-up <id>` completes and its draft is applied, auto-close the parent draft if still in Approved/PendingReview state.
-- **Startup health check**: On any `ta` invocation, emit a one-line warning if stale drafts exist (e.g. "1 draft approved but not applied for 3+ days — run `ta draft list --stale`"). Suppressible via config.
+- ✅ **`ta draft list --stale`**: Show drafts that are in non-terminal states (Approved, PendingReview) but whose staging dirs are older than a threshold — likely forgotten or hand-applied.
+- ✅ **Auto-close on follow-up**: When `ta run --follow-up <id>` completes and its draft is applied, auto-close the parent draft if still in Approved/PendingReview state.
+- ✅ **Startup health check**: On any `ta` invocation, emit a one-line warning if stale drafts exist (e.g. "1 draft approved but not applied for 3+ days — run `ta draft list --stale`"). Suppressible via config.
 
 ---
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-cli"
-version = "0.3.5-alpha"
+version = "0.3.6-alpha"
 edition = "2021"
 description = "CLI for goals, PR review, and approvals in Trusted Autonomy"
 license = "Apache-2.0"

--- a/apps/ta-cli/src/commands/pr.rs
+++ b/apps/ta-cli/src/commands/pr.rs
@@ -119,7 +119,10 @@ fn to_draft_command(cmd: &PrCommands) -> draft::DraftCommands {
             summary: summary.clone(),
             latest: *latest,
         },
-        PrCommands::List { goal } => draft::DraftCommands::List { goal: goal.clone() },
+        PrCommands::List { goal } => draft::DraftCommands::List {
+            goal: goal.clone(),
+            stale: false,
+        },
         PrCommands::View {
             id,
             summary,

--- a/apps/ta-cli/src/main.rs
+++ b/apps/ta-cli/src/main.rs
@@ -165,6 +165,9 @@ fn main() -> anyhow::Result<()> {
     let project_root = cli.project_root.canonicalize().unwrap_or(cli.project_root);
     let config = GatewayConfig::for_project(&project_root);
 
+    // Startup health check: warn about stale drafts (v0.3.6).
+    commands::draft::check_stale_drafts(&config);
+
     match &cli.command {
         Commands::Goal { command } => commands::goal::execute(command, &config),
         Commands::Draft { command } => commands::draft::execute(command, &config),

--- a/crates/ta-changeset/src/output_adapters/terminal.rs
+++ b/crates/ta-changeset/src/output_adapters/terminal.rs
@@ -102,6 +102,7 @@ impl TerminalAdapter {
                 crate::pr_package::PRStatus::Denied { .. } => "\x1b[31m",
                 crate::pr_package::PRStatus::Applied { .. } => "\x1b[32m",
                 crate::pr_package::PRStatus::Superseded { .. } => "\x1b[90m",
+                crate::pr_package::PRStatus::Closed { .. } => "\x1b[90m",
             }
         } else {
             ""

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -418,6 +418,60 @@ ta draft amend <draft-id> src/main.rs --file fixed_main.rs --reason "Fixed typo 
 
 ---
 
+## Draft Lifecycle Hygiene
+
+**New in v0.3.6** — Tools for cleaning up stale draft state.
+
+### Closing a Draft
+
+Close a draft without applying it (e.g., hand-merged, abandoned, or obsolete):
+
+```bash
+ta draft close <draft-id>
+ta draft close <draft-id> --reason "Hand-merged upstream"
+```
+
+### Finding Stale Drafts
+
+List drafts that are in reviewable states (Draft, PendingReview, Approved) but older than the configured threshold:
+
+```bash
+ta draft list --stale
+```
+
+### Garbage Collection
+
+Remove staging directories for drafts in terminal states (Applied, Denied, Closed) older than N days (default 7):
+
+```bash
+# Preview what would be removed
+ta draft gc --dry-run
+
+# Remove stale staging directories
+ta draft gc
+
+# Archive instead of deleting
+ta draft gc --archive
+```
+
+Configure thresholds in `.ta/workflow.toml`:
+
+```toml
+[gc]
+stale_threshold_days = 7   # Days before staging dirs become eligible for cleanup
+health_check = true        # Show warning on startup if stale drafts exist
+```
+
+### Auto-Close on Follow-Up
+
+When a follow-up goal's draft is applied, TA automatically closes the parent draft if it's still in PendingReview or Approved state.
+
+### Startup Health Check
+
+On every `ta` invocation, a one-line hint is printed to stderr if any drafts have been approved or pending for 3+ days without being applied. Suppress via `[gc] health_check = false`.
+
+---
+
 ## Interactive Sessions
 
 **New in v0.3.1.2** — Interactive session orchestration for human-agent collaboration.

--- a/examples/workflow.toml
+++ b/examples/workflow.toml
@@ -31,3 +31,16 @@ open_external = true
 
 # Optional: Override default path to diff-handlers.toml
 # handlers_file = ".ta/diff-handlers.toml"
+
+# ────────────────────────────────────────────────────────────────────
+# Draft Lifecycle / Garbage Collection Configuration (v0.3.6)
+# ────────────────────────────────────────────────────────────────────
+
+[gc]
+# Days after which terminal-state drafts' staging dirs are eligible for cleanup.
+# Affects `ta draft gc`. Default: 7.
+stale_threshold_days = 7
+
+# Show a one-line warning on `ta` startup if stale drafts exist
+# (approved but not applied for 3+ days). Default: true.
+health_check = true


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.3.6 — Draft Lifecycle Hygiene

**Why**: Implement v0.3.6 — Draft Lifecycle Hygiene

**Impact**: 11 file(s) changed

## Changes (11 file(s))

- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/PLAN.md` — Marked all five v0.3.6 items with checkmarks
  - Plan tracking: reflect completed work
- `~` `fs://workspace/apps/ta-cli/Cargo.toml` — Bumped version from 0.3.5-alpha to 0.3.6-alpha
  - Version management per CLAUDE.md: completing a phase requires version bump
- `~` `fs://workspace/apps/ta-cli/src/commands/draft.rs` — Added `Close` and `Gc` subcommands to `DraftCommands`, added `--stale` flag to `List`, implemented `close_package()` (with audit event), `gc_packages()` (with --dry-run and --archive), stale filtering in `list_packages()`, `check_stale_drafts()` startup health check, and auto-close parent draft logic in `apply_package()`
  - Core implementation of all five v0.3.6 features: manual close, garbage collection, stale listing, auto-close on follow-up, and startup warning
- `~` `fs://workspace/apps/ta-cli/src/commands/pr.rs` — Updated deprecated PR shim to pass `stale: false` to new `DraftCommands::List` field
  - Struct field added to List variant requires update in all construction sites
- `~` `fs://workspace/apps/ta-cli/src/main.rs` — Added `check_stale_drafts()` call before command dispatch
  - Startup health check needs to run on every `ta` invocation to warn about stale drafts
- `~` `fs://workspace/crates/ta-changeset/src/draft_package.rs` — Added `Closed { closed_at, reason, closed_by }` variant to `DraftStatus` enum with Display impl and serialization tests
  - Draft close requires a new terminal state to distinguish manually-closed drafts from superseded or denied ones
- `~` `fs://workspace/crates/ta-changeset/src/output_adapters/terminal.rs` — Added color mapping for `DraftStatus::Closed` (dim/gray, same as Superseded)
  - Exhaustive match required after adding new DraftStatus variant
- `~` `fs://workspace/crates/ta-submit/src/config.rs` — Added `GcConfig` struct with `stale_threshold_days` (default 7) and `health_check` (default true) fields, wired into `WorkflowConfig` as `[gc]` section, with tests
  - GC and health check behavior need to be configurable via .ta/workflow.toml
- `~` `fs://workspace/docs/USAGE.md` — Added Draft Lifecycle Hygiene section documenting `ta draft close`, `ta draft gc`, `ta draft list --stale`, auto-close, and health check
  - User-facing behavior changes require USAGE.md documentation
- `~` `fs://workspace/examples/workflow.toml` — Added [gc] section documenting stale_threshold_days and health_check options
  - Example config should document all available configuration sections

## Goal Context

- **Title**: Implement v0.3.6 — Draft Lifecycle Hygiene
- **Objective**: Implement v0.3.6 — Draft Lifecycle Hygiene
- **Goal ID**: `b531ed9e-efdb-4321-8b56-e569d3574340`
- **PR ID**: `5490bdd6-30bb-46d7-b6cf-900aa184128a`
- **Plan Phase**: `0.3.6`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
