### PR TITLE
Implement v0.4.1.1 — Runtime Channel Architecture & Macro Session Loop

### DIFF
--- a/crates/ta-changeset/src/interaction.rs
+++ b/crates/ta-changeset/src/interaction.rs
@@ -1,0 +1,467 @@
+// interaction.rs — Interaction request/response model for ReviewChannel.
+//
+// These types define the protocol for bidirectional human-agent communication.
+// An InteractionRequest is sent when TA needs human input (draft review, plan
+// approval, escalation), and InteractionResponse carries the human's decision.
+//
+// This is the core protocol for v0.4.1.1 (Runtime Channel Architecture).
+
+use std::collections::HashMap;
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// What kind of interaction is being requested.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractionKind {
+    /// A draft is ready for review — human should approve, reject, or discuss.
+    DraftReview,
+    /// General approval question (e.g., "proceed with this approach?").
+    ApprovalDiscussion,
+    /// Agent proposes a plan change — human should accept or reject.
+    PlanNegotiation,
+    /// Agent is escalating an issue that exceeds its authority.
+    Escalation,
+    /// Extension point for future interaction types.
+    Custom(String),
+}
+
+impl fmt::Display for InteractionKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            InteractionKind::DraftReview => write!(f, "draft_review"),
+            InteractionKind::ApprovalDiscussion => write!(f, "approval_discussion"),
+            InteractionKind::PlanNegotiation => write!(f, "plan_negotiation"),
+            InteractionKind::Escalation => write!(f, "escalation"),
+            InteractionKind::Custom(name) => write!(f, "custom:{}", name),
+        }
+    }
+}
+
+/// How urgent is this interaction?
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Urgency {
+    /// Agent blocks until human responds.
+    Blocking,
+    /// Agent can continue, but human should respond eventually.
+    Advisory,
+    /// Informational only — no response expected.
+    Informational,
+}
+
+impl fmt::Display for Urgency {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Urgency::Blocking => write!(f, "blocking"),
+            Urgency::Advisory => write!(f, "advisory"),
+            Urgency::Informational => write!(f, "informational"),
+        }
+    }
+}
+
+/// A request from TA to the human, delivered via a ReviewChannel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InteractionRequest {
+    /// Unique identifier for this interaction (for correlation with response).
+    pub interaction_id: Uuid,
+
+    /// What kind of interaction this is.
+    pub kind: InteractionKind,
+
+    /// Structured payload — contents depend on `kind`.
+    /// For DraftReview: { "draft_id": "...", "summary": "...", "artifact_count": N }
+    /// For PlanNegotiation: { "phase": "...", "proposed_status": "..." }
+    pub context: serde_json::Value,
+
+    /// How urgent is this interaction?
+    pub urgency: Urgency,
+
+    /// Arbitrary key-value pairs for channel-specific rendering hints.
+    /// e.g., { "color": "yellow", "thread_id": "..." }
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
+
+    /// When the request was created.
+    pub created_at: DateTime<Utc>,
+
+    /// Optional goal ID for context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal_id: Option<Uuid>,
+}
+
+impl InteractionRequest {
+    /// Create a new interaction request.
+    pub fn new(kind: InteractionKind, context: serde_json::Value, urgency: Urgency) -> Self {
+        Self {
+            interaction_id: Uuid::new_v4(),
+            kind,
+            context,
+            urgency,
+            metadata: HashMap::new(),
+            created_at: Utc::now(),
+            goal_id: None,
+        }
+    }
+
+    /// Set the goal ID for this interaction.
+    pub fn with_goal_id(mut self, goal_id: Uuid) -> Self {
+        self.goal_id = Some(goal_id);
+        self
+    }
+
+    /// Add a metadata key-value pair.
+    pub fn with_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    /// Create a DraftReview interaction request.
+    pub fn draft_review(draft_id: Uuid, summary: &str, artifact_count: usize) -> Self {
+        Self::new(
+            InteractionKind::DraftReview,
+            serde_json::json!({
+                "draft_id": draft_id.to_string(),
+                "summary": summary,
+                "artifact_count": artifact_count,
+            }),
+            Urgency::Blocking,
+        )
+    }
+
+    /// Create a PlanNegotiation interaction request.
+    pub fn plan_negotiation(phase: &str, proposed_status: &str) -> Self {
+        Self::new(
+            InteractionKind::PlanNegotiation,
+            serde_json::json!({
+                "phase": phase,
+                "proposed_status": proposed_status,
+            }),
+            Urgency::Blocking,
+        )
+    }
+
+    /// Create an Escalation interaction request.
+    pub fn escalation(reason: &str, details: serde_json::Value) -> Self {
+        Self::new(
+            InteractionKind::Escalation,
+            serde_json::json!({
+                "reason": reason,
+                "details": details,
+            }),
+            Urgency::Blocking,
+        )
+    }
+}
+
+impl fmt::Display for InteractionRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{}] {} (urgency: {})",
+            self.interaction_id, self.kind, self.urgency
+        )
+    }
+}
+
+/// The human's decision in response to an InteractionRequest.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "decision")]
+pub enum Decision {
+    /// Approved — proceed as proposed.
+    Approve,
+    /// Rejected — do not proceed, with explanation.
+    Reject { reason: String },
+    /// Human wants to discuss further before deciding.
+    Discuss,
+    /// Skip this interaction for now (non-blocking interactions only).
+    SkipForNow,
+}
+
+impl fmt::Display for Decision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Decision::Approve => write!(f, "approved"),
+            Decision::Reject { reason } => write!(f, "rejected: {}", reason),
+            Decision::Discuss => write!(f, "discuss"),
+            Decision::SkipForNow => write!(f, "skipped"),
+        }
+    }
+}
+
+/// The human's response to an InteractionRequest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InteractionResponse {
+    /// Correlation ID — must match the InteractionRequest.interaction_id.
+    pub interaction_id: Uuid,
+
+    /// The human's decision.
+    pub decision: Decision,
+
+    /// Optional free-text reasoning or feedback.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<String>,
+
+    /// When the response was created.
+    pub responded_at: DateTime<Utc>,
+
+    /// Who responded (channel identity, e.g., "cli:tty0", "slack:U12345").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub responder_id: Option<String>,
+}
+
+impl InteractionResponse {
+    /// Create a new response for a given interaction.
+    pub fn new(interaction_id: Uuid, decision: Decision) -> Self {
+        Self {
+            interaction_id,
+            decision,
+            reasoning: None,
+            responded_at: Utc::now(),
+            responder_id: None,
+        }
+    }
+
+    /// Set reasoning text.
+    pub fn with_reasoning(mut self, reasoning: impl Into<String>) -> Self {
+        self.reasoning = Some(reasoning.into());
+        self
+    }
+
+    /// Set responder identity.
+    pub fn with_responder(mut self, responder_id: impl Into<String>) -> Self {
+        self.responder_id = Some(responder_id.into());
+        self
+    }
+}
+
+impl fmt::Display for InteractionResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}] {}", self.interaction_id, self.decision)
+    }
+}
+
+/// A non-blocking notification from TA to the human.
+/// Unlike InteractionRequest, no response is expected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Notification {
+    /// Unique notification ID.
+    pub notification_id: Uuid,
+
+    /// Human-readable message.
+    pub message: String,
+
+    /// Severity level for rendering.
+    pub level: NotificationLevel,
+
+    /// When the notification was created.
+    pub created_at: DateTime<Utc>,
+
+    /// Optional goal ID for context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal_id: Option<Uuid>,
+}
+
+impl Notification {
+    /// Create a new notification.
+    pub fn new(message: impl Into<String>, level: NotificationLevel) -> Self {
+        Self {
+            notification_id: Uuid::new_v4(),
+            message: message.into(),
+            level,
+            created_at: Utc::now(),
+            goal_id: None,
+        }
+    }
+
+    /// Set the goal ID.
+    pub fn with_goal_id(mut self, goal_id: Uuid) -> Self {
+        self.goal_id = Some(goal_id);
+        self
+    }
+
+    /// Create an info notification.
+    pub fn info(message: impl Into<String>) -> Self {
+        Self::new(message, NotificationLevel::Info)
+    }
+
+    /// Create a warning notification.
+    pub fn warning(message: impl Into<String>) -> Self {
+        Self::new(message, NotificationLevel::Warning)
+    }
+}
+
+/// Notification severity level.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NotificationLevel {
+    Debug,
+    Info,
+    Warning,
+    Error,
+}
+
+impl fmt::Display for NotificationLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NotificationLevel::Debug => write!(f, "debug"),
+            NotificationLevel::Info => write!(f, "info"),
+            NotificationLevel::Warning => write!(f, "warning"),
+            NotificationLevel::Error => write!(f, "error"),
+        }
+    }
+}
+
+/// Describes what a ReviewChannel implementation supports.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ChannelCapabilities {
+    /// Whether the channel supports async responses (human responds later, not inline).
+    pub supports_async: bool,
+
+    /// Whether the channel supports rich media (images, formatted diffs, etc.).
+    pub supports_rich_media: bool,
+
+    /// Whether the channel supports threaded discussions.
+    pub supports_threads: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interaction_request_creation() {
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Test draft", 3);
+        assert_eq!(req.kind, InteractionKind::DraftReview);
+        assert_eq!(req.urgency, Urgency::Blocking);
+        assert_eq!(req.context["artifact_count"], 3);
+        assert_eq!(req.context["summary"], "Test draft");
+    }
+
+    #[test]
+    fn interaction_request_with_metadata() {
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Test", 1)
+            .with_metadata("color", "yellow")
+            .with_goal_id(Uuid::new_v4());
+        assert_eq!(req.metadata.get("color").unwrap(), "yellow");
+        assert!(req.goal_id.is_some());
+    }
+
+    #[test]
+    fn plan_negotiation_request() {
+        let req = InteractionRequest::plan_negotiation("v0.4.2", "done");
+        assert_eq!(req.kind, InteractionKind::PlanNegotiation);
+        assert_eq!(req.context["phase"], "v0.4.2");
+        assert_eq!(req.context["proposed_status"], "done");
+    }
+
+    #[test]
+    fn escalation_request() {
+        let req = InteractionRequest::escalation(
+            "exceeded token budget",
+            serde_json::json!({"budget": 10000, "used": 15000}),
+        );
+        assert_eq!(req.kind, InteractionKind::Escalation);
+        assert_eq!(req.context["reason"], "exceeded token budget");
+    }
+
+    #[test]
+    fn interaction_response_creation() {
+        let id = Uuid::new_v4();
+        let resp = InteractionResponse::new(id, Decision::Approve)
+            .with_reasoning("looks good")
+            .with_responder("cli:tty0");
+        assert_eq!(resp.interaction_id, id);
+        assert_eq!(resp.decision, Decision::Approve);
+        assert_eq!(resp.reasoning.as_deref(), Some("looks good"));
+        assert_eq!(resp.responder_id.as_deref(), Some("cli:tty0"));
+    }
+
+    #[test]
+    fn decision_display() {
+        assert_eq!(format!("{}", Decision::Approve), "approved");
+        assert_eq!(
+            format!(
+                "{}",
+                Decision::Reject {
+                    reason: "missing tests".into()
+                }
+            ),
+            "rejected: missing tests"
+        );
+        assert_eq!(format!("{}", Decision::Discuss), "discuss");
+        assert_eq!(format!("{}", Decision::SkipForNow), "skipped");
+    }
+
+    #[test]
+    fn notification_creation() {
+        let goal_id = Uuid::new_v4();
+        let notif = Notification::info("Sub-goal 2 of 5 started").with_goal_id(goal_id);
+        assert_eq!(notif.level, NotificationLevel::Info);
+        assert_eq!(notif.goal_id, Some(goal_id));
+    }
+
+    #[test]
+    fn interaction_request_serialization_round_trip() {
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Test", 2)
+            .with_metadata("thread_id", "T123");
+        let json = serde_json::to_string(&req).unwrap();
+        let restored: InteractionRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.interaction_id, req.interaction_id);
+        assert_eq!(restored.kind, InteractionKind::DraftReview);
+        assert_eq!(restored.metadata.get("thread_id").unwrap(), "T123");
+    }
+
+    #[test]
+    fn interaction_response_serialization_round_trip() {
+        let resp = InteractionResponse::new(
+            Uuid::new_v4(),
+            Decision::Reject {
+                reason: "needs refactor".into(),
+            },
+        )
+        .with_reasoning("too complex");
+        let json = serde_json::to_string(&resp).unwrap();
+        let restored: InteractionResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.decision, resp.decision);
+        assert_eq!(restored.reasoning.as_deref(), Some("too complex"));
+    }
+
+    #[test]
+    fn notification_serialization_round_trip() {
+        let notif = Notification::warning("Drift detected");
+        let json = serde_json::to_string(&notif).unwrap();
+        let restored: Notification = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.message, "Drift detected");
+        assert_eq!(restored.level, NotificationLevel::Warning);
+    }
+
+    #[test]
+    fn channel_capabilities_defaults() {
+        let caps = ChannelCapabilities::default();
+        assert!(!caps.supports_async);
+        assert!(!caps.supports_rich_media);
+        assert!(!caps.supports_threads);
+    }
+
+    #[test]
+    fn interaction_kind_custom() {
+        let kind = InteractionKind::Custom("webhook_alert".into());
+        assert_eq!(format!("{}", kind), "custom:webhook_alert");
+
+        let json = serde_json::to_string(&kind).unwrap();
+        let restored: InteractionKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, kind);
+    }
+
+    #[test]
+    fn interaction_request_display() {
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Test", 1);
+        let display = format!("{}", req);
+        assert!(display.contains("draft_review"));
+        assert!(display.contains("blocking"));
+    }
+}

