### PR TITLE
Implement 0.4.1.2 — Follow-Up Draft Continuity

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -284,8 +284,19 @@ ta run "Fix clippy warnings from review" --follow-up
 
 # With detailed context
 ta run --follow-up --objective-file review-notes.md --source .
+```
 
-# The follow-up PR supersedes the parent (single unified diff)
+**Staging Reuse (v0.4.1.2)**: When the parent goal's staging directory still exists, `--follow-up` prompts to reuse it. Choosing "yes" (the default) means iterative work accumulates into a single unified draft — no disconnected packages.
+
+- **Extend** (default): Reuses parent staging. `ta draft build` produces a unified diff superseding the previous draft.
+- **Standalone**: Declines the prompt (or `follow_up.default_mode = "standalone"` in `.ta/workflow.toml`). Creates a fresh copy — both drafts remain independently reviewable.
+
+```toml
+# .ta/workflow.toml — follow-up behavior
+[follow_up]
+default_mode = "extend"       # "extend" or "standalone"
+auto_supersede = true          # auto-supersede parent draft when extending
+rebase_on_apply = true         # re-snapshot source for sequential applies
 ```
 
 ---
@@ -478,7 +489,7 @@ health_check = true        # Show warning on startup if stale drafts exist
 
 ### Auto-Close on Follow-Up
 
-When a follow-up goal's draft is applied, TA automatically closes the parent draft if it's still in PendingReview or Approved state.
+When a follow-up goal's draft is applied, TA automatically closes the parent draft if it's still in PendingReview or Approved state. **v0.4.1.2**: Auto-close only applies when the follow-up shares the same staging directory as the parent (extend case). Standalone follow-ups with separate staging leave the parent draft independently reviewable.
 
 ### Startup Health Check
 


### PR DESCRIPTION
## Summary

Changes from goal: Implement 0.4.1.2 — Follow-Up Draft Continuity

**Why**: Implement 0.4.1.2 — Follow-Up Draft Continuity

**Impact**: 5 file(s) changed

## Changes (5 file(s))

- `~` `fs://workspace/PLAN.md` — Updated v0.4.1.2 phase with completed items checklist and test results (6 tests added, 463 total).
  - Required documentation of phase progress per CLAUDE.md instructions.
- `~` `fs://workspace/apps/ta-cli/src/commands/draft.rs` — Fixed auto-supersede in build_package to only supersede when workspace_path matches parent (same staging). Fixed auto-close in apply_package with same check. Added rebase-on-apply: re-snapshots source when it has changed and rebase_on_apply is configured. Added 4 unit tests.
  - Bug fix: build_package was unconditionally superseding parent drafts even for standalone follow-ups with different staging, orphaning independent work. Rebase-on-apply enables sequential draft applies after source changes.
- `~` `fs://workspace/apps/ta-cli/src/commands/goal.rs` — Added check_parent_staging_eligible(), should_extend_parent_staging() with interactive prompt, and start_goal_extending_parent() for reusing parent workspace. Modified start_goal to branch on extend vs fresh copy. Added 2 unit tests.
  - Core feature: when --follow-up is used and parent staging exists, reuse it so iterative work accumulates into a single draft instead of creating disconnected packages.
- `~` `fs://workspace/crates/ta-submit/src/config.rs` — Added FollowUpConfig struct with default_mode (extend/standalone), auto_supersede, and rebase_on_apply fields to WorkflowConfig. Added 3 config tests.
  - Needed a configuration surface for follow-up behavior so users can control extend-vs-standalone default, auto-supersede, and rebase-on-apply.
- `~` `fs://workspace/docs/USAGE.md` — Documented staging reuse behavior in Follow-Up Goals section, added workflow.toml [follow_up] config example, updated Auto-Close section to note same-staging requirement.
  - New user-facing behavior needs documentation: staging reuse prompt, extend/standalone modes, config options.

## Goal Context

- **Title**: Implement 0.4.1.2 — Follow-Up Draft Continuity
- **Objective**: Implement 0.4.1.2 — Follow-Up Draft Continuity
- **Goal ID**: `06d6a66e-a318-4503-acc4-a7507832a74c`
- **PR ID**: `be4615a4-ebad-4e24-bc44-24de44e68982`
- **Plan Phase**: `0.4.1.2`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
