### PR TITLE
Implement v0.4.0 — Intent-to-Access Planner & Agent Alignment Profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "chrono",
  "rmcp",
@@ -1161,12 +1161,14 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "chrono",
  "glob",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "tempfile",
  "thiserror",
  "tracing",
  "uuid",
@@ -1174,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "serde",
  "thiserror",
@@ -1183,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -1199,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "chrono",
  "serde",

--- a/agents/claude-code.yaml
+++ b/agents/claude-code.yaml
@@ -13,3 +13,34 @@ injects_context_file: true
 injects_settings: true
 pre_launch: null
 env: {}
+
+# Agent alignment profile (v0.4.0).
+# Compiled into CapabilityManifest grants by the Policy Compiler.
+# These are enforced constraints, not self-declared promises.
+alignment:
+  principal: "project-owner"
+  autonomy_envelope:
+    bounded_actions:
+      - "fs_read"
+      - "fs_write_patch"
+      - "fs_apply"
+      - "exec: cargo test"
+      - "exec: cargo build"
+      - "exec: cargo clippy"
+      - "exec: cargo fmt"
+    escalation_triggers:
+      - "new_dependency"
+      - "security_sensitive"
+      - "breaking_change"
+    forbidden_actions:
+      - "network_external"
+      - "credential_access"
+  constitution: "default-v1"
+  coordination:
+    allowed_collaborators:
+      - "codex"
+      - "claude-flow"
+    shared_resources:
+      - "src/**"
+      - "tests/**"
+      - "crates/**"

--- a/agents/claude-flow.yaml
+++ b/agents/claude-flow.yaml
@@ -22,3 +22,28 @@ pre_launch:
     - "hive-mind"
     - "init"
 env: {}
+
+# Agent alignment profile (v0.4.0).
+alignment:
+  principal: "project-owner"
+  autonomy_envelope:
+    bounded_actions:
+      - "fs_read"
+      - "fs_write_patch"
+      - "fs_apply"
+    escalation_triggers:
+      - "new_dependency"
+      - "security_sensitive"
+      - "breaking_change"
+    forbidden_actions:
+      - "network_external"
+      - "credential_access"
+  constitution: "default-v1"
+  coordination:
+    allowed_collaborators:
+      - "claude-code"
+      - "codex"
+    shared_resources:
+      - "src/**"
+      - "tests/**"
+      - "crates/**"

--- a/agents/codex.yaml
+++ b/agents/codex.yaml
@@ -15,3 +15,27 @@ injects_context_file: false
 injects_settings: false
 pre_launch: null
 env: {}
+
+# Agent alignment profile (v0.4.0).
+alignment:
+  principal: "project-owner"
+  autonomy_envelope:
+    bounded_actions:
+      - "fs_read"
+      - "fs_write_patch"
+      - "fs_apply"
+    escalation_triggers:
+      - "new_dependency"
+      - "security_sensitive"
+      - "breaking_change"
+    forbidden_actions:
+      - "network_external"
+      - "credential_access"
+  constitution: "default-v1"
+  coordination:
+    allowed_collaborators:
+      - "claude-code"
+      - "claude-flow"
+    shared_resources:
+      - "src/**"
+      - "tests/**"

--- a/agents/generic.yaml
+++ b/agents/generic.yaml
@@ -45,3 +45,27 @@ env: {}
 # env:
 #   MY_AGENT_MODE: "autonomous"
 #   MY_AGENT_LOG_LEVEL: "info"
+
+# Agent alignment profile (v0.4.0).
+# Compiled into CapabilityManifest grants by the Policy Compiler.
+# These are enforced constraints, not self-declared promises.
+#
+# alignment:
+#   principal: "project-owner"           # Who this agent serves
+#   autonomy_envelope:
+#     bounded_actions:                   # Actions the agent CAN perform
+#       - "fs_read"
+#       - "fs_write"
+#       - "exec: cargo test"
+#     escalation_triggers:               # Conditions that require human approval
+#       - "new_dependency"
+#       - "security_sensitive"
+#     forbidden_actions:                 # Actions the agent MUST NEVER perform
+#       - "network_external"
+#       - "credential_access"
+#   constitution: "default-v1"           # Enforcement rules template
+#   coordination:                        # Multi-agent collaboration rules
+#     allowed_collaborators:
+#       - "claude-code"
+#     shared_resources:
+#       - "src/**"

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-cli"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 description = "CLI for goals, PR review, and approvals in Trusted Autonomy"
 license = "Apache-2.0"

--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -56,6 +56,12 @@ struct AgentLaunchConfig {
     #[serde(default)]
     #[allow(dead_code)]
     interactive: Option<ta_changeset::InteractiveConfig>,
+    /// Agent alignment profile (v0.4.0).
+    /// Compiled into CapabilityManifest grants by the Policy Compiler.
+    /// Read via YAML deserialization; will be used by gateway during goal start.
+    #[serde(default)]
+    #[allow(dead_code)]
+    alignment: Option<ta_policy::AlignmentProfile>,
 }
 
 /// Pre-launch command configuration (deserialized from YAML).