--- a/crates/ta-changeset/src/lib.rs
+++ b/crates/ta-changeset/src/lib.rs
@@ -14,13 +14,16 @@ pub mod diff_handlers;
 pub mod draft_package;
 pub mod error;
 pub mod explanation;
+pub mod interaction;
 pub mod interactive_session_store;
 pub mod output_adapters;
 pub mod pr_package;
+pub mod review_channel;
 pub mod review_session;
 pub mod review_session_store;
 pub mod session_channel;
 pub mod supervisor;
+pub mod terminal_channel;
 pub mod uri_pattern;
 
 pub use changeset::{ChangeKind, ChangeSet, CommitIntent};
@@ -29,8 +32,13 @@ pub use diff_handlers::{DiffHandlerError, DiffHandlersConfig, HandlerRule};
 pub use draft_package::{DraftPackage, DraftStatus, ExplanationTiers};
 pub use error::ChangeSetError;
 pub use explanation::ExplanationSidecar;
+pub use interaction::{
+    ChannelCapabilities, Decision, InteractionKind, InteractionRequest, InteractionResponse,
+    Notification, NotificationLevel, Urgency,
+};
 pub use interactive_session_store::InteractiveSessionStore;
 pub use output_adapters::{DetailLevel, OutputAdapter, OutputFormat, RenderContext};
