### PR TITLE
Implement v0.4.1 — Macro Goals & Inner-Loop Iteration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "chrono",
  "rmcp",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "serde",
  "thiserror",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 dependencies = [
  "chrono",
  "serde",

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-cli"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 edition = "2021"
 description = "CLI for goals, PR review, and approvals in Trusted Autonomy"
 license = "Apache-2.0"

--- a/apps/ta-cli/src/main.rs
+++ b/apps/ta-cli/src/main.rs
@@ -88,6 +88,11 @@ enum Commands {
         /// Run in interactive mode with session orchestration.
         #[arg(long)]
         interactive: bool,
+        /// Run as a macro goal with inner-loop iteration.
+        /// Agent stays in-session, can decompose work into sub-goals,
+        /// submit drafts for review, and iterate based on feedback.
+        #[arg(long, alias = "macro")]
+        macro_goal: bool,
     },
     /// Manage interactive sessions.
     Session {
@@ -183,6 +188,7 @@ fn main() -> anyhow::Result<()> {
             objective_file,
             no_launch,
             interactive,
+            macro_goal,
         } => commands::run::execute(
             &config,
             title,
@@ -194,6 +200,7 @@ fn main() -> anyhow::Result<()> {
             objective_file.as_deref(),
             *no_launch,
             *interactive,
+            *macro_goal,
         ),
         Commands::Session { command } => commands::session::execute(command, &config),
         Commands::Plan { command } => commands::plan::execute(command, &config),

--- a/crates/ta-audit/Cargo.toml
+++ b/crates/ta-audit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-audit"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 edition = "2021"
 description = "Append-only event log and artifact hashing for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-changeset/Cargo.toml
+++ b/crates/ta-changeset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-changeset"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 edition = "2021"
 description = "ChangeSet and PR Package data model for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-daemon"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 edition = "2021"
 description = "MCP server daemon for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-goal/Cargo.toml
+++ b/crates/ta-goal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-goal"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 edition = "2021"
 description = "GoalRun lifecycle management and event dispatch for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-goal/src/events.rs
+++ b/crates/ta-goal/src/events.rs
@@ -113,6 +113,15 @@ pub enum TaEvent {
         content_preview: String,
         timestamp: DateTime<Utc>,
     },
+
+    /// Agent proposed a plan update within a macro goal session (v0.4.1).
+    /// Held for human approval — the update is not applied automatically.
+    PlanUpdateProposed {
+        goal_run_id: Uuid,
+        phase: String,
+        status_note: String,
+        timestamp: DateTime<Utc>,
+    },
 }
 
 impl TaEvent {
@@ -129,6 +138,7 @@ impl TaEvent {
             TaEvent::SessionStarted { .. } => "session_started",
             TaEvent::SessionStateChanged { .. } => "session_state_changed",
             TaEvent::SessionMessage { .. } => "session_message",
+            TaEvent::PlanUpdateProposed { .. } => "plan_update_proposed",
         }
     }
 

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-mcp-gateway"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 edition = "2021"
 description = "MCP gateway server with policy enforcement for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-policy/Cargo.toml
+++ b/crates/ta-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-policy"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 edition = "2021"
 description = "Capability manifests and policy evaluation for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-sandbox"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 edition = "2021"
 description = "Allowlisted command execution sandbox for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-submit"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 edition = "2021"
 description = "Submit adapters for VCS integration in Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-workspace"
-version = "0.4.0-alpha"
+version = "0.4.1-alpha"
 edition = "2021"
 description = "Staging workspace manager and change store for Trusted Autonomy"
 license = "Apache-2.0"

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -571,6 +571,60 @@ The `SessionChannel` trait is designed for messaging platform adapters:
 
 ---
 
+## Macro Goals & Inner-Loop Iteration
+
+*(v0.4.1)* Macro goals let agents stay in a single session, decompose work into sub-goals, submit drafts for review, and iterate based on feedback — all without exiting and restarting `ta run`.
+
+### Starting a Macro Goal Session
+
+```bash
+ta run "Build v0.5 features" --source . --macro
+```
+
+The agent receives MCP tools (`ta_draft`, `ta_goal_inner`, `ta_plan`) for interacting with TA during the session.
+
+### How It Works
+
+1. Agent works on a logical unit of change
+2. Agent calls `ta_draft { action: "build" }` to package changes
+3. Agent calls `ta_draft { action: "submit" }` to submit for review
+4. Human reviews and approves/denies via `ta draft approve/deny`
+5. Agent receives the result and either continues or revises
+
+### Sub-Goals
+
+Agents can create sub-goals within a macro session:
+
+```
+ta_goal_inner { action: "start", macro_goal_id: "...", title: "Add auth module" }
+```
+
+Sub-goals inherit the macro goal's plan phase, source directory, and agent configuration.
+
+### Viewing Macro Goal Status
+
+```bash
+# Shows sub-goal tree with approval status
+ta goal status <macro-goal-id>
+
+# Drafts show macro context in the list
+ta draft list
+```
+
+### Security Boundaries
+
+- Agents **can**: propose sub-goals, build drafts, submit for review, read plan status
+- Agents **cannot**: approve their own drafts, apply changes, bypass checkpoints
+- Every sub-goal draft goes through the same human review gate
+
+### Execution Modes
+
+- **Blocking** (default, v0.4.1): Agent submits draft and waits for human response
+- **Optimistic** (future): Agent continues while draft is pending
+- **Hybrid** (future): Agent marks sub-goals as blocking or non-blocking based on risk
+
+---
+
 ## External Diff Handlers
 
 ### Use Cases


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.4.1 — Macro Goals & Inner-Loop Iteration

**Why**: Implement v0.4.1 — Macro Goals & Inner-Loop Iteration

**Impact**: 21 file(s) changed

## Changes (21 file(s))

- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/PLAN.md` — Marked v0.4.1 items as completed with checkmarks. Added Data Model section documenting new fields and tests. Added new Phase v0.4.1.1 — Runtime Channel Architecture & Macro Session Loop with ReviewChannel trait, InteractionRequest model, runtime loop spec, and channel adapter design.
  - Plan tracking requirement: completed items must be marked in PLAN.md. New phase inserted to capture the runtime loop and pluggable channel architecture as a distinct, next-step deliverable.
- `~` `fs://workspace/apps/ta-cli/Cargo.toml` — Bumped version from 0.4.0-alpha to 0.4.1-alpha.
  - Version bump for the v0.4.1 release per versioning policy.
- `~` `fs://workspace/apps/ta-cli/src/commands/draft.rs` — Updated ta draft list to show [M] prefix for macro goals and └ prefix for sub-goal drafts. Added macro_goal=false to run::execute call in amend flow.
  - Draft list needs to visually distinguish macro goal drafts from sub-goal drafts so reviewers understand the hierarchy.
- `~` `fs://workspace/apps/ta-cli/src/commands/goal.rs` — Updated ta goal status to show macro goal metadata (is_macro, parent_macro_id) and sub-goal tree. Updated ta goal list to show [M] prefix for macro goals and └ prefix for sub-goals.
  - Reviewers and operators need visibility into macro goal hierarchies — which goals are macro parents, which are sub-goals, and the approval status of each.
- `~` `fs://workspace/apps/ta-cli/src/commands/run.rs` — Added macro_goal parameter to execute() and inject_claude_md(). Added build_macro_goal_section() that generates CLAUDE.md content explaining MCP tools. Sets is_macro on GoalRun. Added 1 new test for macro goal injection.
  - Orchestrates macro goal mode: marks the goal as macro, injects agent-facing documentation about available MCP tools and inner-loop workflow into CLAUDE.md.
- `~` `fs://workspace/apps/ta-cli/src/main.rs` — Added --macro (alias: --macro-goal) flag to the Run command and passed it through to commands::run::execute.
  - CLI entry point for macro goal sessions. Users start a macro session with `ta run "title" --source . --macro`.
- `~` `fs://workspace/crates/ta-audit/Cargo.toml`
- `~` `fs://workspace/crates/ta-changeset/Cargo.toml`
- `~` `fs://workspace/crates/ta-daemon/Cargo.toml`
- `~` `fs://workspace/crates/ta-goal/Cargo.toml`
- `~` `fs://workspace/crates/ta-goal/src/events.rs` — Added PlanUpdateProposed event variant to TaEvent enum for governance-gated plan updates proposed by agents.
  - When agents propose plan updates via the ta_plan MCP tool, the proposal is logged as an event for human approval — agents cannot unilaterally modify the plan.
- `~` `fs://workspace/crates/ta-goal/src/goal_run.rs` — Added is_macro, parent_macro_id, sub_goal_ids fields to GoalRun. Added PrReady→Running state transition for inner-loop iteration. Added 3 new tests.
  - Macro goals need to track their sub-goals and allow agents to iterate (submit draft, get feedback, continue working) within a single session.
- `~` `fs://workspace/crates/ta-mcp-gateway/Cargo.toml`
- `~` `fs://workspace/crates/ta-mcp-gateway/src/server.rs` — Added three new MCP tools: ta_draft (build/submit/status/list), ta_goal_inner (start/status), ta_plan (read/update). Updated tool count test from 9 to 12.
  - These are the agent-facing MCP tools that enable inner-loop iteration during macro goal sessions. They mirror CLI commands as a passthrough model per PLAN.md specification.
- `~` `fs://workspace/crates/ta-policy/Cargo.toml`
- `~` `fs://workspace/crates/ta-sandbox/Cargo.toml`
- `~` `fs://workspace/crates/ta-submit/Cargo.toml`
- `~` `fs://workspace/crates/ta-workspace/Cargo.toml`
- `~` `fs://workspace/docs/USAGE.md` — Added 'Macro Goals & Inner-Loop Iteration' section documenting --macro flag, MCP tools, sub-goals, security boundaries, and execution modes.
  - User-facing documentation for the new macro goal feature.
- `-` `fs://workspace/docs/use-cases/continuous-department.md`

## Goal Context

- **Title**: Implement v0.4.1 — Macro Goals & Inner-Loop Iteration
- **Objective**: Implement v0.4.1 — Macro Goals & Inner-Loop Iteration
- **Goal ID**: `27cf65c9-9f3e-4563-bad9-e0d1e14fd8f6`
- **PR ID**: `cb59d4a7-0f94-4661-9c52-f1e1515602f8`
- **Plan Phase**: `0.4.1`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