@@ -138,6 +144,7 @@ fn builtin_agent_config(agent_id: &str) -> AgentLaunchConfig {
             name: Some("claude-code".to_string()),
             description: Some("Anthropic's Claude Code CLI".to_string()),
             interactive: None,
+            alignment: Some(ta_policy::AlignmentProfile::default_developer()),
         },
         "codex" => AgentLaunchConfig {
             command: "codex".to_string(),
@@ -153,6 +160,7 @@ fn builtin_agent_config(agent_id: &str) -> AgentLaunchConfig {
             name: Some("codex".to_string()),
             description: Some("OpenAI's Codex CLI".to_string()),
             interactive: None,
+            alignment: Some(ta_policy::AlignmentProfile::default_developer()),
         },
         "claude-flow" => AgentLaunchConfig {
             command: "npx".to_string(),
@@ -177,6 +185,7 @@ fn builtin_agent_config(agent_id: &str) -> AgentLaunchConfig {
             name: Some("claude-flow".to_string()),
             description: Some("Claude Flow multi-agent orchestration".to_string()),
             interactive: None,
+            alignment: Some(ta_policy::AlignmentProfile::default_developer()),
         },
         _ => AgentLaunchConfig {
             command: agent_id.to_string(),
@@ -188,6 +197,7 @@ fn builtin_agent_config(agent_id: &str) -> AgentLaunchConfig {
             name: None,
             description: None,
             interactive: None,
+            alignment: None,
         },
     }
 }

--- a/crates/ta-audit/Cargo.toml
+++ b/crates/ta-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-audit"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 description = "Append-only event log and artifact hashing for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-changeset/Cargo.toml
+++ b/crates/ta-changeset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-changeset"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 description = "ChangeSet and PR Package data model for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-daemon"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 description = "MCP server daemon for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-goal/Cargo.toml
+++ b/crates/ta-goal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-goal"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 description = "GoalRun lifecycle management and event dispatch for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-mcp-gateway"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 description = "MCP gateway server with policy enforcement for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-policy/Cargo.toml
+++ b/crates/ta-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-policy"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 description = "Capability manifests and policy evaluation for Trusted Autonomy"
 license = "Apache-2.0"
@@ -10,8 +10,12 @@ homepage = "https://github.com/trustedautonomy/ta"
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 glob = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/ta-policy/src/alignment.rs
+++ b/crates/ta-policy/src/alignment.rs
@@ -1,0 +1,313 @@
+// alignment.rs — Agent Alignment Profile types (v0.4.0).
+//
+// Alignment profiles extend agent YAML configs with structured declarations
+// of an agent's capabilities, constraints, and coordination rules. Unlike
+// self-declared alignment cards (AAP), these are *enforced* — the Policy
+// Compiler translates them into CapabilityManifest grants.
+//
+// See PLAN.md v0.4.0 for the full specification.
+
+use serde::{Deserialize, Serialize};
+
+/// An agent's alignment profile — compiled into capability grants by the Policy Compiler.
+///
+/// This is the structured `alignment` block in an agent's YAML config:
+/// ```yaml
+/// alignment:
+///   principal: "project-owner"
+///   autonomy_envelope:
+///     bounded_actions: ["fs_read", "fs_write", "exec: cargo test"]
+///     escalation_triggers: ["new_dependency", "security_sensitive"]
+///     forbidden_actions: ["network_external", "credential_access"]
+///   constitution: "default-v1"
+///   coordination:
+///     allowed_collaborators: ["codex", "claude-flow"]
+///     shared_resources: ["src/**", "tests/**"]
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AlignmentProfile {
+    /// Who this agent serves (e.g., "project-owner", "security-team").
+    pub principal: String,
+
+    /// The agent's autonomy envelope — what it can, cannot, and must escalate.
+    pub autonomy_envelope: AutonomyEnvelope,
+
+    /// Reference to enforcement rules (e.g., "default-v1").
+    /// Used by the Policy Compiler to select a constitution template.
+    #[serde(default = "default_constitution")]
+    pub constitution: String,
+
+    /// Coordination rules for multi-agent scenarios (v0.4.1+).
+    #[serde(default)]
+    pub coordination: CoordinationConfig,
+}
+
+fn default_constitution() -> String {
+    "default-v1".to_string()
+}
+
+/// The autonomy envelope — defines the boundaries of what an agent can do.
+///
+/// `bounded_actions` are compiled into CapabilityGrant entries.
+/// `forbidden_actions` produce *no* grants (default-deny handles the rest).
+/// `escalation_triggers` are compiled into RequireApproval-class grants.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutonomyEnvelope {
+    /// Actions the agent is allowed to perform.
+    /// Format: `"<tool>_<verb>"` (e.g., "fs_read") or `"exec: <command>"`.
+    #[serde(default)]
+    pub bounded_actions: Vec<String>,
+
+    /// Conditions that force escalation to human approval.
+    /// These are semantic labels (e.g., "new_dependency", "security_sensitive").
+    #[serde(default)]
+    pub escalation_triggers: Vec<String>,
+
+    /// Actions the agent must never perform. Explicitly excluded from grants.
+    /// The Policy Compiler validates that no bounded_action overlaps with these.
+    #[serde(default)]
+    pub forbidden_actions: Vec<String>,
+}
+
+/// Coordination rules for multi-agent collaboration (v0.4.1+).
+///
+/// Used to determine which agents can co-operate on shared resources
+/// and which peers this agent is allowed to communicate with.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct CoordinationConfig {
+    /// Agent IDs that this agent is allowed to collaborate with.
+    #[serde(default)]
+    pub allowed_collaborators: Vec<String>,
+
+    /// Resource patterns (glob) that this agent shares with collaborators.
+    #[serde(default)]
+    pub shared_resources: Vec<String>,
+}
+
+/// An agent setup proposal — the output of the Intent-to-Policy Planner.
+///
+/// This is the structured plan for how to configure agents for a goal,
+/// submitted for human approval before activation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentSetupProposal {
+    /// Unique ID for this proposal.
+    pub proposal_id: String,
+
+    /// The goal this setup is for.
+    pub goal_title: String,
+    pub goal_objective: String,
+
+    /// Proposed agent configurations.
+    pub agents: Vec<ProposedAgent>,
+
+    /// Milestone plan for the goal execution.
+    #[serde(default)]
+    pub milestones: Vec<Milestone>,
+
+    /// Cost/efficiency notes from the planner.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub efficiency_notes: Option<String>,
+}
+
+/// A proposed agent within an AgentSetupProposal.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProposedAgent {
+    /// The agent ID (must match a known agent config).
+    pub agent_id: String,
+
+    /// Role description for this agent in this goal.
+    pub role: String,
+
+    /// The alignment profile to use (may override the default from agent YAML).
+    pub alignment: AlignmentProfile,
+
+    /// Estimated resource scope (what URIs this agent will access).
+    #[serde(default)]
+    pub resource_scope: Vec<String>,
+}
+
+/// A milestone in the goal execution plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Milestone {
+    /// Milestone description.
+    pub description: String,
+
+    /// Which agent is responsible.
+    pub agent_id: String,
+
+    /// Expected deliverables.
+    #[serde(default)]
+    pub deliverables: Vec<String>,
+}
+
+impl AlignmentProfile {
+    /// Create a default developer alignment profile.
+    ///
+    /// Grants fs read/write_patch/apply on workspace, denies network and credential access.
+    pub fn default_developer() -> Self {
+        Self {
+            principal: "project-owner".to_string(),
+            autonomy_envelope: AutonomyEnvelope {
+                bounded_actions: vec![
+                    "fs_read".to_string(),
+                    "fs_write_patch".to_string(),
+                    "fs_apply".to_string(),
+                ],
+                escalation_triggers: vec![
+                    "new_dependency".to_string(),
+                    "security_sensitive".to_string(),
+                    "breaking_change".to_string(),
+                ],
+                forbidden_actions: vec![
+                    "network_external".to_string(),
+                    "credential_access".to_string(),
+                ],
+            },
+            constitution: "default-v1".to_string(),
+            coordination: CoordinationConfig::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alignment_profile_yaml_round_trip() {
+        let profile = AlignmentProfile::default_developer();
+        let yaml = serde_yaml::to_string(&profile).unwrap();
+        let restored: AlignmentProfile = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(profile, restored);
+    }
+
+    #[test]
+    fn alignment_profile_json_round_trip() {
+        let profile = AlignmentProfile::default_developer();
+        let json = serde_json::to_string(&profile).unwrap();
+        let restored: AlignmentProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(profile, restored);
+    }
+
+    #[test]
+    fn alignment_profile_yaml_parsing() {
+        let yaml = r#"
+principal: "security-team"
+autonomy_envelope:
+  bounded_actions:
+    - "fs_read"
+  escalation_triggers:
+    - "any_write"
+  forbidden_actions:
+    - "network_external"
+    - "credential_access"
+    - "fs_write"
+constitution: "readonly-v1"
+coordination:
+  allowed_collaborators:
+    - "claude-code"
+  shared_resources:
+    - "src/**"
+"#;
+        let profile: AlignmentProfile = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(profile.principal, "security-team");
+        assert_eq!(profile.autonomy_envelope.bounded_actions.len(), 1);
+        assert_eq!(profile.autonomy_envelope.forbidden_actions.len(), 3);
+        assert_eq!(profile.constitution, "readonly-v1");
+        assert_eq!(profile.coordination.allowed_collaborators.len(), 1);
+        assert_eq!(profile.coordination.shared_resources.len(), 1);
+    }
+
+    #[test]
+    fn alignment_profile_defaults() {
+        let yaml = r#"
+principal: "owner"
+autonomy_envelope:
+  bounded_actions: []
+"#;
+        let profile: AlignmentProfile = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(profile.constitution, "default-v1");
+        assert!(profile.coordination.allowed_collaborators.is_empty());
+        assert!(profile.coordination.shared_resources.is_empty());
+        assert!(profile.autonomy_envelope.escalation_triggers.is_empty());
+        assert!(profile.autonomy_envelope.forbidden_actions.is_empty());
+    }
+
+    #[test]
+    fn default_developer_profile_has_expected_actions() {
+        let profile = AlignmentProfile::default_developer();
+        assert!(profile
+            .autonomy_envelope
+            .bounded_actions
+            .contains(&"fs_read".to_string()));
+        assert!(profile
+            .autonomy_envelope
+            .bounded_actions
+            .contains(&"fs_write_patch".to_string()));
+        assert!(profile
+            .autonomy_envelope
+            .forbidden_actions
+            .contains(&"network_external".to_string()));
+    }
+
+    #[test]
+    fn agent_setup_proposal_serialization() {
+        let proposal = AgentSetupProposal {
+            proposal_id: "prop-001".to_string(),
+            goal_title: "Fix auth bug".to_string(),
+            goal_objective: "Resolve JWT validation failure".to_string(),
+            agents: vec![ProposedAgent {
+                agent_id: "claude-code".to_string(),
+                role: "Primary coding agent".to_string(),
+                alignment: AlignmentProfile::default_developer(),
+                resource_scope: vec!["fs://workspace/src/**".to_string()],
+            }],
+            milestones: vec![Milestone {
+                description: "Identify root cause".to_string(),
+                agent_id: "claude-code".to_string(),
+                deliverables: vec!["diagnosis.md".to_string()],
+            }],
+            efficiency_notes: Some("Single agent sufficient for this scope".to_string()),
+        };
+
+        let json = serde_json::to_string_pretty(&proposal).unwrap();
+        let restored: AgentSetupProposal = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.proposal_id, "prop-001");
+        assert_eq!(restored.agents.len(), 1);
+        assert_eq!(restored.milestones.len(), 1);
+    }
+
+    #[test]
+    fn proposed_agent_inherits_alignment() {
+        let agent = ProposedAgent {
+            agent_id: "claude-code".to_string(),
+            role: "Coder".to_string(),
+            alignment: AlignmentProfile {
+                principal: "team-lead".to_string(),
+                autonomy_envelope: AutonomyEnvelope {
+                    bounded_actions: vec!["fs_read".to_string(), "fs_write".to_string()],
+                    escalation_triggers: vec![],
+                    forbidden_actions: vec!["credential_access".to_string()],
+                },
+                constitution: "scoped-v1".to_string(),
+                coordination: CoordinationConfig {
+                    allowed_collaborators: vec!["codex".to_string()],
+                    shared_resources: vec!["src/**".to_string()],
+                },
+            },
+            resource_scope: vec!["fs://workspace/src/**".to_string()],
+        };
+
+        let json = serde_json::to_string(&agent).unwrap();
+        let restored: ProposedAgent = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.alignment.principal, "team-lead");
+        assert_eq!(restored.alignment.constitution, "scoped-v1");
+    }
+
+    #[test]
+    fn coordination_config_default_is_empty() {
+        let config = CoordinationConfig::default();
+        assert!(config.allowed_collaborators.is_empty());
+        assert!(config.shared_resources.is_empty());
+    }
+}