+pub use review_channel::{ReviewChannel, ReviewChannelConfig, ReviewChannelError};
 pub use review_session::{
     ArtifactReview, Comment, CommentThread, DispositionCounts, ReviewReasoning, ReviewSession,
     ReviewState, SessionNote,
@@ -43,6 +51,7 @@ pub use session_channel::{
 pub use supervisor::{
     DependencyGraph, SupervisorAgent, ValidationError, ValidationResult, ValidationWarning,
 };
+pub use terminal_channel::{AutoApproveChannel, TerminalChannel};
 pub use uri_pattern::{filter_uris, matches_uri};
 
 // Backwards compatibility: export old names as aliases

--- a/crates/ta-changeset/src/review_channel.rs
+++ b/crates/ta-changeset/src/review_channel.rs
@@ -1,0 +1,160 @@
+// review_channel.rs — ReviewChannel trait for pluggable human-agent communication.
+//
+// Unlike SessionChannel (which streams agent output), ReviewChannel is for
+// bidirectional interactions where TA needs human input: draft review, plan
+// approval, escalation, etc. Implementations can target any medium — terminal,
+// Slack, Discord, email, webhook.
+//
+// This is the core abstraction for v0.4.1.1 (Runtime Channel Architecture).
+// Future adapters (v0.5.3) implement this same trait for non-terminal mediums.
+
+use std::fmt;
+
+use crate::interaction::{
+    ChannelCapabilities, InteractionRequest, InteractionResponse, Notification,
+};
+
+/// Errors from ReviewChannel operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ReviewChannelError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("channel closed")]
+    ChannelClosed,
+
+    #[error("channel timeout")]
+    Timeout,
+
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+
+    #[error("channel error: {0}")]
+    Other(String),
+}
+
+/// Bidirectional communication channel between agent and human reviewer.
+///
+/// Implementations handle delivery (terminal, Slack, email, etc.) and
+/// response collection. The trait is interaction-agnostic — it carries
+/// any TA interaction, not just draft reviews.
+///
+/// # Blocking Semantics
+///
+/// `request_interaction` is blocking: the caller (MCP tool handler) waits
+/// until the human responds. This is the default for v0.4.1.1. Future phases
+/// may add non-blocking modes where the agent continues and checks back later.
+pub trait ReviewChannel: Send + Sync {
+    /// Send an interaction request to the human and await their response.
+    ///
+    /// This is a blocking call — the MCP tool handler suspends until the
+    /// human provides a decision through whatever medium this channel uses.
+    fn request_interaction(
+        &self,
+        request: &InteractionRequest,
+    ) -> Result<InteractionResponse, ReviewChannelError>;
+
+    /// Non-blocking notification to the human.
+    ///
+    /// Used for status updates, progress reports, and informational messages
+    /// that don't require a response.
+    fn notify(&self, notification: &Notification) -> Result<(), ReviewChannelError>;
+
+    /// What this channel supports (async responses, rich media, threads, etc.).
+    fn capabilities(&self) -> ChannelCapabilities;
+
+    /// Channel identity string for audit trail (e.g., "terminal:tty0", "slack:C04ABC").
+    fn channel_id(&self) -> &str;
+}
+
+/// Configuration for selecting and configuring a ReviewChannel.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ReviewChannelConfig {
+    /// Channel type: "terminal" (default), future: "slack", "discord", "email", "webhook".
+    #[serde(default = "default_channel_type")]
+    pub channel_type: String,
+
+    /// Whether the agent blocks on approval (default: true).
+    #[serde(default = "default_true")]
+    pub blocking_mode: bool,
+
+    /// Notification level filter: "debug", "info", "warning", "error".
+    #[serde(default = "default_notification_level")]
+    pub notification_level: String,
+}
+
+fn default_channel_type() -> String {
+    "terminal".to_string()
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_notification_level() -> String {
+    "info".to_string()
+}
+
+impl Default for ReviewChannelConfig {
+    fn default() -> Self {
+        Self {
+            channel_type: default_channel_type(),
+            blocking_mode: true,
+            notification_level: default_notification_level(),
+        }
+    }
+}
+
+impl fmt::Display for ReviewChannelConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "channel={}, blocking={}, notify_level={}",
+            self.channel_type, self.blocking_mode, self.notification_level
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn review_channel_config_defaults() {
+        let config = ReviewChannelConfig::default();
+        assert_eq!(config.channel_type, "terminal");
+        assert!(config.blocking_mode);
+        assert_eq!(config.notification_level, "info");
+    }
+
+    #[test]
+    fn review_channel_config_serialization() {
+        let config = ReviewChannelConfig {
+            channel_type: "slack".into(),
+            blocking_mode: false,
+            notification_level: "debug".into(),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: ReviewChannelConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.channel_type, "slack");
+        assert!(!restored.blocking_mode);
+        assert_eq!(restored.notification_level, "debug");
+    }
+
+    #[test]
+    fn review_channel_config_display() {
+        let config = ReviewChannelConfig::default();
+        let display = format!("{}", config);
+        assert!(display.contains("terminal"));
+        assert!(display.contains("blocking=true"));
+    }
+
+    #[test]
+    fn review_channel_error_display() {
+        let err = ReviewChannelError::ChannelClosed;
+        assert_eq!(format!("{}", err), "channel closed");
+
+        let err = ReviewChannelError::InvalidResponse("bad json".into());
+        assert_eq!(format!("{}", err), "invalid response: bad json");
+    }
+}

