### PR TITLE
Implement v0.4.5 — CLI UX Polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.4.4-alpha"
+version = "0.4.5-alpha"
 dependencies = [
  "anyhow",
  "chrono",

--- a/PLAN.md
+++ b/PLAN.md
@@ -1138,13 +1138,13 @@ access:
 > **Depends on**: v0.4.1.1 (ReviewChannel + TerminalChannel). Remaining scope after v0.4.1.1 is PTY wrapping for real-time output streaming — the interaction protocol is handled by ReviewChannel.
 
 ### v0.4.5 — CLI UX Polish
-<!-- status: pending -->
+<!-- status: done -->
 **Goal**: Quality-of-life improvements across all CLI commands.
 
-- **Partial ID matching**: Accept 8+ character UUID prefixes in all `ta draft`, `ta goal`, and `ta session` commands (currently requires full UUID)
-- **Apply on PendingReview**: `ta draft apply` works directly on PendingReview drafts without requiring a separate `ta draft approve` first (auto-approves on apply)
-- **Terminal encoding safety**: Ensure disposition badges and status markers render cleanly in all terminal encodings (no garbled characters)
-- **Plan phase in `ta release run`**: Accept plan phase IDs (e.g., `0.4.1.2`) and auto-convert to semver release versions (`0.4.1-alpha.2`) per the versioning policy. Strip `v` prefix if provided.
+- ✅ **Partial ID matching**: Accept 8+ character UUID prefixes in all `ta draft`, `ta goal`, and `ta session` commands (currently requires full UUID)
+- ✅ **Apply on PendingReview**: `ta draft apply` works directly on PendingReview drafts without requiring a separate `ta draft approve` first (auto-approves on apply)
+- ✅ **Terminal encoding safety**: Ensure disposition badges and status markers render cleanly in all terminal encodings (no garbled characters)
+- ✅ **Plan phase in `ta release run`**: Accept plan phase IDs (e.g., `0.4.1.2`) and auto-convert to semver release versions (`0.4.1-alpha.2`) via configurable `version_policy` in `.ta/release.yaml`. Strip `v` prefix if provided.
 
 ---
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-cli"
-version = "0.4.4-alpha"
+version = "0.4.5-alpha"
 edition = "2021"
 description = "CLI for goals, PR review, and approvals in Trusted Autonomy"
 license = "Apache-2.0"

--- a/apps/ta-cli/src/commands/draft.rs
+++ b/apps/ta-cli/src/commands/draft.rs
@@ -571,7 +571,7 @@ fn build_package(
                 anyhow::anyhow!("No running goal found (use a goal ID or start a goal first)")
             })?
     } else {
-        let goal_uuid = Uuid::parse_str(goal_id)?;
+        let goal_uuid = resolve_goal_id_from_store(goal_id, &goal_store)?;
         goal_store
             .get(goal_uuid)?
             .ok_or_else(|| anyhow::anyhow!("Goal run not found: {}", goal_id))?
@@ -1067,7 +1067,7 @@ fn list_packages(
             if let Ok(goal_id) = Uuid::parse_str(&pkg.goal.goal_id) {
                 if let Ok(Some(goal)) = store.get(goal_id) {
                     if goal.parent_macro_id.is_some() {
-                        format!("  └ {}", truncate(&pkg.goal.title, 24))
+                        format!("  +- {}", truncate(&pkg.goal.title, 24))
                     } else if goal.is_macro {
                         format!("[M] {}", truncate(&pkg.goal.title, 24))
                     } else {
@@ -1153,7 +1153,7 @@ fn view_package(
     format_str: &str,
     color: bool,
 ) -> anyhow::Result<()> {
-    let package_id = Uuid::parse_str(id)?;
+    let package_id = resolve_draft_id(id, config)?;
     let pkg = load_package(config, package_id)?;
 
     // Parse detail level and format.
@@ -1233,7 +1233,7 @@ fn view_package(
 }
 
 fn approve_package(config: &GatewayConfig, id: &str, reviewer: &str) -> anyhow::Result<()> {
-    let package_id = Uuid::parse_str(id)?;
+    let package_id = resolve_draft_id(id, config)?;
     let mut pkg = load_package(config, package_id)?;
 
     if !matches!(pkg.status, DraftStatus::PendingReview) {
@@ -1272,7 +1272,7 @@ fn deny_package(
     reason: &str,
     reviewer: &str,
 ) -> anyhow::Result<()> {
-    let package_id = Uuid::parse_str(id)?;
+    let package_id = resolve_draft_id(id, config)?;
     let mut pkg = load_package(config, package_id)?;
 
     if !matches!(pkg.status, DraftStatus::PendingReview) {
@@ -1442,7 +1442,7 @@ fn apply_package(
     conflict_resolution: ta_workspace::ConflictResolution,
     patterns: SelectiveReviewPatterns,
 ) -> anyhow::Result<()> {
-    let package_id = Uuid::parse_str(id)?;
+    let package_id = resolve_draft_id(id, config)?;
     let mut pkg = load_package(config, package_id)?;
 
     // Check if selective review is enabled.
@@ -1492,10 +1492,10 @@ fn apply_package(
             for error in &validation.errors {
                 match error {
                     ta_changeset::supervisor::ValidationError::CyclicDependency { cycle } => {
-                        println!("  ❌ Cyclic dependency detected: {}", cycle.join(" → "));
+                        println!("  [!] Cyclic dependency detected: {}", cycle.join(" -> "));
                     }
                     ta_changeset::supervisor::ValidationError::SelfDependency { artifact } => {
-                        println!("  ❌ Self-dependency detected: {}", artifact);
+                        println!("  [!] Self-dependency detected: {}", artifact);
                     }
                 }
             }
@@ -1516,7 +1516,7 @@ fn apply_package(
                         required_by,
                     } => {
                         println!(
-                            "  ⚠️  Rejecting {} will break {} artifact(s) that depend on it:",
+                            "  [warn] Rejecting {} will break {} artifact(s) that depend on it:",
                             artifact.split('/').next_back().unwrap_or(artifact),
                             required_by.len()
                         );
@@ -1529,7 +1529,7 @@ fn apply_package(
                         depends_on_rejected,
                     } => {
                         println!(
-                            "  ⚠️  Approving {} but it depends on {} rejected artifact(s):",
+                            "  [warn] Approving {} but it depends on {} rejected artifact(s):",
                             artifact.split('/').next_back().unwrap_or(artifact),
                             depends_on_rejected.len()
                         );
@@ -1538,7 +1538,7 @@ fn apply_package(
                         }
                     }
                     ValidationWarning::DiscussBlockingApproval { artifact, blocking } => {
-                        println!("  ⚠️  {} is marked for discussion but {} approved artifact(s) depend on it:",
+                        println!("  [warn] {} is marked for discussion but {} approved artifact(s) depend on it:",
                             artifact.split('/').next_back().unwrap_or(artifact),
                             blocking.len());
                         for blk in blocking {
@@ -1568,10 +1568,20 @@ fn apply_package(
 
         println!("Applying {} approved artifact(s)...", approved_count);
     } else {
-        // Legacy all-or-nothing mode: require Approved status.
-        if !matches!(pkg.status, DraftStatus::Approved { .. }) {
+        // All-or-nothing mode: accept Approved or PendingReview (auto-approve on apply).
+        if matches!(pkg.status, DraftStatus::PendingReview) {
+            pkg.status = DraftStatus::Approved {
+                approved_by: "auto (apply)".to_string(),
+                approved_at: Utc::now(),
+            };
+            save_package(config, &pkg)?;
+            println!(
+                "Auto-approved draft {} (apply implies approval).",
+                package_id
+            );
+        } else if !matches!(pkg.status, DraftStatus::Approved { .. }) {
             anyhow::bail!(
-                "Cannot apply package in {:?} state (must be Approved)",
+                "Cannot apply package in {:?} state (must be PendingReview or Approved)",
                 pkg.status
             );
         }
@@ -1635,7 +1645,7 @@ fn apply_package(
                         })
                     {
                         println!(
-                            "\nℹ️  Source changed since goal start — rebasing against current source."
+                            "\n[info] Source changed since goal start — rebasing against current source."
                         );
                         overlay.set_snapshot(fresh_snapshot);
                     }
@@ -1644,7 +1654,7 @@ fn apply_package(
                     if let Ok(Some(conflicts)) = overlay.detect_conflicts() {
                         if !conflicts.is_empty() {
                             println!(
-                                "\nℹ️  {} source file(s) changed since goal start.",
+                                "\n[info] {} source file(s) changed since goal start.",
                                 conflicts.len()
                             );
                             println!(
@@ -1802,7 +1812,7 @@ fn apply_package(
 
         match adapter.commit(goal, &pkg, &commit_msg) {
             Ok(result) => {
-                println!("✓ {}", result.message);
+                println!("[ok] {}", result.message);
             }
             Err(e) => {
                 eprintln!("Commit failed: {}", e);
@@ -1818,7 +1828,7 @@ fn apply_package(
             println!("Pushing to remote...");
             match adapter.push(goal) {
                 Ok(result) => {
-                    println!("✓ {}", result.message);
+                    println!("[ok] {}", result.message);
                 }
                 Err(e) => {
                     if adapter.name() != "none" {
@@ -1833,7 +1843,7 @@ fn apply_package(
             println!("Creating pull request...");
             match adapter.open_review(goal, &pkg) {
                 Ok(result) => {
-                    println!("✓ {}", result.message);
+                    println!("[ok] {}", result.message);
                     if !result.review_url.starts_with("none://") {
                         println!("  PR URL: {}", result.review_url);
                     }
@@ -1890,10 +1900,10 @@ fn apply_package(
 
     // Post-apply validation summary: confirm state is consistent for the human.
     println!();
-    println!("── Post-Apply Status ──");
-    println!("  Draft:  {} → applied", id);
+    println!("-- Post-Apply Status --");
+    println!("  Draft:  {} -> applied", id);
     println!(
-        "  Goal:   {} → applied",
+        "  Goal:   {} -> applied",
         goal.goal_run_id.to_string().get(..8).unwrap_or("?")
     );
     if let Some(ref phase) = goal.plan_phase {
@@ -1908,15 +1918,15 @@ fn apply_package(
                     super::plan::PlanStatus::Pending => "pending",
                 };
                 if p.status == super::plan::PlanStatus::Done {
-                    println!("  Plan:   {} → {}", phase, status_str);
+                    println!("  Plan:   {} -> {}", phase, status_str);
                 } else {
                     eprintln!(
-                        "  ⚠ Plan:  {} is still '{}' — expected 'done'. Check PLAN.md.",
+                        "  [warn] Plan: {} is still '{}' -- expected 'done'. Check PLAN.md.",
                         phase, status_str
                     );
                 }
             } else {
-                eprintln!("  ⚠ Plan:  phase '{}' not found in PLAN.md", phase);
+                eprintln!("  [warn] Plan: phase '{}' not found in PLAN.md", phase);
             }
         }
     }
@@ -1948,7 +1958,7 @@ fn amend_package(
     reason: Option<&str>,
     amended_by: &str,
 ) -> anyhow::Result<()> {
-    let package_id = Uuid::parse_str(id)?;
+    let package_id = resolve_draft_id(id, config)?;
     let mut pkg = load_package(config, package_id)?;
 
     // Only allow amendment on drafts in review states.
@@ -2220,7 +2230,7 @@ fn fix_package(
     agent: &str,
     no_launch: bool,
 ) -> anyhow::Result<()> {
-    let package_id = Uuid::parse_str(id)?;
+    let package_id = resolve_draft_id(id, config)?;
     let pkg = load_package(config, package_id)?;
 
     // Only allow fix on drafts in review states.
@@ -2343,7 +2353,7 @@ fn close_package(
     reason: Option<&str>,
     closed_by: &str,
 ) -> anyhow::Result<()> {
-    let package_id = Uuid::parse_str(id)?;
+    let package_id = resolve_draft_id(id, config)?;
     let mut pkg = load_package(config, package_id)?;
 
     // Only allow closing drafts that are in non-terminal states.
@@ -2463,7 +2473,7 @@ fn gc_packages(config: &GatewayConfig, dry_run: bool, archive: bool) -> anyhow::
             } else {
                 std::fs::rename(&goal.workspace_path, &archive_dest)?;
                 println!(
-                    "Archived: {} → {}",
+                    "Archived: {} -> {}",
                     goal.workspace_path.display(),
                     archive_dest.display()
                 );
@@ -2552,11 +2562,76 @@ fn truncate(s: &str, max: usize) -> String {
     format!("{}...", &s[..end])
 }
 
+/// Resolve a draft ID from a full UUID or an 8+ character prefix.
+///
+/// Tries exact UUID parse first. On failure, scans all draft packages for
+/// a unique prefix match. Returns an error if the prefix is ambiguous or
+/// matches nothing.
+fn resolve_draft_id(id: &str, config: &GatewayConfig) -> anyhow::Result<Uuid> {
+    // Fast path: exact UUID.
+    if let Ok(uuid) = Uuid::parse_str(id) {
+        return Ok(uuid);
+    }
+
+    if id.len() < 8 {
+        anyhow::bail!(
+            "ID prefix '{}' is too short — use at least 8 characters (or a full UUID)",
+            id
+        );
+    }
+
+    let packages = load_all_packages(config)?;
+    let matches: Vec<_> = packages
+        .iter()
+        .filter(|p| p.package_id.to_string().starts_with(id))
+        .collect();
+
+    match matches.len() {
+        0 => anyhow::bail!("No draft found matching '{}'", id),
+        1 => Ok(matches[0].package_id),
+        n => anyhow::bail!(
+            "Ambiguous prefix '{}' matches {} drafts. Use a longer prefix.",
+            id,
+            n
+        ),
+    }
+}
+
+/// Resolve a goal ID from a full UUID or an 8+ character prefix.
+fn resolve_goal_id_from_store(id: &str, store: &GoalRunStore) -> anyhow::Result<Uuid> {
+    if let Ok(uuid) = Uuid::parse_str(id) {
+        return Ok(uuid);
+    }
+
+    if id.len() < 8 {
+        anyhow::bail!(
+            "ID prefix '{}' is too short — use at least 8 characters (or a full UUID)",
+            id
+        );
+    }
+
+    let goals = store.list()?;
+    let matches: Vec<_> = goals
+        .iter()
+        .filter(|g| g.goal_run_id.to_string().starts_with(id))
+        .collect();
+
+    match matches.len() {
+        0 => anyhow::bail!("No goal found matching '{}'", id),
+        1 => Ok(matches[0].goal_run_id),
+        n => anyhow::bail!(
+            "Ambiguous prefix '{}' matches {} goals. Use a longer prefix.",
+            id,
+            n
+        ),
+    }
+}
+
 // ── Review Session Commands ────────────────────────────────────
 
 /// Start or resume a review session for a draft package.
 fn review_start(config: &GatewayConfig, draft_id: &str, reviewer: &str) -> anyhow::Result<()> {
-    let package_id = Uuid::parse_str(draft_id)?;
+    let package_id = resolve_draft_id(draft_id, config)?;
     let pkg = load_package(config, package_id)?;
 
     // Create the review sessions directory in .ta/review_sessions/
@@ -2733,8 +2808,20 @@ fn review_finish(config: &GatewayConfig, session_id: Option<&str>) -> anyhow::Re
 
     // Load the session.
     let mut session = if let Some(id) = session_id {
-        let uuid = Uuid::parse_str(id)?;
-        store.load(uuid)?
+        if let Ok(uuid) = Uuid::parse_str(id) {
+            store.load(uuid)?
+        } else {
+            let all = store.list()?;
+            let matches: Vec<_> = all
+                .into_iter()
+                .filter(|s| s.session_id.to_string().starts_with(id))
+                .collect();
+            match matches.len() {
+                0 => anyhow::bail!("No review session found matching '{}'", id),
+                1 => matches.into_iter().next().unwrap(),
+                n => anyhow::bail!("Ambiguous prefix '{}' matches {} sessions", id, n),
+            }
+        }
     } else {
         // Use the most recent active session.
         let sessions = store.list()?;
@@ -2759,7 +2846,7 @@ fn review_finish(config: &GatewayConfig, session_id: Option<&str>) -> anyhow::Re
 
     if counts.pending > 0 {
         println!(
-            "⚠️  Warning: {} artifact(s) were not explicitly reviewed.",
+            "[warn] Warning: {} artifact(s) were not explicitly reviewed.",
             counts.pending
         );
         println!();
@@ -2767,7 +2854,7 @@ fn review_finish(config: &GatewayConfig, session_id: Option<&str>) -> anyhow::Re
 
     if session.has_unresolved_discuss() {
         println!(
-            "⚠️  Warning: {} artifact(s) marked for discussion remain unresolved.",
+            "[warn] Warning: {} artifact(s) marked for discussion remain unresolved.",
             counts.discuss
         );
         println!();
@@ -2801,7 +2888,7 @@ fn review_list(config: &GatewayConfig, draft_filter: Option<&str>) -> anyhow::Re
 
     // Apply draft filter if specified.
     let sessions: Vec<_> = if let Some(draft_id) = draft_filter {
-        let draft_uuid = Uuid::parse_str(draft_id)?;
+        let draft_uuid = resolve_draft_id(draft_id, config)?;
         all_sessions
             .into_iter()
             .filter(|s| s.draft_package_id == draft_uuid)
@@ -2842,8 +2929,20 @@ fn review_show(config: &GatewayConfig, session_id: Option<&str>) -> anyhow::Resu
 
     // Load the session.
     let session = if let Some(id) = session_id {
-        let uuid = Uuid::parse_str(id)?;
-        store.load(uuid)?
+        if let Ok(uuid) = Uuid::parse_str(id) {
+            store.load(uuid)?
+        } else {
+            let all = store.list()?;
+            let matches: Vec<_> = all
+                .into_iter()
+                .filter(|s| s.session_id.to_string().starts_with(id))
+                .collect();
+            match matches.len() {
+                0 => anyhow::bail!("No review session found matching '{}'", id),
+                1 => matches.into_iter().next().unwrap(),
+                n => anyhow::bail!("Ambiguous prefix '{}' matches {} sessions", id, n),
+            }
+        }
     } else {
         // Use the most recent active session.
         let sessions = store.list()?;
@@ -4411,5 +4510,67 @@ mod tests {
             "Expected PendingReview (not superseded), got {:?}",
             parent_pkg.status
         );
+    }
+
+    // ── v0.4.5 Partial ID matching tests ──────────────────────────────
+
+    #[test]
+    fn resolve_draft_id_exact_uuid() {
+        let project = TempDir::new().unwrap();
+        let config = GatewayConfig::for_project(project.path());
+
+        // Create a draft package to resolve.
+        std::fs::write(project.path().join("README.md"), "# Hello\n").unwrap();
+        let goal_store = GoalRunStore::new(&config.goals_dir).unwrap();
+        super::super::goal::execute(
+            &super::super::goal::GoalCommands::Start {
+                title: "Prefix test".to_string(),
+                source: Some(project.path().to_path_buf()),
+                objective: "Test prefix matching".to_string(),
+                agent: "test-agent".to_string(),
+                phase: None,
+                follow_up: None,
+                objective_file: None,
+            },
+            &config,
+        )
+        .unwrap();
+        let goals = goal_store.list().unwrap();
+        let goal_id = goals[0].goal_run_id.to_string();
+
+        std::fs::write(goals[0].workspace_path.join("README.md"), "# Changed\n").unwrap();
+        build_package(&config, &goal_id, "Test", false).unwrap();
+
+        let pkgs = load_all_packages(&config).unwrap();
+        let pkg_id = pkgs[0].package_id;
+
+        // Exact UUID should resolve.
+        let resolved = resolve_draft_id(&pkg_id.to_string(), &config).unwrap();
+        assert_eq!(resolved, pkg_id);
+
+        // 8-char prefix should resolve.
+        let prefix = &pkg_id.to_string()[..8];
+        let resolved = resolve_draft_id(prefix, &config).unwrap();
+        assert_eq!(resolved, pkg_id);
+    }
+
+    #[test]
+    fn resolve_draft_id_rejects_short_prefix() {
+        let project = TempDir::new().unwrap();
+        let config = GatewayConfig::for_project(project.path());
+
+        let result = resolve_draft_id("abc", &config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too short"));
+    }
+
+    #[test]
+    fn resolve_draft_id_no_match() {
+        let project = TempDir::new().unwrap();
+        let config = GatewayConfig::for_project(project.path());
+
+        let result = resolve_draft_id("00000000", &config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No draft found"));
     }
 }

--- a/apps/ta-cli/src/commands/goal.rs
+++ b/apps/ta-cli/src/commands/goal.rs
@@ -418,6 +418,36 @@ fn start_goal(
     Ok(())
 }
 
+/// Resolve a goal ID from a full UUID or an 8+ character prefix.
+fn resolve_goal_id(id: &str, store: &GoalRunStore) -> anyhow::Result<Uuid> {
+    if let Ok(uuid) = Uuid::parse_str(id) {
+        return Ok(uuid);
+    }
+
+    if id.len() < 8 {
+        anyhow::bail!(
+            "ID prefix '{}' is too short -- use at least 8 characters (or a full UUID)",
+            id
+        );
+    }
+
+    let goals = store.list()?;
+    let matches: Vec<_> = goals
+        .iter()
+        .filter(|g| g.goal_run_id.to_string().starts_with(id))
+        .collect();
+
+    match matches.len() {
+        0 => anyhow::bail!("No goal found matching '{}'", id),
+        1 => Ok(matches[0].goal_run_id),
+        n => anyhow::bail!(
+            "Ambiguous prefix '{}' matches {} goals. Use a longer prefix.",
+            id,
+            n
+        ),
+    }
+}
+
 fn list_goals(store: &GoalRunStore, state: Option<&str>) -> anyhow::Result<()> {
     let goals = if let Some(state_filter) = state {
         store.list_by_state(state_filter)?
@@ -441,13 +471,13 @@ fn list_goals(store: &GoalRunStore, state: Option<&str>) -> anyhow::Result<()> {
             format!("[M] {}", truncate(&g.title, 24))
         } else if let Some(ref macro_id) = g.parent_macro_id {
             format!(
-                "  └ {} (← {})",
+                "  +- {} (<- {})",
                 truncate(&g.title, 16),
                 &macro_id.to_string()[..8]
             )
         } else if let Some(parent_id) = g.parent_goal_id {
             format!(
-                "{} (→ {})",
+                "{} (-> {})",
                 truncate(&g.title, 20),
                 &parent_id.to_string()[..8]
             )
@@ -469,7 +499,7 @@ fn list_goals(store: &GoalRunStore, state: Option<&str>) -> anyhow::Result<()> {
 }
 
 fn show_status(store: &GoalRunStore, id: &str) -> anyhow::Result<()> {
-    let goal_run_id = Uuid::parse_str(id)?;
+    let goal_run_id = resolve_goal_id(id, store)?;
     match store.get(goal_run_id)? {
         Some(g) => {
             println!("Goal Run: {}", g.goal_run_id);
@@ -534,7 +564,7 @@ fn show_status(store: &GoalRunStore, id: &str) -> anyhow::Result<()> {
 }
 
 fn delete_goal(store: &GoalRunStore, id: &str) -> anyhow::Result<()> {
-    let goal_run_id = uuid::Uuid::parse_str(id)?;
+    let goal_run_id = resolve_goal_id(id, store)?;
     let goal = store.get(goal_run_id)?;
 
     match goal {
@@ -644,7 +674,7 @@ fn execute_constitution(
 
         ConstitutionCommands::Propose { goal_id, agent } => {
             // Resolve the agent ID from the goal if not specified.
-            let goal_uuid = Uuid::parse_str(goal_id)?;
+            let goal_uuid = resolve_goal_id(goal_id, goal_store)?;
             let goal = goal_store
                 .get(goal_uuid)?
                 .ok_or_else(|| anyhow::anyhow!("Goal not found: {}", goal_id))?;
@@ -875,5 +905,42 @@ mod tests {
 
         // Verify staging directory is removed.
         assert!(!staging_path.exists());
+    }
+
+    #[test]
+    fn resolve_goal_id_by_prefix() {
+        let temp = TempDir::new().unwrap();
+        let config = GatewayConfig::for_project(temp.path());
+        let store = GoalRunStore::new(&config.goals_dir).unwrap();
+
+        execute(
+            &GoalCommands::Start {
+                title: "Prefix goal".to_string(),
+                source: Some(temp.path().to_path_buf()),
+                objective: "Test goal prefix matching".to_string(),
+                agent: "test-agent".to_string(),
+                phase: None,
+                follow_up: None,
+                objective_file: None,
+            },
+            &config,
+        )
+        .unwrap();
+
+        let goals = store.list().unwrap();
+        let goal_id = goals[0].goal_run_id;
+
+        // Full UUID resolves.
+        let resolved = resolve_goal_id(&goal_id.to_string(), &store).unwrap();
+        assert_eq!(resolved, goal_id);
+
+        // 8-char prefix resolves.
+        let prefix = &goal_id.to_string()[..8];
+        let resolved = resolve_goal_id(prefix, &store).unwrap();
+        assert_eq!(resolved, goal_id);
+
+        // Short prefix rejected.
+        let result = resolve_goal_id("abc", &store);
+        assert!(result.is_err());
     }
 }

--- a/apps/ta-cli/src/commands/release.rs
+++ b/apps/ta-cli/src/commands/release.rs
@@ -21,7 +21,7 @@ use ta_mcp_gateway::GatewayConfig;
 pub enum ReleaseCommands {
     /// Run the release pipeline for a new version.
     Run {
-        /// Target version (e.g., "0.4.0-alpha").
+        /// Target version (semver or plan phase ID, e.g., "0.4.0-alpha" or "v0.4.1.2").
         version: String,
 
         /// Skip approval gates (non-interactive / CI mode).
@@ -80,8 +80,64 @@ pub struct ReleasePipeline {
     /// Human-readable pipeline name.
     #[serde(default = "default_pipeline_name")]
     pub name: String,
+    /// How plan phase IDs (e.g., "0.4.1.2") are converted to semver versions.
+    #[serde(default)]
+    pub version_policy: VersionPolicy,
     /// Ordered list of pipeline steps.
     pub steps: Vec<PipelineStep>,
+}
+
+/// Configurable policy for converting plan phase IDs to semver release versions.
+///
+/// Each template supports placeholders `{0}`, `{1}`, `{2}`, `{3}` for the
+/// numeric segments of the input, plus `{pre}` for the `prerelease_suffix`.
+///
+/// Example YAML:
+/// ```yaml
+/// version_policy:
+///   prerelease_suffix: "alpha"
+///   two_segment: "{0}.{1}.0-{pre}"
+///   three_segment: "{0}.{1}.{2}-{pre}"
+///   four_segment: "{0}.{1}.{2}-{pre}.{3}"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionPolicy {
+    /// Prerelease label appended to bare versions (default: "alpha").
+    #[serde(default = "default_prerelease_suffix")]
+    pub prerelease_suffix: String,
+    /// Template for 2-segment inputs like "0.4". Default: "{0}.{1}.0-{pre}"
+    #[serde(default = "default_two_segment")]
+    pub two_segment: String,
+    /// Template for 3-segment inputs like "0.4.1". Default: "{0}.{1}.{2}-{pre}"
+    #[serde(default = "default_three_segment")]
+    pub three_segment: String,
+    /// Template for 4-segment inputs like "0.4.1.2". Default: "{0}.{1}.{2}-{pre}.{3}"
+    #[serde(default = "default_four_segment")]
+    pub four_segment: String,
+}
+
+fn default_prerelease_suffix() -> String {
+    "alpha".to_string()
+}
+fn default_two_segment() -> String {
+    "{0}.{1}.0-{pre}".to_string()
+}
+fn default_three_segment() -> String {
+    "{0}.{1}.{2}-{pre}".to_string()
+}
+fn default_four_segment() -> String {
+    "{0}.{1}.{2}-{pre}.{3}".to_string()
+}
+
+impl Default for VersionPolicy {
+    fn default() -> Self {
+        Self {
+            prerelease_suffix: default_prerelease_suffix(),
+            two_segment: default_two_segment(),
+            three_segment: default_three_segment(),
+            four_segment: default_four_segment(),
+        }
+    }
 }
 
 fn default_pipeline_name() -> String {
@@ -252,6 +308,40 @@ fn substitute_vars(template: &str, version: &str, commits: &str, last_tag: Optio
 
 // ── Pipeline execution ──────────────────────────────────────────
 
+/// Normalize a version string, accepting plan phase IDs and converting to semver.
+///
+/// Uses the `VersionPolicy` templates to control how segments map to semver.
+/// Strips leading `v` prefix. Passes through versions that already contain
+/// a hyphen (prerelease marker).
+fn normalize_version(input: &str, policy: &VersionPolicy) -> String {
+    // Strip leading `v` prefix.
+    let s = input.strip_prefix('v').unwrap_or(input);
+
+    // If it already contains a hyphen (prerelease), pass through as-is.
+    if s.contains('-') {
+        return s.to_string();
+    }
+
+    let parts: Vec<&str> = s.split('.').collect();
+    let template = match parts.len() {
+        2 => &policy.two_segment,
+        3 => &policy.three_segment,
+        4 => &policy.four_segment,
+        _ => return s.to_string(),
+    };
+
+    apply_version_template(template, &parts, &policy.prerelease_suffix)
+}
+
+/// Expand a version template with segment placeholders and prerelease suffix.
+fn apply_version_template(template: &str, parts: &[&str], prerelease: &str) -> String {
+    let mut result = template.replace("{pre}", prerelease);
+    for (i, part) in parts.iter().enumerate() {
+        result = result.replace(&format!("{{{}}}", i), part);
+    }
+    result
+}
+
 fn run_pipeline(
     config: &GatewayConfig,
     version: &str,
@@ -260,16 +350,20 @@ fn run_pipeline(
     from_step: Option<usize>,
     pipeline_path: Option<&Path>,
 ) -> anyhow::Result<()> {
+    let pipeline = load_pipeline(config, pipeline_path)?;
+
+    // Normalize plan phase IDs to semver using the pipeline's version policy.
+    let version = normalize_version(version, &pipeline.version_policy);
+    let version = version.as_str();
+
     // Validate version format.
     let version_re = regex::Regex::new(r"^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$")?;
     if !version_re.is_match(version) {
         anyhow::bail!(
-            "Invalid version '{}'. Expected semver (e.g., 0.4.0-alpha, 1.0.0)",
+            "Invalid version '{}'. Expected semver (e.g., 0.4.0-alpha, 1.0.0) or plan phase ID (e.g., v0.4.1.2)",
             version
         );
     }
-
-    let pipeline = load_pipeline(config, pipeline_path)?;
     let (commits, last_tag) = collect_commits_since_last_tag(&config.workspace_root)?;
 
     let total = pipeline.steps.len();
@@ -592,6 +686,15 @@ const DEFAULT_PIPELINE_YAML: &str = r#"# .ta/release.yaml — TA release pipelin
 
 name: ta-release
 
+# Version policy: controls how plan phase IDs are converted to semver.
+# Uncomment and edit to customize. Templates use {0}..{3} for segments, {pre} for the suffix.
+#
+# version_policy:
+#   prerelease_suffix: "alpha"
+#   two_segment: "{0}.{1}.0-{pre}"
+#   three_segment: "{0}.{1}.{2}-{pre}"
+#   four_segment: "{0}.{1}.{2}-{pre}.{3}"
+
 steps:
   - name: Preflight checks
     run: |
@@ -857,6 +960,7 @@ steps:
     fn validate_empty_pipeline_fails() {
         let pipeline = ReleasePipeline {
             name: "empty".to_string(),
+            version_policy: VersionPolicy::default(),
             steps: vec![],
         };
         assert!(validate_pipeline(&pipeline).is_err());
@@ -915,5 +1019,109 @@ steps:
 
         // Dry run should succeed even though the step would fail.
         run_pipeline(&config, "1.0.0", true, true, None, None).unwrap();
+    }
+
+    #[test]
+    fn normalize_version_strips_v_prefix() {
+        let p = VersionPolicy::default();
+        assert_eq!(normalize_version("v0.4.1", &p), "0.4.1-alpha");
+    }
+
+    #[test]
+    fn normalize_version_two_segments() {
+        let p = VersionPolicy::default();
+        assert_eq!(normalize_version("0.4", &p), "0.4.0-alpha");
+    }
+
+    #[test]
+    fn normalize_version_three_segments() {
+        let p = VersionPolicy::default();
+        assert_eq!(normalize_version("0.4.1", &p), "0.4.1-alpha");
+    }
+
+    #[test]
+    fn normalize_version_four_segments_to_prerelease() {
+        let p = VersionPolicy::default();
+        assert_eq!(normalize_version("0.4.1.2", &p), "0.4.1-alpha.2");
+        assert_eq!(normalize_version("v0.4.1.2", &p), "0.4.1-alpha.2");
+    }
+
+    #[test]
+    fn normalize_version_passthrough_semver() {
+        let p = VersionPolicy::default();
+        assert_eq!(normalize_version("0.4.0-alpha", &p), "0.4.0-alpha");
+        assert_eq!(normalize_version("1.0.0-beta.1", &p), "1.0.0-beta.1");
+    }
+
+    #[test]
+    fn normalize_version_custom_suffix() {
+        let p = VersionPolicy {
+            prerelease_suffix: "beta".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(normalize_version("0.4.1", &p), "0.4.1-beta");
+        assert_eq!(normalize_version("0.4.1.2", &p), "0.4.1-beta.2");
+    }
+
+    #[test]
+    fn normalize_version_custom_templates() {
+        let p = VersionPolicy {
+            prerelease_suffix: "rc".to_string(),
+            three_segment: "{0}.{1}.{2}".to_string(), // No prerelease for 3-segment
+            four_segment: "{0}.{1}.{2}-{pre}{3}".to_string(), // e.g., 0.4.1-rc2
+            ..Default::default()
+        };
+        assert_eq!(normalize_version("0.4.1", &p), "0.4.1");
+        assert_eq!(normalize_version("0.4.1.2", &p), "0.4.1-rc2");
+    }
+
+    #[test]
+    fn normalize_version_no_prerelease() {
+        let p = VersionPolicy {
+            prerelease_suffix: String::new(),
+            two_segment: "{0}.{1}.0".to_string(),
+            three_segment: "{0}.{1}.{2}".to_string(),
+            four_segment: "{0}.{1}.{2}.{3}".to_string(),
+        };
+        assert_eq!(normalize_version("0.4", &p), "0.4.0");
+        assert_eq!(normalize_version("1.2.3", &p), "1.2.3");
+        assert_eq!(normalize_version("1.2.3.4", &p), "1.2.3.4");
+    }
+
+    #[test]
+    fn version_policy_deserializes_from_yaml() {
+        let yaml = r#"
+prerelease_suffix: "beta"
+three_segment: "{0}.{1}.{2}"
+"#;
+        let policy: VersionPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(policy.prerelease_suffix, "beta");
+        assert_eq!(policy.three_segment, "{0}.{1}.{2}");
+        // Defaults for fields not specified.
+        assert_eq!(policy.two_segment, "{0}.{1}.0-{pre}");
+        assert_eq!(policy.four_segment, "{0}.{1}.{2}-{pre}.{3}");
+    }
+
+    #[test]
+    fn pipeline_with_version_policy() {
+        let yaml = r#"
+name: custom
+version_policy:
+  prerelease_suffix: "beta"
+  three_segment: "{0}.{1}.{2}"
+steps:
+  - name: test
+    run: echo hi
+"#;
+        let pipeline: ReleasePipeline = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(pipeline.version_policy.prerelease_suffix, "beta");
+        assert_eq!(
+            normalize_version("0.5.0", &pipeline.version_policy),
+            "0.5.0"
+        );
+        assert_eq!(
+            normalize_version("0.5.0.1", &pipeline.version_policy),
+            "0.5.0-beta.1"
+        );
     }
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: v0.4.4-alpha
+**Version**: v0.4.5-alpha
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 
@@ -123,6 +123,8 @@ ta draft approve <id>           # Mark as approved
 ta draft apply <id>             # Copy approved changes to your project
 ta draft close <id>             # Abandon without applying
 ```
+
+All `<id>` arguments accept either a full UUID or an 8+ character prefix (e.g., `ta draft view a1b2c3d4`). If a prefix is ambiguous, you'll be asked to use a longer one.
 
 For simple workflows, `ta draft apply` works directly on unapproved drafts (auto-approves on apply).
 
@@ -639,6 +641,10 @@ TA includes a YAML-driven release pipeline:
 # Run the built-in release pipeline
 ta release run 0.4.0-alpha
 
+# Use plan phase IDs -- auto-converted to semver
+ta release run v0.4.1.2           # becomes 0.4.1-alpha.2
+ta release run 0.4                # becomes 0.4.0-alpha
+
 # Preview without executing
 ta release run 0.4.0-alpha --dry-run
 
@@ -672,6 +678,22 @@ steps:
 ```
 
 Variables available: `${VERSION}`, `${TAG}`, `${COMMITS}`, `${LAST_TAG}`.
+
+The `version_policy` section controls how plan phase IDs are converted to semver. Templates use `{0}`..`{3}` for numeric segments and `{pre}` for the prerelease suffix:
+
+```yaml
+# .ta/release.yaml (customize version normalization)
+version_policy:
+  prerelease_suffix: "alpha"          # default suffix for bare versions
+  two_segment: "{0}.{1}.0-{pre}"     # 0.4 -> 0.4.0-alpha
+  three_segment: "{0}.{1}.{2}-{pre}" # 0.4.1 -> 0.4.1-alpha
+  four_segment: "{0}.{1}.{2}-{pre}.{3}"  # 0.4.1.2 -> 0.4.1-alpha.2
+```
+
+Examples for other projects:
+- **No prerelease**: set `three_segment: "{0}.{1}.{2}"` and `prerelease_suffix: ""`
+- **Beta channel**: set `prerelease_suffix: "beta"`
+- **RC numbering**: set `four_segment: "{0}.{1}.{2}-rc.{3}"`
 
 ### Versioning and Release Lifecycle
 
@@ -793,7 +815,7 @@ TA has a working end-to-end workflow: staging isolation, agent wrapping, draft r
 | v0.4.2 | Behavioral drift detection | Done |
 | v0.4.3 | Access constitutions | Done |
 | v0.4.4 | Interactive session completion (PTY) | Done |
-| v0.4.5 | CLI UX polish | Pending |
+| v0.4.5 | CLI UX polish | Done |
 
 ### What's Next (v0.5 -- v0.6)
 


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.4.5 — CLI UX Polish

**Why**: Implement v0.4.5 — CLI UX Polish

**Impact**: 7 file(s) changed

## Changes (7 file(s))

- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/PLAN.md` — Marked all 4 items in v0.4.5 phase as completed with checkmarks.
  - Reflect completed implementation work in the roadmap.
- `~` `fs://workspace/apps/ta-cli/Cargo.toml` — Bumped version from 0.4.4-alpha to 0.4.5-alpha.
  - Version bump for v0.4.5 phase completion.
- `~` `fs://workspace/apps/ta-cli/src/commands/draft.rs` — Added resolve_draft_id() and resolve_goal_id_from_store() helpers for 8+ character UUID prefix matching. Replaced all Uuid::parse_str() calls in user-facing functions (view, approve, deny, apply, amend, fix, close, review_start, review_finish, review_show, review_list) with prefix-aware resolution. In apply_package legacy path, PendingReview drafts are now auto-approved on apply. Replaced all emoji/Unicode characters (cross-mark, warning, check, info, arrows, box-drawing) with ASCII equivalents ([!], [warn], [ok], [info], ->, +-). Added 3 tests for prefix resolution.
  - UUIDs are hard to type in full. Auto-approve on apply eliminates a redundant step. Emoji characters render as garbled text on terminals without UTF-8/emoji support (CI, Windows CMD, bare TTYs).
- `~` `fs://workspace/apps/ta-cli/src/commands/goal.rs` — Added resolve_goal_id() helper for 8+ char UUID prefix matching. Updated show_status(), delete_goal(), and execute_constitution Propose to use it. Replaced Unicode tree/arrow characters with ASCII equivalents. Added 1 test for prefix resolution.
  - Same prefix-matching and terminal-safety improvements as draft.rs, applied to goal commands.
- `~` `fs://workspace/apps/ta-cli/src/commands/release.rs` — Added configurable VersionPolicy struct with template-based version normalization. Policy is defined in .ta/release.yaml under version_policy with fields: prerelease_suffix, two_segment, three_segment, four_segment. Templates use {0}..{3} placeholders for numeric segments and {pre} for the suffix. Default policy produces the existing alpha convention. normalize_version() now takes a &VersionPolicy parameter. ReleasePipeline struct gains a version_policy field (serde-defaulted for backward compat). Default pipeline YAML includes commented-out version_policy example. Added 10 tests including custom suffix, custom templates, no-prerelease, YAML deserialization, and pipeline integration.
  - Users think in plan phase IDs (v0.4.1.2) not semver (0.4.1-alpha.2). The release command should accept both. Made configurable rather than hard-coded so other projects can use different prerelease conventions (beta, rc, none).
- `~` `fs://workspace/docs/USAGE.md` — Added documentation for partial ID matching (8+ char prefix), auto-approve on apply, configurable version_policy in release.yaml with template examples, and plan phase ID normalization in ta release run. Updated v0.4.5 status to Done in the version table. Updated version header from v0.4.4-alpha to v0.4.5-alpha.
  - New user-facing features need to be documented.

## Goal Context

- **Title**: Implement v0.4.5 — CLI UX Polish
- **Objective**: Implement v0.4.5 — CLI UX Polish
- **Goal ID**: `76aae7ae-2b93-4a3b-b8d2-9b600c5142fd`
- **PR ID**: `710257eb-847a-4a0b-a37b-095d66299296`
- **Plan Phase**: `0.4.5`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