--- a/crates/ta-policy/src/compiler.rs
+++ b/crates/ta-policy/src/compiler.rs
@@ -1,0 +1,419 @@
+// compiler.rs — Policy Compiler (v0.4.0).
+//
+// Compiles an AlignmentProfile into a CapabilityManifest. This replaces
+// the hardcoded manifest generation in ta-mcp-gateway/server.rs.
+//
+// The compiler:
+// 1. Parses bounded_actions into (tool, verb) pairs
+// 2. Validates that no forbidden_action overlaps with bounded_actions
+// 3. Applies resource_scope patterns (or defaults to workspace/**)
+// 4. Generates time-bounded CapabilityManifest with matching grants
+//
+// The key invariant: if an action is in `forbidden_actions`, it NEVER
+// appears in the manifest — this is enforced, not promised.
+
+use chrono::{Duration, Utc};
+use uuid::Uuid;
+
+use crate::alignment::AlignmentProfile;
+use crate::capability::{CapabilityGrant, CapabilityManifest};
+
+/// Errors that can occur during policy compilation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompilerError {
+    /// A bounded_action overlaps with a forbidden_action.
+    ForbiddenOverlap { action: String, message: String },
+    /// A bounded_action has an unrecognized format.
+    InvalidAction { action: String, message: String },
+}
+
+impl std::fmt::Display for CompilerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CompilerError::ForbiddenOverlap { action, message } => {
+                write!(f, "forbidden overlap for '{}': {}", action, message)
+            }
+            CompilerError::InvalidAction { action, message } => {
+                write!(f, "invalid action '{}': {}", action, message)
+            }
+        }
+    }
+}
+
+impl std::error::Error for CompilerError {}
+
+/// Options for the Policy Compiler.
+#[derive(Debug, Clone)]
+pub struct CompilerOptions {
+    /// Resource patterns to scope grants to (defaults to ["fs://workspace/**"]).
+    pub resource_scope: Vec<String>,
+
+    /// How long the manifest is valid for (defaults to 8 hours).
+    pub validity_hours: i64,
+}
+
+impl Default for CompilerOptions {
+    fn default() -> Self {
+        Self {
+            resource_scope: vec!["fs://workspace/**".to_string()],
+            validity_hours: 8,
+        }
+    }
+}
+
+/// The Policy Compiler — transforms alignment profiles into enforceable capability manifests.
+pub struct PolicyCompiler;
+
+impl PolicyCompiler {
+    /// Compile an AlignmentProfile into a CapabilityManifest.
+    ///
+    /// This is the core function that replaces hardcoded manifest generation.
+    /// It parses bounded_actions, validates against forbidden_actions, and
+    /// generates scoped grants.
+    pub fn compile(
+        agent_id: &str,
+        profile: &AlignmentProfile,
+        options: &CompilerOptions,
+    ) -> Result<CapabilityManifest, CompilerError> {
+        // Step 1: Validate no overlaps between bounded and forbidden actions.
+        Self::validate_no_overlaps(profile)?;
+
+        // Step 2: Parse bounded_actions into grants.
+        let mut grants = Vec::new();
+        for action in &profile.autonomy_envelope.bounded_actions {
+            let parsed = Self::parse_action(action)?;
+            // Generate a grant for each resource scope pattern.
+            for pattern in &options.resource_scope {
+                grants.push(CapabilityGrant {
+                    tool: parsed.tool.clone(),
+                    verb: parsed.verb.clone(),
+                    resource_pattern: pattern.clone(),
+                });
+            }
+        }
+
+        // Step 3: Build time-bounded manifest.
+        let now = Utc::now();
+        Ok(CapabilityManifest {
+            manifest_id: Uuid::new_v4(),
+            agent_id: agent_id.to_string(),
+            grants,
+            issued_at: now,
+            expires_at: now + Duration::hours(options.validity_hours),
+        })
+    }
+
+    /// Compile with a specific manifest_id (for goal runs that pre-generate IDs).
+    pub fn compile_with_id(
+        manifest_id: Uuid,
+        agent_id: &str,
+        profile: &AlignmentProfile,
+        options: &CompilerOptions,
+    ) -> Result<CapabilityManifest, CompilerError> {
+        let mut manifest = Self::compile(agent_id, profile, options)?;
+        manifest.manifest_id = manifest_id;
+        Ok(manifest)
+    }
+
+    /// Validate that no bounded_action overlaps with forbidden_actions.
+    fn validate_no_overlaps(profile: &AlignmentProfile) -> Result<(), CompilerError> {
+        for bounded in &profile.autonomy_envelope.bounded_actions {
+            let parsed = Self::parse_action(bounded)?;
+            let canonical = format!("{}_{}", parsed.tool, parsed.verb);
+
+            for forbidden in &profile.autonomy_envelope.forbidden_actions {
+                if canonical == *forbidden || *bounded == *forbidden {
+                    return Err(CompilerError::ForbiddenOverlap {
+                        action: bounded.clone(),
+                        message: format!(
+                            "'{}' is both bounded and forbidden — this is a contradiction",
+                            bounded
+                        ),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Parse an action string into a (tool, verb) pair.
+    ///
+    /// Supported formats:
+    /// - `"fs_read"` → tool="fs", verb="read"
+    /// - `"fs_write_patch"` → tool="fs", verb="write_patch"
+    /// - `"exec: cargo test"` → tool="exec", verb="cargo test"
+    /// - `"web_fetch"` → tool="web", verb="fetch"
+    fn parse_action(action: &str) -> Result<ParsedAction, CompilerError> {
+        // Handle "exec: <command>" format.
+        if let Some(command) = action.strip_prefix("exec: ") {
+            return Ok(ParsedAction {
+                tool: "exec".to_string(),
+                verb: command.to_string(),
+            });
+        }
+
+        // Handle "tool_verb" format — split on first underscore.
+        if let Some(underscore_pos) = action.find('_') {
+            let tool = &action[..underscore_pos];
+            let verb = &action[underscore_pos + 1..];
+            if tool.is_empty() || verb.is_empty() {
+                return Err(CompilerError::InvalidAction {
+                    action: action.to_string(),
+                    message: "tool and verb must both be non-empty".to_string(),
+                });
+            }
+            Ok(ParsedAction {
+                tool: tool.to_string(),
+                verb: verb.to_string(),
+            })
+        } else {
+            Err(CompilerError::InvalidAction {
+                action: action.to_string(),
+                message: "expected format 'tool_verb' (e.g., 'fs_read') or 'exec: command'"
+                    .to_string(),
+            })
+        }
+    }
+}
+
+/// A parsed action — intermediate representation.
+#[derive(Debug, Clone)]
+struct ParsedAction {
+    tool: String,
+    verb: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alignment::{AlignmentProfile, AutonomyEnvelope, CoordinationConfig};
+
+    fn test_profile() -> AlignmentProfile {
+        AlignmentProfile {
+            principal: "project-owner".to_string(),
+            autonomy_envelope: AutonomyEnvelope {
+                bounded_actions: vec![
+                    "fs_read".to_string(),
+                    "fs_write_patch".to_string(),
+                    "fs_apply".to_string(),
+                ],
+                escalation_triggers: vec!["new_dependency".to_string()],
+                forbidden_actions: vec![
+                    "network_external".to_string(),
+                    "credential_access".to_string(),
+                ],
+            },
+            constitution: "default-v1".to_string(),
+            coordination: CoordinationConfig::default(),
+        }
+    }
+
+    #[test]
+    fn compile_default_developer_profile() {
+        let profile = AlignmentProfile::default_developer();
+        let options = CompilerOptions::default();
+        let manifest = PolicyCompiler::compile("claude-code", &profile, &options).unwrap();
+
+        assert_eq!(manifest.agent_id, "claude-code");
+        // 3 bounded_actions × 1 resource_scope = 3 grants
+        assert_eq!(manifest.grants.len(), 3);
+        assert!(!manifest.is_expired());
+    }
+
+    #[test]
+    fn compile_generates_correct_grants() {
+        let profile = test_profile();
+        let options = CompilerOptions::default();
+        let manifest = PolicyCompiler::compile("agent-1", &profile, &options).unwrap();
+
+        // Should have grants for fs.read, fs.write_patch, fs.apply
+        let tools_verbs: Vec<(String, String)> = manifest
+            .grants
+            .iter()
+            .map(|g| (g.tool.clone(), g.verb.clone()))
+            .collect();
+        assert!(tools_verbs.contains(&("fs".to_string(), "read".to_string())));
+        assert!(tools_verbs.contains(&("fs".to_string(), "write_patch".to_string())));
+        assert!(tools_verbs.contains(&("fs".to_string(), "apply".to_string())));
+    }
+
+    #[test]
+    fn compile_applies_resource_scope() {
+        let profile = test_profile();
+        let options = CompilerOptions {
+            resource_scope: vec![
+                "fs://workspace/src/**".to_string(),
+                "fs://workspace/tests/**".to_string(),
+            ],
+            validity_hours: 4,
+        };
+        let manifest = PolicyCompiler::compile("agent-1", &profile, &options).unwrap();
+
+        // 3 actions × 2 scopes = 6 grants
+        assert_eq!(manifest.grants.len(), 6);
+
+        // Every grant should match one of the resource scopes
+        for grant in &manifest.grants {
+            assert!(
+                grant.resource_pattern == "fs://workspace/src/**"
+                    || grant.resource_pattern == "fs://workspace/tests/**"
+            );
+        }
+    }
+
+    #[test]
+    fn compile_with_custom_validity() {
+        let profile = test_profile();
+        let options = CompilerOptions {
+            resource_scope: vec!["fs://workspace/**".to_string()],
+            validity_hours: 2,
+        };
+        let manifest = PolicyCompiler::compile("agent-1", &profile, &options).unwrap();
+
+        let duration = manifest.expires_at - manifest.issued_at;
+        assert_eq!(duration.num_hours(), 2);
+    }
+
+    #[test]
+    fn compile_rejects_forbidden_overlap() {
+        let profile = AlignmentProfile {
+            principal: "owner".to_string(),
+            autonomy_envelope: AutonomyEnvelope {
+                bounded_actions: vec!["fs_read".to_string(), "network_external".to_string()],
+                escalation_triggers: vec![],
+                forbidden_actions: vec!["network_external".to_string()],
+            },
+            constitution: "default-v1".to_string(),
+            coordination: CoordinationConfig::default(),
+        };
+        let options = CompilerOptions::default();
+        let result = PolicyCompiler::compile("agent-1", &profile, &options);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CompilerError::ForbiddenOverlap { action, .. } => {
+                assert_eq!(action, "network_external");
+            }
+            other => panic!("expected ForbiddenOverlap, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn compile_rejects_invalid_action_format() {
+        let profile = AlignmentProfile {
+            principal: "owner".to_string(),
+            autonomy_envelope: AutonomyEnvelope {
+                bounded_actions: vec!["invalid".to_string()],
+                escalation_triggers: vec![],
+                forbidden_actions: vec![],
+            },
+            constitution: "default-v1".to_string(),
+            coordination: CoordinationConfig::default(),
+        };
+        let options = CompilerOptions::default();
+        let result = PolicyCompiler::compile("agent-1", &profile, &options);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            CompilerError::InvalidAction { action, .. } => {
+                assert_eq!(action, "invalid");
+            }
+            other => panic!("expected InvalidAction, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_exec_action() {
+        let profile = AlignmentProfile {
+            principal: "owner".to_string(),
+            autonomy_envelope: AutonomyEnvelope {
+                bounded_actions: vec!["exec: cargo test".to_string()],
+                escalation_triggers: vec![],
+                forbidden_actions: vec![],
+            },
+            constitution: "default-v1".to_string(),
+            coordination: CoordinationConfig::default(),
+        };
+        let options = CompilerOptions::default();
+        let manifest = PolicyCompiler::compile("agent-1", &profile, &options).unwrap();
+
+        assert_eq!(manifest.grants.len(), 1);
+        assert_eq!(manifest.grants[0].tool, "exec");
+        assert_eq!(manifest.grants[0].verb, "cargo test");
+    }
+
+    #[test]
+    fn compile_with_specific_manifest_id() {
+        let profile = test_profile();
+        let options = CompilerOptions::default();
+        let id = Uuid::new_v4();
+        let manifest = PolicyCompiler::compile_with_id(id, "agent-1", &profile, &options).unwrap();
+        assert_eq!(manifest.manifest_id, id);
+    }
+
+    #[test]
+    fn compile_empty_bounded_actions_produces_empty_manifest() {
+        let profile = AlignmentProfile {
+            principal: "owner".to_string(),
+            autonomy_envelope: AutonomyEnvelope {
+                bounded_actions: vec![],
+                escalation_triggers: vec![],
+                forbidden_actions: vec!["fs_write".to_string()],
+            },
+            constitution: "default-v1".to_string(),
+            coordination: CoordinationConfig::default(),
+        };
+        let options = CompilerOptions::default();
+        let manifest = PolicyCompiler::compile("agent-1", &profile, &options).unwrap();
+        assert!(manifest.grants.is_empty());
+    }
+
+    #[test]
+    fn compile_forbidden_actions_not_in_grants() {
+        let profile = AlignmentProfile {
+            principal: "owner".to_string(),
+            autonomy_envelope: AutonomyEnvelope {
+                bounded_actions: vec!["fs_read".to_string()],
+                escalation_triggers: vec![],
+                forbidden_actions: vec!["fs_write".to_string(), "network_external".to_string()],
+            },
+            constitution: "default-v1".to_string(),
+            coordination: CoordinationConfig::default(),
+        };
+        let options = CompilerOptions::default();
+        let manifest = PolicyCompiler::compile("agent-1", &profile, &options).unwrap();
+
+        // Only fs_read should be granted, not fs_write or network_external
+        assert_eq!(manifest.grants.len(), 1);
+        assert_eq!(manifest.grants[0].tool, "fs");
+        assert_eq!(manifest.grants[0].verb, "read");
+    }
+
+    #[test]
+    fn compiler_error_display() {
+        let err = CompilerError::ForbiddenOverlap {
+            action: "network_external".to_string(),
+            message: "contradicts forbidden list".to_string(),
+        };
+        let display = format!("{}", err);
+        assert!(display.contains("network_external"));
+        assert!(display.contains("contradicts"));
+    }
+
+    #[test]
+    fn compile_multi_segment_verb() {
+        // "fs_write_patch" should parse as tool="fs", verb="write_patch"
+        let profile = AlignmentProfile {
+            principal: "owner".to_string(),
+            autonomy_envelope: AutonomyEnvelope {
+                bounded_actions: vec!["fs_write_patch".to_string()],
+                escalation_triggers: vec![],
+                forbidden_actions: vec![],
+            },
+            constitution: "default-v1".to_string(),
+            coordination: CoordinationConfig::default(),
+        };
+        let options = CompilerOptions::default();
+        let manifest = PolicyCompiler::compile("agent-1", &profile, &options).unwrap();
+        assert_eq!(manifest.grants[0].tool, "fs");
+        assert_eq!(manifest.grants[0].verb, "write_patch");
+    }
+}

--- a/crates/ta-policy/src/exemption.rs
+++ b/crates/ta-policy/src/exemption.rs
@@ -1,0 +1,234 @@
+// exemption.rs — Configurable summary exemption patterns (v0.4.0).
+//
+// Replaces the hardcoded `is_auto_summary_exempt()` function in draft.rs
+// with a `.gitignore`-style pattern file (`.ta/summary-exempt`).
+//
+// Patterns match against `fs://workspace/` URIs. The file supports:
+// - Glob patterns (e.g., `*.lock`, `**/*.toml`)
+// - Comments (lines starting with `#`)
+// - Blank lines (ignored)
+//
+// Default patterns are provided when no file exists, matching the
+// previously hardcoded list (lockfiles, config manifests, docs).
+
+use glob::Pattern;
+
+/// A set of summary exemption patterns loaded from `.ta/summary-exempt`.
+///
+/// Files matching these patterns are exempt from summary enforcement —
+/// they get auto-summaries and don't require agent-provided descriptions.
+#[derive(Debug, Clone)]
+pub struct ExemptionPatterns {
+    patterns: Vec<Pattern>,
+    raw_patterns: Vec<String>,
+}
+
+impl ExemptionPatterns {
+    /// Load patterns from a file. Each non-empty, non-comment line is a glob pattern.
+    pub fn from_file(path: &std::path::Path) -> Result<Self, std::io::Error> {
+        let content = std::fs::read_to_string(path)?;
+        Ok(Self::parse_content(&content))
+    }
+
+    /// Parse patterns from a string (the file contents).
+    pub fn parse_content(content: &str) -> Self {
+        let mut patterns = Vec::new();
+        let mut raw_patterns = Vec::new();
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+            // Skip comments and blank lines.
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            raw_patterns.push(trimmed.to_string());
+            if let Ok(pattern) = Pattern::new(trimmed) {
+                patterns.push(pattern);
+            }
+        }
+
+        Self {
+            patterns,
+            raw_patterns,
+        }
+    }
+
+    /// Load from file if it exists, otherwise use defaults.
+    pub fn load_or_default(path: &std::path::Path) -> Self {
+        if path.exists() {
+            Self::from_file(path).unwrap_or_else(|_| Self::defaults())
+        } else {
+            Self::defaults()
+        }
+    }
+
+    /// Default exemption patterns — matches the previously hardcoded list.
+    pub fn defaults() -> Self {
+        Self::parse_content(DEFAULT_PATTERNS)
+    }
+
+    /// Check if a URI is exempt from summary enforcement.
+    ///
+    /// The URI is expected to be in `fs://workspace/...` format.
+    /// The path portion (after `fs://workspace/`) is matched against patterns.
+    pub fn is_exempt(&self, uri: &str) -> bool {
+        let path = uri.strip_prefix("fs://workspace/").unwrap_or(uri);
+        self.patterns.iter().any(|p| {
+            p.matches(path)
+                || path
+                    .rsplit('/')
+                    .next()
+                    .map(|filename| p.matches(filename))
+                    .unwrap_or(false)
+        })
+    }
+
+    /// Return the raw pattern strings (for display/debugging).
+    pub fn raw_patterns(&self) -> &[String] {
+        &self.raw_patterns
+    }
+}
+
+/// Default exemption patterns — equivalent to the hardcoded list from v0.3.6.
+const DEFAULT_PATTERNS: &str = r#"# Default summary exemption patterns.
+# Files matching these patterns get auto-summaries and don't need
+# agent-provided descriptions at `ta draft build` time.
+#
+# Format: .gitignore-style glob patterns, one per line.
+# Matches against the path portion of fs://workspace/ URIs.
+
+# Lockfiles
+Cargo.lock
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+Gemfile.lock
+poetry.lock
+
+# Config / manifest files
+Cargo.toml
+package.json
+pyproject.toml
+
+# Plan / docs
+PLAN.md
+CHANGELOG.md
+README.md
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_patterns_match_lockfiles() {
+        let patterns = ExemptionPatterns::defaults();
+        assert!(patterns.is_exempt("fs://workspace/Cargo.lock"));
+        assert!(patterns.is_exempt("fs://workspace/package-lock.json"));
+        assert!(patterns.is_exempt("fs://workspace/yarn.lock"));
+        assert!(patterns.is_exempt("fs://workspace/pnpm-lock.yaml"));
+        assert!(patterns.is_exempt("fs://workspace/Gemfile.lock"));
+        assert!(patterns.is_exempt("fs://workspace/poetry.lock"));
+    }
+
+    #[test]
+    fn default_patterns_match_config_manifests() {
+        let patterns = ExemptionPatterns::defaults();
+        assert!(patterns.is_exempt("fs://workspace/Cargo.toml"));
+        assert!(patterns.is_exempt("fs://workspace/package.json"));
+        assert!(patterns.is_exempt("fs://workspace/pyproject.toml"));
+    }
+
+    #[test]
+    fn default_patterns_match_nested_config_files() {
+        let patterns = ExemptionPatterns::defaults();
+        // Should match Cargo.toml in subdirectories via filename matching
+        assert!(patterns.is_exempt("fs://workspace/crates/foo/Cargo.toml"));
+        assert!(patterns.is_exempt("fs://workspace/deep/pnpm-lock.yaml"));
+    }
+
+    #[test]
+    fn default_patterns_match_docs() {
+        let patterns = ExemptionPatterns::defaults();
+        assert!(patterns.is_exempt("fs://workspace/PLAN.md"));
+        assert!(patterns.is_exempt("fs://workspace/CHANGELOG.md"));
+        assert!(patterns.is_exempt("fs://workspace/README.md"));
+    }
+
+    #[test]
+    fn default_patterns_do_not_match_source_files() {
+        let patterns = ExemptionPatterns::defaults();
+        assert!(!patterns.is_exempt("fs://workspace/src/main.rs"));
+        assert!(!patterns.is_exempt("fs://workspace/src/lib.rs"));
+        assert!(!patterns.is_exempt("fs://workspace/tests/test.rs"));
+        assert!(!patterns.is_exempt("fs://workspace/build.rs"));
+    }
+
+    #[test]
+    fn custom_patterns_override_defaults() {
+        let content = "*.lock\n*.md\n";
+        let patterns = ExemptionPatterns::parse_content(content);
+        assert!(patterns.is_exempt("fs://workspace/Cargo.lock"));
+        assert!(patterns.is_exempt("fs://workspace/README.md"));
+        // *.toml is NOT in the custom patterns
+        assert!(!patterns.is_exempt("fs://workspace/Cargo.toml"));
+    }
+
+    #[test]
+    fn comments_and_blanks_are_ignored() {
+        let content = "# This is a comment\n\n*.lock\n  # Another comment\n";
+        let patterns = ExemptionPatterns::parse_content(content);
+        assert_eq!(patterns.raw_patterns().len(), 1);
+        assert!(patterns.is_exempt("fs://workspace/Cargo.lock"));
+    }
+
+    #[test]
+    fn glob_star_patterns() {
+        let content = "**/*.generated.*\n";
+        let patterns = ExemptionPatterns::parse_content(content);
+        assert!(patterns.is_exempt("fs://workspace/src/types.generated.ts"));
+        assert!(patterns.is_exempt("fs://workspace/deep/path/schema.generated.rs"));
+        assert!(!patterns.is_exempt("fs://workspace/src/main.rs"));
+    }
+
+    #[test]
+    fn empty_patterns_exempt_nothing() {
+        let patterns = ExemptionPatterns::parse_content("");
+        assert!(!patterns.is_exempt("fs://workspace/anything.rs"));
+        assert!(!patterns.is_exempt("fs://workspace/Cargo.lock"));
+    }
+
+    #[test]
+    fn uri_without_prefix_still_matches() {
+        let patterns = ExemptionPatterns::defaults();
+        // If URI doesn't have the prefix, match against the raw string
+        assert!(patterns.is_exempt("Cargo.lock"));
+    }
+
+    #[test]
+    fn load_or_default_returns_defaults_for_missing_file() {
+        let patterns =
+            ExemptionPatterns::load_or_default(std::path::Path::new("/nonexistent/path"));
+        assert!(patterns.is_exempt("fs://workspace/Cargo.lock"));
+    }
+
+    #[test]
+    fn load_from_tempfile() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("summary-exempt");
+        std::fs::write(&path, "*.custom\nspecial.txt\n").unwrap();
+
+        let patterns = ExemptionPatterns::from_file(&path).unwrap();
+        assert!(patterns.is_exempt("fs://workspace/file.custom"));
+        assert!(patterns.is_exempt("fs://workspace/special.txt"));
+        assert!(!patterns.is_exempt("fs://workspace/src/main.rs"));
+    }
+
+    #[test]
+    fn raw_patterns_accessible() {
+        let patterns = ExemptionPatterns::parse_content("*.lock\n*.toml\n");
+        assert_eq!(patterns.raw_patterns().len(), 2);
+        assert_eq!(patterns.raw_patterns()[0], "*.lock");
+        assert_eq!(patterns.raw_patterns()[1], "*.toml");
+    }
+}

--- a/crates/ta-policy/src/lib.rs
+++ b/crates/ta-policy/src/lib.rs
@@ -7,6 +7,15 @@
 //! evaluates each tool call request against the agent's grants and returns
 //! Allow, Deny, or RequireApproval.
 //!
+//! ## v0.4.0 additions
+//!
+//! - **Alignment profiles**: Structured declarations of agent capabilities,
+//!   constraints, and coordination rules (`alignment` module).
+//! - **Policy compiler**: Compiles alignment profiles into enforceable
+//!   capability manifests (`compiler` module).
+//! - **Exemption patterns**: Configurable summary exemption via `.ta/summary-exempt`
+//!   file, replacing hardcoded patterns (`exemption` module).
+//!
 //! ## Key invariants
 //!
 //! - **Default deny**: no manifest → denied. No matching grant → denied.
@@ -14,10 +23,19 @@
 //!   always return RequireApproval, even when granted.
 //! - **Path traversal blocked**: URIs containing ".." are always denied.
 
+pub mod alignment;
 pub mod capability;
+pub mod compiler;
 pub mod engine;
 pub mod error;
+pub mod exemption;
 
+pub use alignment::{
+    AgentSetupProposal, AlignmentProfile, AutonomyEnvelope, CoordinationConfig, Milestone,
+    ProposedAgent,
+};
 pub use capability::{CapabilityGrant, CapabilityManifest};
+pub use compiler::{CompilerError, CompilerOptions, PolicyCompiler};
 pub use engine::{EvaluationStep, EvaluationTrace, PolicyDecision, PolicyEngine, PolicyRequest};
 pub use error::PolicyError;
+pub use exemption::ExemptionPatterns;

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-sandbox"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 description = "Allowlisted command execution sandbox for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-submit"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 description = "Submit adapters for VCS integration in Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-workspace"
-version = "0.3.6-alpha"
+version = "0.4.0-alpha"
 edition = "2021"
 description = "Staging workspace manager and change store for Trusted Autonomy"
 license = "Apache-2.0"

--- a/examples/summary-exempt
+++ b/examples/summary-exempt
@@ -1,0 +1,30 @@
+# Summary exemption patterns for Trusted Autonomy.
+# Files matching these patterns are exempt from summary enforcement —
+# they get auto-summaries and don't need agent-provided descriptions
+# at `ta draft build` time.
+#
+# Format: .gitignore-style glob patterns, one per line.
+# Lines starting with # are comments.
+# Patterns match against the filename portion of fs://workspace/ URIs.
+#
+# Place this file at: .ta/summary-exempt
+#
+# See also: [build] summary_enforcement in .ta/workflow.toml
+
+# Lockfiles
+Cargo.lock
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+Gemfile.lock
+poetry.lock
+
+# Config / manifest files
+Cargo.toml
+package.json
+pyproject.toml
+
+# Plan / docs
+PLAN.md
+CHANGELOG.md
+README.md


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.4.0 — Intent-to-Access Planner & Agent Alignment Profiles

**Why**: Implement v0.4.0 — Intent-to-Access Planner & Agent Alignment Profiles

**Impact**: 25 file(s) changed

## Changes (25 file(s))

- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/PLAN.md` — Added completion notes for v0.4.0 phase: 7 checkmarked items covering AlignmentProfile types, PolicyCompiler, AgentSetupProposal, configurable exemption patterns, gateway integration, agent YAML configs, and documentation.
  - Records what was accomplished in this phase for plan tracking.
- `~` `fs://workspace/agents/claude-code.yaml` — Added alignment block with principal, autonomy_envelope (bounded_actions, escalation_triggers, forbidden_actions), constitution, and coordination config.
  - Declares the alignment profile for Claude Code agent — these are enforced constraints compiled into CapabilityManifest grants by the Policy Compiler.
- `~` `fs://workspace/agents/claude-flow.yaml` — Added alignment block with principal, autonomy_envelope, constitution, and coordination config.
  - Declares the alignment profile for the Claude Flow multi-agent orchestrator.
- `~` `fs://workspace/agents/codex.yaml` — Added alignment block with principal, autonomy_envelope, constitution, and coordination config.
  - Declares the alignment profile for the Codex CLI agent.
- `~` `fs://workspace/agents/generic.yaml` — Added commented-out alignment block as a template for custom agents.
  - Shows users how to define alignment profiles for their own agents.
- `~` `fs://workspace/apps/ta-cli/Cargo.toml` — Version bumped to 0.4.0-alpha.
  - Version alignment for v0.4.0 release.
- `~` `fs://workspace/apps/ta-cli/src/commands/draft.rs` — Replaced hardcoded is_auto_summary_exempt() with configurable is_auto_summary_exempt_with_patterns() that loads patterns from .ta/summary-exempt via ExemptionPatterns.
  - Projects can now customize which files are exempt from summary enforcement without modifying TA source code.
- `~` `fs://workspace/apps/ta-cli/src/commands/run.rs` — Added alignment: Option<ta_policy::AlignmentProfile> field to AgentLaunchConfig. All hardcoded agent configs (claude-code, codex, claude-flow) now include AlignmentProfile::default_developer().
  - Prepares agent launch configs to carry alignment profiles, which will be passed to the gateway for policy compilation in future work.
- `~` `fs://workspace/crates/ta-audit/Cargo.toml` — Version bumped to 0.4.0-alpha.
  - Version alignment for v0.4.0 release.
- `~` `fs://workspace/crates/ta-changeset/Cargo.toml` — Version bumped to 0.4.0-alpha.
  - Version alignment for v0.4.0 release.
- `~` `fs://workspace/crates/ta-daemon/Cargo.toml` — Version bumped to 0.4.0-alpha.
  - Version alignment for v0.4.0 release.
- `~` `fs://workspace/crates/ta-goal/Cargo.toml` — Version bumped to 0.4.0-alpha.
  - Version alignment for v0.4.0 release.
- `~` `fs://workspace/crates/ta-mcp-gateway/Cargo.toml` — Version bumped to 0.4.0-alpha.
  - Version alignment for v0.4.0 release.
- `~` `fs://workspace/crates/ta-mcp-gateway/src/server.rs` — Replaced hardcoded CapabilityManifest construction in start_goal() with PolicyCompiler::compile_with_id() using AlignmentProfile::default_developer(). Added new start_goal_with_profile() method accepting custom AlignmentProfile and optional resource scope.
  - Core integration point — the gateway now uses the principled PolicyCompiler pipeline instead of manually constructing manifests.
- `~` `fs://workspace/crates/ta-policy/Cargo.toml` — Added serde_yaml and glob dependencies, tempfile dev-dependency. Version bumped to 0.4.0-alpha.
  - serde_yaml needed for AlignmentProfile deserialization from YAML agent configs; glob needed for ExemptionPatterns pattern matching; tempfile for filesystem tests.
- `+` `fs://workspace/crates/ta-policy/src/alignment.rs` — Added AlignmentProfile, AutonomyEnvelope, CoordinationConfig types (deserialized from YAML agent configs) and AgentSetupProposal, ProposedAgent, Milestone types for LLM-based intent-to-policy planning. Includes default_developer() constructor and 10 tests.
  - Core v0.4.0 data model — structured alignment blocks replace informal agent conventions with enforceable, machine-readable profiles.
- `+` `fs://workspace/crates/ta-policy/src/compiler.rs` — Added PolicyCompiler that transforms AlignmentProfile into CapabilityManifest. Parses action format (tool_verb or exec: command), validates no overlap between bounded and forbidden actions, scopes grants to resource patterns. Includes CompilerOptions and CompilerError types, 14 tests.
  - Replaces hardcoded manifest construction in the MCP gateway with a principled compilation step that derives grants from alignment profiles.
- `+` `fs://workspace/crates/ta-policy/src/exemption.rs` — Added ExemptionPatterns type with .gitignore-style glob pattern matching for summary exemption. Supports loading from .ta/summary-exempt file or falling back to defaults. Handles both full URI and filename-only matching for nested paths. 13 tests.
  - Replaces hardcoded is_auto_summary_exempt() function in draft.rs with configurable, project-specific exemption patterns.
- `~` `fs://workspace/crates/ta-policy/src/lib.rs` — Added module declarations for alignment, compiler, exemption and re-exported all public types from these modules.
  - Makes the new v0.4.0 types available to downstream crates (ta-mcp-gateway, ta-cli).
- `~` `fs://workspace/crates/ta-sandbox/Cargo.toml` — Version bumped to 0.4.0-alpha.
  - Version alignment for v0.4.0 release.
- `~` `fs://workspace/crates/ta-submit/Cargo.toml` — Version bumped to 0.4.0-alpha.
  - Version alignment for v0.4.0 release.
- `~` `fs://workspace/crates/ta-workspace/Cargo.toml` — Version bumped to 0.4.0-alpha.
  - Version alignment for v0.4.0 release.
- `~` `fs://workspace/docs/USAGE.md` — Expanded v0.4.0 docs from reference-only into persona-driven usage guide. Added 'Who this is for' sections (team lead, developer, non-technical reviewer), practical workflows (new project setup, tightening permissions, adding custom agents, reviewing as non-technical user), common profile examples (read-only auditor, full developer, orchestrator), action format reference table, and customization guidance for summary exemption. Updated version to v0.4.0-alpha.
  - Reference docs alone don't help users understand when/why to use alignment profiles. Persona-based guidance helps both technical users (configure agents, tighten permissions) and non-technical reviewers (understand audit trail, verify agent stayed within bounds).
- `+` `fs://workspace/examples/summary-exempt` — Example .ta/summary-exempt file showing the default exemption patterns with documentation comments.
  - Gives users a starting point for customizing summary exemption patterns in their projects.

## Goal Context

- **Title**: Implement v0.4.0 — Intent-to-Access Planner & Agent Alignment Profiles
- **Objective**: Implement v0.4.0 — Intent-to-Access Planner & Agent Alignment Profiles
- **Goal ID**: `11beee9e-6949-4c8b-8c78-9cef43da9d0d`
- **PR ID**: `1902845b-18b8-4145-8eca-0407ce29ed84`
- **Plan Phase**: `0.4.0`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