--- a/crates/ta-changeset/src/terminal_channel.rs
+++ b/crates/ta-changeset/src/terminal_channel.rs
@@ -1,0 +1,471 @@
+// terminal_channel.rs — Terminal-based ReviewChannel adapter.
+//
+// The default ReviewChannel implementation for v0.4.1.1. Renders interaction
+// requests to stdout with formatting, collects responses from stdin.
+// Supports mock I/O for testing.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::sync::Mutex;
+
+use crate::interaction::{
+    ChannelCapabilities, Decision, InteractionKind, InteractionRequest, InteractionResponse,
+    Notification, NotificationLevel,
+};
+use crate::review_channel::{ReviewChannel, ReviewChannelError};
+
+/// A ReviewChannel that uses stdin/stdout for human interaction.
+///
+/// Renders interaction requests as formatted text, prompts for input,
+/// and parses responses into InteractionResponse values.
+pub struct TerminalChannel {
+    reader: Mutex<BufReader<Box<dyn Read + Send>>>,
+    writer: Mutex<Box<dyn Write + Send>>,
+    channel_id: String,
+}
+
+impl TerminalChannel {
+    /// Create a TerminalChannel from raw reader/writer.
+    /// Use `TerminalChannel::stdio()` for real terminal, or pass mock I/O for tests.
+    pub fn new(
+        reader: Box<dyn Read + Send>,
+        writer: Box<dyn Write + Send>,
+        channel_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            reader: Mutex::new(BufReader::new(reader)),
+            writer: Mutex::new(writer),
+            channel_id: channel_id.into(),
+        }
+    }
+
+    /// Create a TerminalChannel that reads/writes to real stdin/stdout.
+    pub fn stdio() -> Self {
+        Self::new(
+            Box::new(std::io::stdin()),
+            Box::new(std::io::stdout()),
+            "terminal:stdio",
+        )
+    }
+
+    /// Render an interaction request as formatted text.
+    fn render_request(&self, request: &InteractionRequest) -> String {
+        let mut out = String::new();
+        out.push('\n');
+        out.push_str(&"=".repeat(60));
+        out.push('\n');
+
+        match &request.kind {
+            InteractionKind::DraftReview => {
+                out.push_str("  DRAFT REVIEW REQUIRED\n");
+                out.push_str(&"-".repeat(60));
+                out.push('\n');
+                if let Some(summary) = request.context.get("summary").and_then(|v| v.as_str()) {
+                    out.push_str(&format!("  Summary: {}\n", summary));
+                }
+                if let Some(count) = request
+                    .context
+                    .get("artifact_count")
+                    .and_then(|v| v.as_u64())
+                {
+                    out.push_str(&format!("  Artifacts: {}\n", count));
+                }
+                if let Some(draft_id) = request.context.get("draft_id").and_then(|v| v.as_str()) {
+                    out.push_str(&format!("  Draft ID: {}\n", draft_id));
+                }
+            }
+            InteractionKind::PlanNegotiation => {
+                out.push_str("  PLAN UPDATE PROPOSED\n");
+                out.push_str(&"-".repeat(60));
+                out.push('\n');
+                if let Some(phase) = request.context.get("phase").and_then(|v| v.as_str()) {
+                    out.push_str(&format!("  Phase: {}\n", phase));
+                }
+                if let Some(status) = request
+                    .context
+                    .get("proposed_status")
+                    .and_then(|v| v.as_str())
+                {
+                    out.push_str(&format!("  Proposed status: {}\n", status));
+                }
+            }
+            InteractionKind::ApprovalDiscussion => {
+                out.push_str("  APPROVAL REQUIRED\n");
+                out.push_str(&"-".repeat(60));
+                out.push('\n');
+                if let Some(msg) = request.context.as_str() {
+                    out.push_str(&format!("  {}\n", msg));
+                }
+            }
+            InteractionKind::Escalation => {
+                out.push_str("  ESCALATION\n");
+                out.push_str(&"-".repeat(60));
+                out.push('\n');
+                if let Some(reason) = request.context.get("reason").and_then(|v| v.as_str()) {
+                    out.push_str(&format!("  Reason: {}\n", reason));
+                }
+            }
+            InteractionKind::Custom(name) => {
+                out.push_str(&format!("  INTERACTION: {}\n", name.to_uppercase()));
+                out.push_str(&"-".repeat(60));
+                out.push('\n');
+            }
+        }
+
+        out.push_str(&"-".repeat(60));
+        out.push('\n');
+        out.push_str("  [a]pprove  [r]eject  [d]iscuss  [s]kip\n");
+        out.push_str(&"=".repeat(60));
+        out.push_str("\n> ");
+        out
+    }
+
+    /// Parse a user's text response into a Decision.
+    fn parse_decision(input: &str) -> Result<Decision, ReviewChannelError> {
+        let trimmed = input.trim().to_lowercase();
+        match trimmed.as_str() {
+            "a" | "approve" | "y" | "yes" => Ok(Decision::Approve),
+            "d" | "discuss" => Ok(Decision::Discuss),
+            "s" | "skip" => Ok(Decision::SkipForNow),
+            _ if trimmed.starts_with("r") || trimmed.starts_with("n") => {
+                // "r", "reject", "n", "no" — optionally followed by a reason
+                let reason = if trimmed.len() > 1 {
+                    // "reject: reason" or "r reason" or "r: reason"
+                    let rest = trimmed
+                        .trim_start_matches("reject")
+                        .trim_start_matches("no")
+                        .trim_start_matches('r')
+                        .trim_start_matches('n')
+                        .trim_start_matches(':')
+                        .trim();
+                    if rest.is_empty() {
+                        "rejected by reviewer".to_string()
+                    } else {
+                        rest.to_string()
+                    }
+                } else {
+                    "rejected by reviewer".to_string()
+                };
+                Ok(Decision::Reject { reason })
+            }
+            "" => Err(ReviewChannelError::InvalidResponse("empty response".into())),
+            _ => Err(ReviewChannelError::InvalidResponse(format!(
+                "unrecognized input: '{}'",
+                trimmed
+            ))),
+        }
+    }
+
+    /// Render a notification as formatted text.
+    fn render_notification(notification: &Notification) -> String {
+        let prefix = match notification.level {
+            NotificationLevel::Debug => "[DEBUG]",
+            NotificationLevel::Info => "[INFO]",
+            NotificationLevel::Warning => "[WARN]",
+            NotificationLevel::Error => "[ERROR]",
+        };
+        format!("{} {}\n", prefix, notification.message)
+    }
+}
+
+impl ReviewChannel for TerminalChannel {
+    fn request_interaction(
+        &self,
+        request: &InteractionRequest,
+    ) -> Result<InteractionResponse, ReviewChannelError> {
+        let rendered = self.render_request(request);
+
+        // Write the rendered request to output.
+        {
+            let mut writer = self
+                .writer
+                .lock()
+                .map_err(|e| ReviewChannelError::Other(format!("writer lock poisoned: {}", e)))?;
+            writer.write_all(rendered.as_bytes())?;
+            writer.flush()?;
+        }
+
+        // Read the response from input.
+        let mut line = String::new();
+        {
+            let mut reader = self
+                .reader
+                .lock()
+                .map_err(|e| ReviewChannelError::Other(format!("reader lock poisoned: {}", e)))?;
+            let bytes = reader.read_line(&mut line)?;
+            if bytes == 0 {
+                return Err(ReviewChannelError::ChannelClosed);
+            }
+        }
+
+        let decision = Self::parse_decision(&line)?;
+
+        Ok(InteractionResponse::new(request.interaction_id, decision)
+            .with_responder(&self.channel_id))
+    }
+
+    fn notify(&self, notification: &Notification) -> Result<(), ReviewChannelError> {
+        let rendered = Self::render_notification(notification);
+        let mut writer = self
+            .writer
+            .lock()
+            .map_err(|e| ReviewChannelError::Other(format!("writer lock poisoned: {}", e)))?;
+        writer.write_all(rendered.as_bytes())?;
+        writer.flush()?;
+        Ok(())
+    }
+
+    fn capabilities(&self) -> ChannelCapabilities {
+        ChannelCapabilities {
+            supports_async: false,
+            supports_rich_media: false,
+            supports_threads: false,
+        }
+    }
+
+    fn channel_id(&self) -> &str {
+        &self.channel_id
+    }
+}
+
+/// A no-op ReviewChannel that auto-approves all interactions.
+/// Useful for non-interactive/batch mode and testing.
+pub struct AutoApproveChannel {
+    channel_id: String,
+}
+
+impl AutoApproveChannel {
+    pub fn new() -> Self {
+        Self {
+            channel_id: "auto-approve".to_string(),
+        }
+    }
+}
+
+impl Default for AutoApproveChannel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReviewChannel for AutoApproveChannel {
+    fn request_interaction(
+        &self,
+        request: &InteractionRequest,
+    ) -> Result<InteractionResponse, ReviewChannelError> {
+        Ok(
+            InteractionResponse::new(request.interaction_id, Decision::Approve)
+                .with_responder(&self.channel_id),
+        )
+    }
+
+    fn notify(&self, _notification: &Notification) -> Result<(), ReviewChannelError> {
+        Ok(())
+    }
+
+    fn capabilities(&self) -> ChannelCapabilities {
+        ChannelCapabilities::default()
+    }
+
+    fn channel_id(&self) -> &str {
+        &self.channel_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interaction::Notification;
+    use std::io::Cursor;
+    use uuid::Uuid;
+
+    fn mock_channel(input: &str) -> (TerminalChannel, std::sync::Arc<Mutex<Vec<u8>>>) {
+        let output_buf = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let output_writer = output_buf.clone();
+
+        struct SharedWriter(std::sync::Arc<Mutex<Vec<u8>>>);
+        impl Write for SharedWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().write(buf)
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let reader = Box::new(Cursor::new(input.as_bytes().to_vec()));
+        let writer = Box::new(SharedWriter(output_writer));
+        let channel = TerminalChannel::new(reader, writer, "test:mock");
+        (channel, output_buf)
+    }
+
+    #[test]
+    fn approve_draft_review() {
+        let (channel, _output) = mock_channel("a\n");
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Test draft", 3);
+        let resp = channel.request_interaction(&req).unwrap();
+        assert_eq!(resp.decision, Decision::Approve);
+        assert_eq!(resp.interaction_id, req.interaction_id);
+        assert_eq!(resp.responder_id.as_deref(), Some("test:mock"));
+    }
+
+    #[test]
+    fn reject_with_reason() {
+        let (channel, _output) = mock_channel("reject: needs more tests\n");
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Draft", 1);
+        let resp = channel.request_interaction(&req).unwrap();
+        assert_eq!(
+            resp.decision,
+            Decision::Reject {
+                reason: "needs more tests".into()
+            }
+        );
+    }
+
+    #[test]
+    fn reject_shorthand() {
+        let (channel, _output) = mock_channel("r\n");
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Draft", 1);
+        let resp = channel.request_interaction(&req).unwrap();
+        assert!(matches!(resp.decision, Decision::Reject { .. }));
+    }
+
+    #[test]
+    fn discuss_response() {
+        let (channel, _output) = mock_channel("d\n");
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Draft", 1);
+        let resp = channel.request_interaction(&req).unwrap();
+        assert_eq!(resp.decision, Decision::Discuss);
+    }
+
+    #[test]
+    fn skip_response() {
+        let (channel, _output) = mock_channel("s\n");
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Draft", 1);
+        let resp = channel.request_interaction(&req).unwrap();
+        assert_eq!(resp.decision, Decision::SkipForNow);
+    }
+
+    #[test]
+    fn yes_is_approve() {
+        let (channel, _output) = mock_channel("yes\n");
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Draft", 1);
+        let resp = channel.request_interaction(&req).unwrap();
+        assert_eq!(resp.decision, Decision::Approve);
+    }
+
+    #[test]
+    fn empty_input_is_error() {
+        let (channel, _output) = mock_channel("\n");
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Draft", 1);
+        let result = channel.request_interaction(&req);
+        assert!(matches!(
+            result,
+            Err(ReviewChannelError::InvalidResponse(_))
+        ));
+    }
+
+    #[test]
+    fn eof_is_channel_closed() {
+        let (channel, _output) = mock_channel("");
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Draft", 1);
+        let result = channel.request_interaction(&req);
+        assert!(matches!(result, Err(ReviewChannelError::ChannelClosed)));
+    }
+
+    #[test]
+    fn renders_draft_review_output() {
+        let (channel, output) = mock_channel("a\n");
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Add auth module", 5);
+        channel.request_interaction(&req).unwrap();
+
+        let rendered = String::from_utf8(output.lock().unwrap().clone()).unwrap();
+        assert!(rendered.contains("DRAFT REVIEW REQUIRED"));
+        assert!(rendered.contains("Add auth module"));
+        assert!(rendered.contains("Artifacts: 5"));
+        assert!(rendered.contains("[a]pprove"));
+    }
+
+    #[test]
+    fn renders_plan_negotiation() {
+        let (channel, output) = mock_channel("a\n");
+        let req = InteractionRequest::plan_negotiation("v0.4.2", "done");
+        channel.request_interaction(&req).unwrap();
+
+        let rendered = String::from_utf8(output.lock().unwrap().clone()).unwrap();
+        assert!(rendered.contains("PLAN UPDATE PROPOSED"));
+        assert!(rendered.contains("v0.4.2"));
+    }
+
+    #[test]
+    fn notify_renders_to_output() {
+        let (channel, output) = mock_channel("");
+        let notif = Notification::info("Sub-goal 2 of 5 complete");
+        channel.notify(&notif).unwrap();
+
+        let rendered = String::from_utf8(output.lock().unwrap().clone()).unwrap();
+        assert!(rendered.contains("[INFO]"));
+        assert!(rendered.contains("Sub-goal 2 of 5 complete"));
+    }
+
+    #[test]
+    fn notify_warning_prefix() {
+        let (channel, output) = mock_channel("");
+        let notif = Notification::warning("Agent approaching token limit");
+        channel.notify(&notif).unwrap();
+
+        let rendered = String::from_utf8(output.lock().unwrap().clone()).unwrap();
+        assert!(rendered.contains("[WARN]"));
+    }
+
+    #[test]
+    fn channel_capabilities() {
+        let (channel, _) = mock_channel("");
+        let caps = channel.capabilities();
+        assert!(!caps.supports_async);
+        assert!(!caps.supports_rich_media);
+        assert!(!caps.supports_threads);
+    }
+
+    #[test]
+    fn channel_id_returns_configured_id() {
+        let (channel, _) = mock_channel("");
+        assert_eq!(channel.channel_id(), "test:mock");
+    }
+
+    #[test]
+    fn auto_approve_channel_approves_all() {
+        let channel = AutoApproveChannel::new();
+        let req = InteractionRequest::draft_review(Uuid::new_v4(), "Any draft", 10);
+        let resp = channel.request_interaction(&req).unwrap();
+        assert_eq!(resp.decision, Decision::Approve);
+        assert_eq!(resp.responder_id.as_deref(), Some("auto-approve"));
+    }
+
+    #[test]
+    fn auto_approve_channel_notify_is_noop() {
+        let channel = AutoApproveChannel::new();
+        let notif = Notification::info("test");
+        assert!(channel.notify(&notif).is_ok());
+    }
+
+    #[test]
+    fn parse_decision_variants() {
+        assert_eq!(
+            TerminalChannel::parse_decision("approve").unwrap(),
+            Decision::Approve
+        );
+        assert_eq!(
+            TerminalChannel::parse_decision("y").unwrap(),
+            Decision::Approve
+        );
+        assert_eq!(
+            TerminalChannel::parse_decision("discuss").unwrap(),
+            Decision::Discuss
+        );
+        assert_eq!(
+            TerminalChannel::parse_decision("skip").unwrap(),
+            Decision::SkipForNow
+        );
+        assert!(TerminalChannel::parse_decision("unknown").is_err());
+    }
+}

--- a/crates/ta-mcp-gateway/src/config.rs
+++ b/crates/ta-mcp-gateway/src/config.rs
@@ -8,6 +8,7 @@
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use ta_changeset::review_channel::ReviewChannelConfig;
 
 /// Configuration for the MCP gateway server.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,6 +36,10 @@ pub struct GatewayConfig {
 
     /// Directory for interactive session records (v0.3.1.2).
     pub interactive_sessions_dir: PathBuf,
+
+    /// ReviewChannel configuration (v0.4.1.1).
+    #[serde(default)]
+    pub review_channel: ReviewChannelConfig,
 }
 
 impl GatewayConfig {
@@ -51,6 +56,7 @@ impl GatewayConfig {
             events_log: ta_dir.join("events.jsonl"),
             pr_packages_dir: ta_dir.join("pr_packages"),
             interactive_sessions_dir: ta_dir.join("interactive_sessions"),
+            review_channel: ReviewChannelConfig::default(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.4.1.1 — Runtime Channel Architecture & Macro Session Loop

**Why**: Implement v0.4.1.1 — Runtime Channel Architecture & Macro Session Loop

**Impact**: 7 file(s) changed

## Changes (7 file(s))

- `~` `fs://workspace/PLAN.md` — Updated v0.4.1.1 section: marked completed with checklist of all deliverables, updated trait signature to match implementation (sync, not async), added AutoApproveChannel to adapter list
  - Reflects completion of the phase with accurate implementation details for future reference.
- `+` `fs://workspace/crates/ta-changeset/src/interaction.rs` — Added InteractionRequest, InteractionResponse, Decision, Notification, InteractionKind, Urgency, ChannelCapabilities types with full serialization support and builder methods (draft_review, plan_negotiation, escalation constructors)
  - Core protocol model for bidirectional human-agent communication — every interaction point (draft review, plan approval, escalation) uses these types. Required by the ReviewChannel trait and MCP gateway integration.
- `~` `fs://workspace/crates/ta-changeset/src/lib.rs` — Added module declarations (interaction, review_channel, terminal_channel) and public re-exports for all new types
  - Makes new types available to downstream crates (ta-mcp-gateway, ta-cli) through the ta-changeset public API.
- `+` `fs://workspace/crates/ta-changeset/src/review_channel.rs` — Added ReviewChannel trait (request_interaction, notify, capabilities, channel_id), ReviewChannelConfig (channel_type, blocking_mode, notification_level), and ReviewChannelError enum
  - Pluggable abstraction so TA can communicate with humans through any medium (terminal, Slack, email, webhook). Future adapters (v0.5.3) implement this same trait.
- `+` `fs://workspace/crates/ta-changeset/src/terminal_channel.rs` — Added TerminalChannel (renders interaction requests to stdout, parses stdin responses) and AutoApproveChannel (auto-approves all interactions for batch mode). TerminalChannel supports mock I/O for testing via constructor injection.
  - Default ReviewChannel implementation for terminal-based workflows. AutoApproveChannel enables non-interactive/CI usage without special-casing.
- `~` `fs://workspace/crates/ta-mcp-gateway/src/config.rs` — Added ReviewChannelConfig field to GatewayConfig with serde default, imported from ta-changeset
  - Allows channel configuration to be specified in the gateway config alongside existing settings (workspace_root, staging_dir, etc.)
- `~` `fs://workspace/crates/ta-mcp-gateway/src/server.rs` — Added review_channel field to GatewayState, set_review_channel/request_review/notify_reviewer methods. Updated ta_draft submit handler to route through ReviewChannel and return decision to agent (with macro goal PrReady→Running transition on approval). Updated ta_plan update handler to route through ReviewChannel.
  - Connects the ReviewChannel abstraction to the MCP tool handlers that agents call. This is the key integration point — when an agent calls ta_draft submit, the human is notified through whatever channel is configured and the agent receives the decision.

## Goal Context

- **Title**: Implement v0.4.1.1 — Runtime Channel Architecture & Macro Session Loop
- **Objective**: Implement v0.4.1.1 — Runtime Channel Architecture & Macro Session Loop
- **Goal ID**: `923683da-3699-4e59-b9d8-124a8b5eea6e`
- **PR ID**: `0b174e39-1706-448b-a711-dddea61e21a0`
- **Plan Phase**: `0.4.1.1`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
