### PR TITLE
Implement v0.5.6 — Framework-Agnostic Agent State

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.5.5-alpha"
+version = "0.5.6-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.5.0-alpha"
+version = "0.5.6-alpha"
 dependencies = [
  "chrono",
  "glob",

--- a/PLAN.md
+++ b/PLAN.md
@@ -1378,7 +1378,7 @@ Store/recall round-trip, semantic search returns relevant results, self-learning
 - ✅ Bug fix: macro session exit no longer errors when goal already applied/submitted via MCP
 
 ### v0.5.6 — Framework-Agnostic Agent State
-<!-- status: pending -->
+<!-- status: done -->
 **Goal**: Use TA's memory store as the canonical source of project state so users can switch between agentic frameworks (Claude Code, Codex, Cursor, Claude Flow, etc.) across tasks — or run them simultaneously — without losing context or locking into any framework's native state management.
 
 > **Problem today**: Each framework keeps its own state. Claude Code has CLAUDE.md and project memory. Codex has session state. Cursor has codebase indices. None of it transfers. When you switch agents mid-project, the new agent starts cold — it doesn't know what the previous agent learned, what conventions the human established, or what approaches were tried and rejected.
@@ -1440,6 +1440,18 @@ ta_context recall "test-conventions"
 
 #### Tests (minimum 6)
 Auto-capture on goal complete, auto-capture on rejection, context injection into CLAUDE.md, context injection via MCP tool, cross-framework recall (store from "claude-code", recall from "codex"), repeated-correction auto-promotion.
+
+#### Completed
+- ✅ `MemoryCategory` enum (convention, architecture, history, preference, relationship, other)
+- ✅ `StoreParams` with `goal_id` and `category` — `store_with_params()` on `MemoryStore` trait
+- ✅ `AutoCaptureConfig` parsed from `.ta/workflow.toml` `[memory.auto_capture]` section
+- ✅ `AutoCapture` event handlers: `on_goal_complete`, `on_draft_reject`, `on_human_guidance`, `check_repeated_correction`
+- ✅ `build_memory_context_section()` for CLAUDE.md injection from prior sessions
+- ✅ `ta_context` MCP tool extended: `source`, `goal_id`, `category` params; new `search` action
+- ✅ Draft submit wired: PrApproved/PrDenied events dispatched, rejection auto-captured to memory
+- ✅ `ta run` context injection: memory context section injected into CLAUDE.md at launch
+- ✅ `ta run` auto-capture: goal completion + change_summary captured after draft build
+- ✅ Tests: auto_capture_goal_complete, auto_capture_draft_rejection, context_injection_builds_markdown_section, cross_framework_recall, repeated_correction_auto_promotes, config_parsing_from_toml, config_defaults_when_no_section, disabled_capture_is_noop, slug_generation (9 new tests, 18 total in ta-memory)
 
 ### v0.5.7 — Semantic Memory Queries & Memory Dashboard
 <!-- status: pending -->

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-cli"
-version = "0.5.5-alpha"
+version = "0.5.6-alpha"
 edition = "2021"
 description = "CLI for goals, PR review, and approvals in Trusted Autonomy"
 license = "Apache-2.0"

--- a/apps/ta-cli/src/commands/context.rs
+++ b/apps/ta-cli/src/commands/context.rs
@@ -186,6 +186,7 @@ fn list_entries(
             key_prefix: prefix.map(|s| s.to_string()),
             tags: tags.to_vec(),
             goal_id: None,
+            category: None,
             limit,
         })?
     };

--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -470,6 +470,11 @@ pub fn execute(
         false
     };
 
+    // 7b. Auto-capture goal completion into memory (v0.5.6).
+    if draft_built {
+        auto_capture_goal_completion(config, goal, &staging_path);
+    }
+
     // 8. Mark interactive session as completed.
     if let Some((store, mut session)) = session_store {
         if draft_built {
@@ -1190,6 +1195,9 @@ fn inject_claude_md(
         String::new()
     };
 
+    // Build memory context section from prior sessions (v0.5.6).
+    let memory_section = build_memory_context_section_for_inject(config, title);
+
     let injected = format!(
         r#"# Trusted Autonomy — Mediated Goal
 
@@ -1197,7 +1205,7 @@ You are working on a TA-mediated goal in a staging workspace.
 
 **Goal:** {}
 **Goal ID:** {}
-{}{}{}
+{}{}{}{}
 ## How this works
 
 - This directory is a copy of the original project
@@ -1261,11 +1269,86 @@ If your changes affect user-facing behavior (new commands, changed flags, new co
 
 {}
 "#,
-        title, goal_id, plan_section, parent_section, macro_section, existing_section
+        title,
+        goal_id,
+        plan_section,
+        parent_section,
+        macro_section,
+        memory_section,
+        existing_section
     );
 
     std::fs::write(&claude_md_path, injected)?;
     Ok(())
+}
+
+/// Auto-capture goal completion into memory (v0.5.6).
+///
+/// Reads `.ta/change_summary.json` from the staging workspace and stores
+/// the goal completion event in the memory store for future context injection.
+fn auto_capture_goal_completion(
+    config: &GatewayConfig,
+    goal: &ta_goal::GoalRun,
+    staging_path: &Path,
+) {
+    let memory_dir = config.workspace_root.join(".ta").join("memory");
+    let mut store = ta_memory::FsMemoryStore::new(&memory_dir);
+
+    let workflow_toml = config.workspace_root.join(".ta").join("workflow.toml");
+    let capture_config = ta_memory::auto_capture::load_config(&workflow_toml);
+    let capture = ta_memory::AutoCapture::new(capture_config);
+
+    // Try to read change_summary.json from staging.
+    let summary_path = staging_path.join(".ta").join("change_summary.json");
+    let change_summary = if summary_path.exists() {
+        std::fs::read_to_string(&summary_path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+    } else {
+        None
+    };
+
+    // Extract changed file list from change_summary if available.
+    let changed_files = change_summary
+        .as_ref()
+        .and_then(|v: &serde_json::Value| v.get("changes"))
+        .and_then(|c| c.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|c| c.get("path").and_then(|p| p.as_str()).map(String::from))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let event = ta_memory::GoalCompleteEvent {
+        goal_id: goal.goal_run_id,
+        title: goal.title.clone(),
+        agent_framework: goal.agent_id.clone(),
+        change_summary,
+        changed_files,
+    };
+
+    if let Err(e) = capture.on_goal_complete(&mut store, &event) {
+        tracing::warn!("failed to auto-capture goal completion: {}", e);
+    }
+}
+
+/// Build a memory context section from prior sessions for CLAUDE.md injection (v0.5.6).
+///
+/// Queries the memory store for relevant entries and formats them as a
+/// markdown section. Returns an empty string if no entries are found or
+/// if the memory store is unavailable.
+fn build_memory_context_section_for_inject(config: &GatewayConfig, goal_title: &str) -> String {
+    let memory_dir = config.workspace_root.join(".ta").join("memory");
+    let store = ta_memory::FsMemoryStore::new(&memory_dir);
+
+    // Load auto-capture config for max_context_entries setting.
+    let workflow_toml = config.workspace_root.join(".ta").join("workflow.toml");
+    let capture_config = ta_memory::auto_capture::load_config(&workflow_toml);
+    let max_entries = capture_config.max_context_entries;
+
+    ta_memory::auto_capture::build_memory_context_section(&store, goal_title, max_entries)
+        .unwrap_or_default()
 }
 
 /// Restore the original CLAUDE.md content before computing diffs.

--- a/crates/ta-mcp-gateway/src/server.rs
+++ b/crates/ta-mcp-gateway/src/server.rs
@@ -35,7 +35,7 @@ use ta_changeset::review_channel::{ReviewChannel, ReviewChannelError};
 use ta_changeset::terminal_channel::AutoApproveChannel;
 use ta_connector_fs::FsConnector;
 use ta_goal::{EventDispatcher, GoalRun, GoalRunState, GoalRunStore, LogSink, TaEvent};
-use ta_memory::{FsMemoryStore, MemoryStore};
+use ta_memory::{AutoCapture, DraftRejectEvent, FsMemoryStore, MemoryStore};
 use ta_policy::{
     AlignmentProfile, CompilerOptions, PolicyCompiler, PolicyDecision, PolicyEngine, PolicyRequest,
 };
@@ -182,10 +182,10 @@ pub struct PlanToolParams {
     pub status_note: Option<String>,
 }
 
-/// Parameters for `ta_context` (persistent memory tool, v0.5.4).
+/// Parameters for `ta_context` (persistent memory tool, v0.5.4+).
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ContextToolParams {
-    /// Action: "store", "recall", "list", or "forget".
+    /// Action: "store", "recall", "list", "forget", or "search".
     pub action: String,
     /// Key for the memory entry (required for store, recall, forget).
     #[serde(default)]
@@ -196,9 +196,23 @@ pub struct ContextToolParams {
     /// Tags for the entry (used with "store" action).
     #[serde(default)]
     pub tags: Option<Vec<String>>,
-    /// Maximum entries to return (used with "list" action).
+    /// Maximum entries to return (used with "list" and "search" actions).
     #[serde(default)]
     pub limit: Option<usize>,
+    /// Source framework identifier (v0.5.6). Defaults to "agent".
+    /// Examples: "claude-code", "codex", "cursor", "claude-flow".
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Associate this entry with a specific goal (v0.5.6).
+    #[serde(default)]
+    pub goal_id: Option<String>,
+    /// Knowledge category (v0.5.6): "convention", "architecture",
+    /// "history", "preference", "relationship".
+    #[serde(default)]
+    pub category: Option<String>,
+    /// Search query text (used with "search" action, v0.5.6).
+    #[serde(default)]
+    pub query: Option<String>,
 }
 
 // ── Gateway state ────────────────────────────────────────────────
@@ -220,6 +234,8 @@ pub struct GatewayState {
     pub review_channel: Box<dyn ReviewChannel>,
     /// Persistent memory store for cross-agent context (v0.5.4).
     pub memory_store: FsMemoryStore,
+    /// Auto-capture config for lifecycle events (v0.5.6).
+    pub auto_capture_config: ta_memory::AutoCaptureConfig,
     /// MCP tool call interceptor for capturing external actions (v0.5.1).
     pub interceptor: ToolCallInterceptor,
     /// Pending actions captured by the interceptor, keyed by goal_run_id.
@@ -236,6 +252,10 @@ impl GatewayState {
         event_dispatcher.add_sink(Box::new(LogSink::new(&config.events_log)));
         let memory_store = FsMemoryStore::new(config.workspace_root.join(".ta").join("memory"));
 
+        // Load auto-capture config from .ta/workflow.toml (v0.5.6).
+        let workflow_toml = config.workspace_root.join(".ta").join("workflow.toml");
+        let auto_capture_config = ta_memory::auto_capture::load_config(&workflow_toml);
+
         Ok(Self {
             config,
             policy_engine: PolicyEngine::new(),
@@ -246,6 +266,7 @@ impl GatewayState {
             event_dispatcher,
             review_channel: Box::new(AutoApproveChannel::new()),
             memory_store,
+            auto_capture_config,
             interceptor: ToolCallInterceptor::new(),
             pending_actions: HashMap::new(),
         })
@@ -935,14 +956,53 @@ impl TaGatewayServer {
                         let (review_status, review_decision) = match &review_result {
                             Ok(resp) => {
                                 let decision_str = format!("{}", resp.decision);
-                                // If approved and this is a macro goal, transition back to Running.
-                                if decision_str == "approved" && goal.is_macro {
-                                    if let Ok(Some(mut g)) = state.goal_store.get(goal_run_id) {
-                                        if g.state == GoalRunState::PrReady {
-                                            let _ = g.transition(GoalRunState::Running);
-                                            let _ = state.goal_store.save(&g);
+                                if decision_str == "approved" {
+                                    // Dispatch PrApproved event (v0.5.6).
+                                    state.event_dispatcher.dispatch(&TaEvent::PrApproved {
+                                        goal_run_id,
+                                        pr_package_id: pkg_id,
+                                        approved_by: "human".to_string(),
+                                        timestamp: Utc::now(),
+                                    });
+
+                                    // If macro goal, transition back to Running.
+                                    if goal.is_macro {
+                                        if let Ok(Some(mut g)) = state.goal_store.get(goal_run_id) {
+                                            if g.state == GoalRunState::PrReady {
+                                                let _ = g.transition(GoalRunState::Running);
+                                                let _ = state.goal_store.save(&g);
+                                            }
                                         }
                                     }
+                                } else {
+                                    // Dispatch PrDenied event (v0.5.6).
+                                    state.event_dispatcher.dispatch(&TaEvent::PrDenied {
+                                        goal_run_id,
+                                        pr_package_id: pkg_id,
+                                        reason: resp
+                                            .reasoning
+                                            .clone()
+                                            .unwrap_or_else(|| "denied".to_string()),
+                                        denied_by: "human".to_string(),
+                                        timestamp: Utc::now(),
+                                    });
+
+                                    // Auto-capture rejection in memory (v0.5.6).
+                                    // Clone config to avoid borrow conflict on state.
+                                    let reject_event = DraftRejectEvent {
+                                        goal_id: goal_run_id,
+                                        draft_id: pkg_id,
+                                        agent_framework: goal.agent_id.clone(),
+                                        attempted: goal.title.clone(),
+                                        rejection_reason: resp
+                                            .reasoning
+                                            .clone()
+                                            .unwrap_or_else(|| "denied".to_string()),
+                                    };
+                                    let capture =
+                                        AutoCapture::new(state.auto_capture_config.clone());
+                                    let _ = capture
+                                        .on_draft_reject(&mut state.memory_store, &reject_event);
                                 }
                                 ("reviewed".to_string(), decision_str)
                             }
@@ -1311,10 +1371,11 @@ impl TaGatewayServer {
     /// persists across sessions and works across different agent frameworks.
     ///
     /// Actions:
-    /// - "store": Save a memory entry (key + value + optional tags).
+    /// - "store": Save a memory entry (key + value + optional tags/source/goal_id/category).
     /// - "recall": Retrieve a single entry by exact key.
     /// - "list": List all entries (optionally limited).
     /// - "forget": Delete an entry by key.
+    /// - "search": Semantic search by query text (v0.5.6).
     #[tool]
     fn ta_context(
         &self,
@@ -1333,16 +1394,30 @@ impl TaGatewayServer {
                     .ok_or_else(|| McpError::invalid_params("key required for store", None))?;
                 let value = params.value.clone().unwrap_or(serde_json::Value::Null);
                 let tags = params.tags.clone().unwrap_or_default();
+                let source = params.source.as_deref().unwrap_or("agent");
 
+                // Parse optional goal_id and category (v0.5.6).
+                let goal_id = params
+                    .goal_id
+                    .as_deref()
+                    .and_then(|s| s.parse::<Uuid>().ok());
+                let category = params
+                    .category
+                    .as_deref()
+                    .map(ta_memory::MemoryCategory::from_str_lossy);
+
+                let store_params = ta_memory::StoreParams { goal_id, category };
                 let entry = state
                     .memory_store
-                    .store(key, value, tags, "agent")
+                    .store_with_params(key, value, tags, source, store_params)
                     .map_err(|e| McpError::internal_error(e.to_string(), None))?;
 
                 let response = serde_json::json!({
                     "status": "stored",
                     "entry_id": entry.entry_id.to_string(),
                     "key": entry.key,
+                    "source": entry.source,
+                    "category": entry.category.as_ref().map(|c| c.to_string()),
                 });
                 Ok(CallToolResult::success(vec![Content::json(response)
                     .map_err(|e| {
@@ -1367,6 +1442,8 @@ impl TaGatewayServer {
                             "value": e.value,
                             "tags": e.tags,
                             "source": e.source,
+                            "category": e.category.as_ref().map(|c| c.to_string()),
+                            "goal_id": e.goal_id.map(|id| id.to_string()),
                             "created_at": e.created_at.to_rfc3339(),
                             "updated_at": e.updated_at.to_rfc3339(),
                         });
@@ -1400,6 +1477,7 @@ impl TaGatewayServer {
                             "key": e.key,
                             "tags": e.tags,
                             "source": e.source,
+                            "category": e.category.as_ref().map(|c| c.to_string()),
                             "updated_at": e.updated_at.to_rfc3339(),
                         })
                     })
@@ -1434,9 +1512,47 @@ impl TaGatewayServer {
                         McpError::internal_error(e.to_string(), None)
                     })?]))
             }
+            "search" => {
+                let query = params
+                    .query
+                    .as_deref()
+                    .or(params.key.as_deref())
+                    .ok_or_else(|| {
+                        McpError::invalid_params("query or key required for search", None)
+                    })?;
+                let k = params.limit.unwrap_or(5);
+
+                let entries = state
+                    .memory_store
+                    .semantic_search(query, k)
+                    .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+
+                let items: Vec<serde_json::Value> = entries
+                    .iter()
+                    .map(|e| {
+                        serde_json::json!({
+                            "key": e.key,
+                            "value": e.value,
+                            "tags": e.tags,
+                            "source": e.source,
+                            "category": e.category.as_ref().map(|c| c.to_string()),
+                        })
+                    })
+                    .collect();
+
+                let response = serde_json::json!({
+                    "count": items.len(),
+                    "results": items,
+                    "backend": if items.is_empty() { "no results (semantic search requires ruvector backend)" } else { "ok" },
+                });
+                Ok(CallToolResult::success(vec![Content::json(response)
+                    .map_err(|e| {
+                        McpError::internal_error(e.to_string(), None)
+                    })?]))
+            }
             _ => Err(McpError::invalid_params(
                 format!(
-                    "unknown action '{}'. Expected: store, recall, list, forget",
+                    "unknown action '{}'. Expected: store, recall, list, forget, search",
                     params.action
                 ),
                 None,

--- a/crates/ta-memory/Cargo.toml
+++ b/crates/ta-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-memory"
-version = "0.5.0-alpha"
+version = "0.5.6-alpha"
 edition = "2021"
 description = "Agent-agnostic persistent memory store for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-memory/src/auto_capture.rs
+++ b/crates/ta-memory/src/auto_capture.rs
@@ -1,0 +1,660 @@
+// auto_capture.rs — Automatic state capture from goal/draft lifecycle events.
+//
+// Converts TA lifecycle events (goal completion, draft rejection, human
+// guidance, repeated corrections) into persistent memory entries. This is
+// what makes TA's memory framework-agnostic: every agent framework produces
+// the same events, and auto-capture stores them in a unified memory store.
+//
+// The AutoCapture struct is stateless — it takes a MemoryStore reference
+// and event data, and writes entries. Configuration comes from
+// `.ta/workflow.toml` (AutoCaptureConfig).
+
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+use uuid::Uuid;
+
+use crate::error::MemoryError;
+use crate::store::{MemoryCategory, MemoryStore, StoreParams};
+
+/// Configuration for automatic state capture, parsed from `.ta/workflow.toml`.
+///
+/// ```toml
+/// [memory.auto_capture]
+/// on_goal_complete = true
+/// on_draft_reject = true
+/// on_human_guidance = true
+/// on_repeated_correction = true
+/// correction_threshold = 3
+/// max_context_entries = 10
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AutoCaptureConfig {
+    /// Capture "what worked" patterns from approved drafts.
+    #[serde(default = "default_true")]
+    pub on_goal_complete: bool,
+
+    /// Store rejection reason + what the agent tried.
+    #[serde(default = "default_true")]
+    pub on_draft_reject: bool,
+
+    /// Store human feedback from interactive sessions.
+    #[serde(default = "default_true")]
+    pub on_human_guidance: bool,
+
+    /// Auto-promote to persistent memory when the same correction repeats.
+    #[serde(default = "default_true")]
+    pub on_repeated_correction: bool,
+
+    /// How many times a correction must repeat before auto-promotion.
+    #[serde(default = "default_correction_threshold")]
+    pub correction_threshold: u32,
+
+    /// Maximum number of memory entries to inject as context on agent launch.
+    #[serde(default = "default_max_context")]
+    pub max_context_entries: usize,
+}
+
+fn default_true() -> bool {
+    true
+}
+fn default_correction_threshold() -> u32 {
+    3
+}
+fn default_max_context() -> usize {
+    10
+}
+
+impl Default for AutoCaptureConfig {
+    fn default() -> Self {
+        Self {
+            on_goal_complete: true,
+            on_draft_reject: true,
+            on_human_guidance: true,
+            on_repeated_correction: true,
+            correction_threshold: 3,
+            max_context_entries: 10,
+        }
+    }
+}
+
+/// Event data for goal completion capture.
+#[derive(Debug, Clone)]
+pub struct GoalCompleteEvent {
+    pub goal_id: Uuid,
+    pub title: String,
+    pub agent_framework: String,
+    /// JSON summary from `.ta/change_summary.json` (if available).
+    pub change_summary: Option<serde_json::Value>,
+    /// Files that were changed in this goal.
+    pub changed_files: Vec<String>,
+}
+
+/// Event data for draft rejection capture.
+#[derive(Debug, Clone)]
+pub struct DraftRejectEvent {
+    pub goal_id: Uuid,
+    pub draft_id: Uuid,
+    pub agent_framework: String,
+    /// What the agent tried (draft summary).
+    pub attempted: String,
+    /// Why the human rejected it.
+    pub rejection_reason: String,
+}
+
+/// Event data for human guidance capture.
+#[derive(Debug, Clone)]
+pub struct HumanGuidanceEvent {
+    pub goal_id: Option<Uuid>,
+    pub agent_framework: String,
+    /// The guidance/instruction the human gave.
+    pub guidance: String,
+    /// Tags to classify the guidance.
+    pub tags: Vec<String>,
+}
+
+/// Captures lifecycle events into the memory store.
+pub struct AutoCapture {
+    config: AutoCaptureConfig,
+}
+
+impl AutoCapture {
+    pub fn new(config: AutoCaptureConfig) -> Self {
+        Self { config }
+    }
+
+    /// Capture a goal completion event into memory.
+    ///
+    /// Extracts "what worked" patterns: the goal title, changed files,
+    /// and change summary become searchable memory entries.
+    pub fn on_goal_complete(
+        &self,
+        store: &mut dyn MemoryStore,
+        event: &GoalCompleteEvent,
+    ) -> Result<(), MemoryError> {
+        if !self.config.on_goal_complete {
+            return Ok(());
+        }
+
+        let key = format!("goal:{}:complete", event.goal_id);
+        let value = serde_json::json!({
+            "title": event.title,
+            "changed_files": event.changed_files,
+            "change_summary": event.change_summary,
+        });
+        let tags = vec![
+            "goal".to_string(),
+            "completed".to_string(),
+            format!("framework:{}", event.agent_framework),
+        ];
+        let params = StoreParams {
+            goal_id: Some(event.goal_id),
+            category: Some(MemoryCategory::History),
+        };
+
+        store.store_with_params(&key, value, tags, "ta-system", params)?;
+        debug!(goal_id = %event.goal_id, "auto-captured goal completion");
+        Ok(())
+    }
+
+    /// Capture a draft rejection event into memory.
+    ///
+    /// Records what was tried, why it failed, and the human's feedback.
+    /// Prevents agents from repeating the same mistakes.
+    pub fn on_draft_reject(
+        &self,
+        store: &mut dyn MemoryStore,
+        event: &DraftRejectEvent,
+    ) -> Result<(), MemoryError> {
+        if !self.config.on_draft_reject {
+            return Ok(());
+        }
+
+        let key = format!("draft:{}:rejection", event.draft_id);
+        let value = serde_json::json!({
+            "attempted": event.attempted,
+            "rejection_reason": event.rejection_reason,
+        });
+        let tags = vec![
+            "draft".to_string(),
+            "rejected".to_string(),
+            format!("framework:{}", event.agent_framework),
+        ];
+        let params = StoreParams {
+            goal_id: Some(event.goal_id),
+            category: Some(MemoryCategory::History),
+        };
+
+        store.store_with_params(&key, value, tags, "ta-system", params)?;
+        debug!(draft_id = %event.draft_id, "auto-captured draft rejection");
+        Ok(())
+    }
+
+    /// Capture human guidance into persistent memory.
+    pub fn on_human_guidance(
+        &self,
+        store: &mut dyn MemoryStore,
+        event: &HumanGuidanceEvent,
+    ) -> Result<(), MemoryError> {
+        if !self.config.on_human_guidance {
+            return Ok(());
+        }
+
+        // Use a content-based key so duplicate guidance is deduplicated.
+        let key = format!("guidance:{}", slug_from_text(&event.guidance, 80));
+        let value = serde_json::json!({
+            "guidance": event.guidance,
+        });
+        let mut tags = event.tags.clone();
+        tags.push("human-guidance".to_string());
+        tags.push(format!("framework:{}", event.agent_framework));
+
+        let params = StoreParams {
+            goal_id: event.goal_id,
+            category: Some(MemoryCategory::Preference),
+        };
+
+        store.store_with_params(&key, value, tags, "ta-system", params)?;
+        debug!("auto-captured human guidance");
+        Ok(())
+    }
+
+    /// Check if a correction has been repeated enough times to auto-promote.
+    ///
+    /// Returns true if the correction was promoted to persistent memory.
+    pub fn check_repeated_correction(
+        &self,
+        store: &mut dyn MemoryStore,
+        correction_key: &str,
+        correction_value: &str,
+    ) -> Result<bool, MemoryError> {
+        if !self.config.on_repeated_correction {
+            return Ok(false);
+        }
+
+        let counter_key = format!("correction-count:{}", correction_key);
+
+        // Read current count.
+        let current_count = match store.recall(&counter_key)? {
+            Some(entry) => entry.value.as_u64().unwrap_or(0) as u32,
+            None => 0,
+        };
+
+        let new_count = current_count + 1;
+
+        // Update counter.
+        store.store(
+            &counter_key,
+            serde_json::json!(new_count),
+            vec!["correction-counter".to_string()],
+            "ta-system",
+        )?;
+
+        // Promote if threshold reached.
+        if new_count >= self.config.correction_threshold {
+            let promo_key = format!("preference:{}", correction_key);
+            let params = StoreParams {
+                goal_id: None,
+                category: Some(MemoryCategory::Preference),
+            };
+            store.store_with_params(
+                &promo_key,
+                serde_json::json!({"pattern": correction_value, "auto_promoted": true}),
+                vec!["preference".to_string(), "auto-promoted".to_string()],
+                "ta-system",
+                params,
+            )?;
+            debug!(
+                correction_key,
+                count = new_count,
+                "auto-promoted repeated correction to preference"
+            );
+
+            // Clean up counter.
+            store.forget(&counter_key)?;
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    /// Get the config reference.
+    pub fn config(&self) -> &AutoCaptureConfig {
+        &self.config
+    }
+}
+
+/// Build a context injection section from memory entries for CLAUDE.md.
+///
+/// Queries the memory store for entries relevant to the current goal,
+/// formats them as a markdown section, and returns the text to inject.
+pub fn build_memory_context_section(
+    store: &dyn MemoryStore,
+    goal_title: &str,
+    max_entries: usize,
+) -> Result<String, MemoryError> {
+    if max_entries == 0 {
+        return Ok(String::new());
+    }
+
+    // Try semantic search first (returns results only with ruvector backend).
+    let mut entries = store.semantic_search(goal_title, max_entries)?;
+
+    // Fall back to tag-based lookup if semantic search returned nothing.
+    if entries.is_empty() {
+        entries = store.lookup(crate::store::MemoryQuery {
+            limit: Some(max_entries),
+            ..Default::default()
+        })?;
+    }
+
+    if entries.is_empty() {
+        return Ok(String::new());
+    }
+
+    let mut section = String::from("\n## Prior Context (from TA memory)\n\n");
+    section.push_str("The following knowledge was captured from previous sessions across all agent frameworks.\n\n");
+
+    for entry in &entries {
+        let category_label = entry
+            .category
+            .as_ref()
+            .map(|c| format!("[{}] ", c))
+            .unwrap_or_default();
+
+        let source_label = if entry.source != "ta-system" {
+            format!(" (source: {})", entry.source)
+        } else {
+            String::new()
+        };
+
+        // Format value as a concise string.
+        let value_str = if let Some(s) = entry.value.as_str() {
+            s.to_string()
+        } else {
+            serde_json::to_string(&entry.value).unwrap_or_default()
+        };
+
+        section.push_str(&format!(
+            "- **{}{}**{}: {}\n",
+            category_label, entry.key, source_label, value_str,
+        ));
+    }
+
+    section.push('\n');
+    Ok(section)
+}
+
+/// Create a URL-safe slug from text (for use as memory keys).
+fn slug_from_text(text: &str, max_len: usize) -> String {
+    let slug: String = text
+        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    // Collapse consecutive dashes.
+    let mut prev_dash = false;
+    let collapsed: String = slug
+        .chars()
+        .filter(|&c| {
+            if c == '-' {
+                if prev_dash {
+                    return false;
+                }
+                prev_dash = true;
+            } else {
+                prev_dash = false;
+            }
+            true
+        })
+        .collect();
+    let trimmed = collapsed.trim_matches('-');
+    if trimmed.len() > max_len {
+        trimmed[..max_len].to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Parse AutoCaptureConfig from a `.ta/workflow.toml` file.
+///
+/// If the file doesn't exist or doesn't contain `[memory.auto_capture]`,
+/// returns the default config (all features enabled).
+pub fn load_config(workflow_toml_path: &std::path::Path) -> AutoCaptureConfig {
+    if !workflow_toml_path.exists() {
+        return AutoCaptureConfig::default();
+    }
+
+    match std::fs::read_to_string(workflow_toml_path) {
+        Ok(content) => parse_config_from_toml(&content),
+        Err(_) => AutoCaptureConfig::default(),
+    }
+}
+
+/// Parse the auto-capture section from TOML content.
+fn parse_config_from_toml(content: &str) -> AutoCaptureConfig {
+    // Minimal TOML parsing — extract [memory.auto_capture] section values.
+    // We avoid pulling in a full TOML crate by doing simple line parsing.
+    let mut config = AutoCaptureConfig::default();
+    let mut in_section = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if trimmed == "[memory.auto_capture]" {
+            in_section = true;
+            continue;
+        }
+
+        // New section starts — stop parsing.
+        if trimmed.starts_with('[') {
+            if in_section {
+                break;
+            }
+            continue;
+        }
+
+        if !in_section {
+            continue;
+        }
+
+        if let Some((key, value)) = trimmed.split_once('=') {
+            let key = key.trim();
+            let value = value.trim();
+
+            match key {
+                "on_goal_complete" => config.on_goal_complete = value == "true",
+                "on_draft_reject" => config.on_draft_reject = value == "true",
+                "on_human_guidance" => config.on_human_guidance = value == "true",
+                "on_repeated_correction" => config.on_repeated_correction = value == "true",
+                "correction_threshold" => {
+                    if let Ok(n) = value.parse() {
+                        config.correction_threshold = n;
+                    }
+                }
+                "max_context_entries" => {
+                    if let Ok(n) = value.parse() {
+                        config.max_context_entries = n;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    config
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FsMemoryStore;
+    use tempfile::TempDir;
+
+    fn test_store(dir: &TempDir) -> FsMemoryStore {
+        FsMemoryStore::new(dir.path().join("memory"))
+    }
+
+    #[test]
+    fn auto_capture_goal_complete() {
+        let dir = TempDir::new().unwrap();
+        let mut store = test_store(&dir);
+        let capture = AutoCapture::new(AutoCaptureConfig::default());
+
+        let event = GoalCompleteEvent {
+            goal_id: Uuid::new_v4(),
+            title: "Fix auth bug".to_string(),
+            agent_framework: "claude-code".to_string(),
+            change_summary: Some(serde_json::json!({"summary": "Fixed JWT validation"})),
+            changed_files: vec!["src/auth.rs".to_string()],
+        };
+
+        capture.on_goal_complete(&mut store, &event).unwrap();
+
+        let key = format!("goal:{}:complete", event.goal_id);
+        let entry = store.recall(&key).unwrap().unwrap();
+        assert_eq!(entry.goal_id, Some(event.goal_id));
+        assert_eq!(entry.category, Some(MemoryCategory::History));
+        assert!(entry.tags.contains(&"completed".to_string()));
+        assert!(entry.tags.contains(&"framework:claude-code".to_string()));
+    }
+
+    #[test]
+    fn auto_capture_draft_rejection() {
+        let dir = TempDir::new().unwrap();
+        let mut store = test_store(&dir);
+        let capture = AutoCapture::new(AutoCaptureConfig::default());
+
+        let event = DraftRejectEvent {
+            goal_id: Uuid::new_v4(),
+            draft_id: Uuid::new_v4(),
+            agent_framework: "codex".to_string(),
+            attempted: "Added Redis caching layer".to_string(),
+            rejection_reason: "Too complex for MVP, use in-memory cache".to_string(),
+        };
+
+        capture.on_draft_reject(&mut store, &event).unwrap();
+
+        let key = format!("draft:{}:rejection", event.draft_id);
+        let entry = store.recall(&key).unwrap().unwrap();
+        assert_eq!(entry.category, Some(MemoryCategory::History));
+        assert!(entry.tags.contains(&"rejected".to_string()));
+        assert!(entry.tags.contains(&"framework:codex".to_string()));
+        let reason = entry.value["rejection_reason"].as_str().unwrap();
+        assert!(reason.contains("Too complex"));
+    }
+
+    #[test]
+    fn context_injection_builds_markdown_section() {
+        let dir = TempDir::new().unwrap();
+        let mut store = test_store(&dir);
+
+        // Store some entries.
+        store
+            .store_with_params(
+                "convention:test-style",
+                serde_json::json!("Use tempfile::tempdir() for all tests"),
+                vec!["convention".into()],
+                "claude-code",
+                StoreParams {
+                    goal_id: None,
+                    category: Some(MemoryCategory::Convention),
+                },
+            )
+            .unwrap();
+
+        let section = build_memory_context_section(&store, "Fix tests", 10).unwrap();
+        assert!(section.contains("Prior Context"));
+        assert!(section.contains("tempfile::tempdir()"));
+        assert!(section.contains("[convention]"));
+    }
+
+    #[test]
+    fn cross_framework_recall() {
+        let dir = TempDir::new().unwrap();
+        let mut store = test_store(&dir);
+
+        // Store from "claude-code".
+        store
+            .store(
+                "shared-convention",
+                serde_json::json!("Always run clippy before commit"),
+                vec!["convention".into(), "framework:claude-code".into()],
+                "claude-code",
+            )
+            .unwrap();
+
+        // Recall as "codex" — the entry is framework-agnostic, accessible to all.
+        let entry = store.recall("shared-convention").unwrap().unwrap();
+        assert_eq!(entry.source, "claude-code");
+        assert_eq!(
+            entry.value,
+            serde_json::json!("Always run clippy before commit")
+        );
+    }
+
+    #[test]
+    fn repeated_correction_auto_promotes() {
+        let dir = TempDir::new().unwrap();
+        let mut store = test_store(&dir);
+        let config = AutoCaptureConfig {
+            correction_threshold: 3,
+            ..Default::default()
+        };
+        let capture = AutoCapture::new(config);
+
+        // First two corrections — not yet promoted.
+        let promoted = capture
+            .check_repeated_correction(&mut store, "use-tempdir", "Use tempfile::tempdir()")
+            .unwrap();
+        assert!(!promoted);
+
+        let promoted = capture
+            .check_repeated_correction(&mut store, "use-tempdir", "Use tempfile::tempdir()")
+            .unwrap();
+        assert!(!promoted);
+
+        // Third correction — promoted!
+        let promoted = capture
+            .check_repeated_correction(&mut store, "use-tempdir", "Use tempfile::tempdir()")
+            .unwrap();
+        assert!(promoted);
+
+        // The preference entry should exist.
+        let pref = store.recall("preference:use-tempdir").unwrap().unwrap();
+        assert_eq!(pref.category, Some(MemoryCategory::Preference));
+        assert!(pref.tags.contains(&"auto-promoted".to_string()));
+
+        // The counter should have been cleaned up.
+        assert!(store
+            .recall("correction-count:use-tempdir")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn config_parsing_from_toml() {
+        let toml = r#"
+[memory.auto_capture]
+on_goal_complete = true
+on_draft_reject = false
+on_human_guidance = true
+on_repeated_correction = true
+correction_threshold = 5
+max_context_entries = 20
+"#;
+        let config = parse_config_from_toml(toml);
+        assert!(config.on_goal_complete);
+        assert!(!config.on_draft_reject);
+        assert!(config.on_human_guidance);
+        assert_eq!(config.correction_threshold, 5);
+        assert_eq!(config.max_context_entries, 20);
+    }
+
+    #[test]
+    fn config_defaults_when_no_section() {
+        let config = parse_config_from_toml("[other]\nfoo = bar");
+        assert!(config.on_goal_complete);
+        assert!(config.on_draft_reject);
+        assert_eq!(config.correction_threshold, 3);
+    }
+
+    #[test]
+    fn disabled_capture_is_noop() {
+        let dir = TempDir::new().unwrap();
+        let mut store = test_store(&dir);
+        let config = AutoCaptureConfig {
+            on_goal_complete: false,
+            on_draft_reject: false,
+            ..Default::default()
+        };
+        let capture = AutoCapture::new(config);
+
+        let event = GoalCompleteEvent {
+            goal_id: Uuid::new_v4(),
+            title: "test".to_string(),
+            agent_framework: "test".to_string(),
+            change_summary: None,
+            changed_files: vec![],
+        };
+        capture.on_goal_complete(&mut store, &event).unwrap();
+
+        // Nothing stored.
+        assert!(store.list(None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn slug_generation() {
+        assert_eq!(slug_from_text("Hello World!", 80), "hello-world");
+        assert_eq!(
+            slug_from_text("use tempfile::tempdir()", 80),
+            "use-tempfile-tempdir"
+        );
+        assert_eq!(slug_from_text("a".repeat(100).as_str(), 50), "a".repeat(50));
+    }
+}

--- a/crates/ta-memory/src/fs_store.rs
+++ b/crates/ta-memory/src/fs_store.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 use uuid::Uuid;
 
 use crate::error::MemoryError;
-use crate::store::{MemoryEntry, MemoryQuery, MemoryStore};
+use crate::store::{MemoryEntry, MemoryQuery, MemoryStore, StoreParams};
 
 /// Filesystem-backed memory store.
 pub struct FsMemoryStore {
@@ -87,6 +87,17 @@ impl MemoryStore for FsMemoryStore {
         tags: Vec<String>,
         source: &str,
     ) -> Result<MemoryEntry, MemoryError> {
+        self.store_with_params(key, value, tags, source, StoreParams::default())
+    }
+
+    fn store_with_params(
+        &mut self,
+        key: &str,
+        value: serde_json::Value,
+        tags: Vec<String>,
+        source: &str,
+        params: StoreParams,
+    ) -> Result<MemoryEntry, MemoryError> {
         fs::create_dir_all(&self.base_dir)?;
 
         let now = Utc::now();
@@ -109,7 +120,8 @@ impl MemoryStore for FsMemoryStore {
             value,
             tags,
             source: source.to_string(),
-            goal_id: None,
+            goal_id: params.goal_id,
+            category: params.category,
             created_at,
             updated_at: now,
         };
@@ -145,6 +157,11 @@ impl MemoryStore for FsMemoryStore {
                 }
                 if let Some(goal_id) = query.goal_id {
                     if e.goal_id != Some(goal_id) {
+                        return false;
+                    }
+                }
+                if let Some(ref cat) = query.category {
+                    if e.category.as_ref() != Some(cat) {
                         return false;
                     }
                 }

--- a/crates/ta-memory/src/lib.rs
+++ b/crates/ta-memory/src/lib.rs
@@ -13,14 +13,18 @@
 //! - **RuVectorStore** (feature `ruvector`): HNSW-indexed vector database
 //!   for semantic search. Sub-millisecond recall at scale.
 
+pub mod auto_capture;
 pub mod error;
 pub mod fs_store;
 #[cfg(feature = "ruvector")]
 pub mod ruvector_store;
 pub mod store;
 
+pub use auto_capture::{
+    AutoCapture, AutoCaptureConfig, DraftRejectEvent, GoalCompleteEvent, HumanGuidanceEvent,
+};
 pub use error::MemoryError;
 pub use fs_store::FsMemoryStore;
 #[cfg(feature = "ruvector")]
 pub use ruvector_store::RuVectorStore;
-pub use store::{MemoryEntry, MemoryQuery, MemoryStore};
+pub use store::{MemoryCategory, MemoryEntry, MemoryQuery, MemoryStore, StoreParams};

--- a/crates/ta-memory/src/ruvector_store.rs
+++ b/crates/ta-memory/src/ruvector_store.rs
@@ -17,7 +17,7 @@ use tracing::{debug, warn};
 use uuid::Uuid;
 
 use crate::error::MemoryError;
-use crate::store::{MemoryEntry, MemoryQuery, MemoryStore};
+use crate::store::{MemoryCategory, MemoryEntry, MemoryQuery, MemoryStore, StoreParams};
 
 /// Embedding dimension used for hash-based text embeddings.
 /// Matches ruvector-core's default hash embedding output size.
@@ -115,6 +115,17 @@ impl MemoryStore for RuVectorStore {
         tags: Vec<String>,
         source: &str,
     ) -> Result<MemoryEntry, MemoryError> {
+        self.store_with_params(key, value, tags, source, StoreParams::default())
+    }
+
+    fn store_with_params(
+        &mut self,
+        key: &str,
+        value: serde_json::Value,
+        tags: Vec<String>,
+        source: &str,
+        params: StoreParams,
+    ) -> Result<MemoryEntry, MemoryError> {
         let now = Utc::now();
 
         // Check for existing entry to preserve ID and created_at.
@@ -136,7 +147,8 @@ impl MemoryStore for RuVectorStore {
             value: value.clone(),
             tags,
             source: source.to_string(),
-            goal_id: None,
+            goal_id: params.goal_id,
+            category: params.category,
             created_at,
             updated_at: now,
         };
@@ -181,6 +193,11 @@ impl MemoryStore for RuVectorStore {
                 }
                 if let Some(goal_id) = query.goal_id {
                     if e.goal_id != Some(goal_id) {
+                        return false;
+                    }
+                }
+                if let Some(ref cat) = query.category {
+                    if e.category.as_ref() != Some(cat) {
                         return false;
                     }
                 }
@@ -326,6 +343,9 @@ fn entry_to_metadata(entry: &MemoryEntry) -> HashMap<String, serde_json::Value> 
     if let Some(goal_id) = entry.goal_id {
         meta.insert("goal_id".into(), serde_json::json!(goal_id.to_string()));
     }
+    if let Some(ref category) = entry.category {
+        meta.insert("category".into(), serde_json::json!(category.to_string()));
+    }
     meta.insert(
         "created_at".into(),
         serde_json::json!(entry.created_at.to_rfc3339()),
@@ -373,6 +393,11 @@ fn metadata_to_entry(rv_entry: &RvEntry) -> Option<MemoryEntry> {
         .map(|dt| dt.with_timezone(&chrono::Utc))
         .unwrap_or_else(Utc::now);
 
+    let category = meta
+        .get("category")
+        .and_then(|v| v.as_str())
+        .map(MemoryCategory::from_str_lossy);
+
     Some(MemoryEntry {
         entry_id,
         key,
@@ -380,6 +405,7 @@ fn metadata_to_entry(rv_entry: &RvEntry) -> Option<MemoryEntry> {
         tags,
         source,
         goal_id,
+        category,
         created_at,
         updated_at,
     })

--- a/crates/ta-memory/src/store.rs
+++ b/crates/ta-memory/src/store.rs
@@ -9,6 +9,54 @@ use uuid::Uuid;
 
 use crate::error::MemoryError;
 
+/// Categories for memory entries (v0.5.6 framework-agnostic state).
+///
+/// Used to classify what kind of knowledge a memory entry represents,
+/// enabling targeted recall (e.g., "give me all conventions for this project").
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryCategory {
+    /// Coding style, formatting rules, tool preferences.
+    Convention,
+    /// Module layout, dependency relationships, design decisions.
+    Architecture,
+    /// What was tried and why it succeeded or failed.
+    History,
+    /// Human workflow preferences (small PRs, never auto-commit, etc.).
+    Preference,
+    /// File/module dependency relationships.
+    Relationship,
+    /// Uncategorized or user-defined.
+    Other,
+}
+
+impl std::fmt::Display for MemoryCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Convention => write!(f, "convention"),
+            Self::Architecture => write!(f, "architecture"),
+            Self::History => write!(f, "history"),
+            Self::Preference => write!(f, "preference"),
+            Self::Relationship => write!(f, "relationship"),
+            Self::Other => write!(f, "other"),
+        }
+    }
+}
+
+impl MemoryCategory {
+    /// Parse from a string, falling back to `Other` for unknown values.
+    pub fn from_str_lossy(s: &str) -> Self {
+        match s {
+            "convention" => Self::Convention,
+            "architecture" => Self::Architecture,
+            "history" => Self::History,
+            "preference" => Self::Preference,
+            "relationship" => Self::Relationship,
+            _ => Self::Other,
+        }
+    }
+}
+
 /// A stored memory entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryEntry {
@@ -18,6 +66,9 @@ pub struct MemoryEntry {
     pub tags: Vec<String>,
     pub source: String,
     pub goal_id: Option<Uuid>,
+    /// Knowledge category for targeted recall (v0.5.6).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<MemoryCategory>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -31,8 +82,22 @@ pub struct MemoryQuery {
     pub tags: Vec<String>,
     /// Restrict to a specific goal's memories.
     pub goal_id: Option<Uuid>,
+    /// Filter by category.
+    pub category: Option<MemoryCategory>,
     /// Maximum number of results.
     pub limit: Option<usize>,
+}
+
+/// Parameters for storing a memory entry (v0.5.6).
+///
+/// Provides a builder-style API so callers can set optional fields
+/// without breaking the existing `store()` signature.
+#[derive(Debug, Clone, Default)]
+pub struct StoreParams {
+    /// Associate this entry with a specific goal.
+    pub goal_id: Option<Uuid>,
+    /// Classify the entry for targeted recall.
+    pub category: Option<MemoryCategory>,
 }
 
 /// Pluggable memory storage backend.
@@ -46,10 +111,27 @@ pub trait MemoryStore: Send + Sync {
         source: &str,
     ) -> Result<MemoryEntry, MemoryError>;
 
+    /// Store a memory entry with extended parameters (goal_id, category).
+    fn store_with_params(
+        &mut self,
+        key: &str,
+        value: serde_json::Value,
+        tags: Vec<String>,
+        source: &str,
+        params: StoreParams,
+    ) -> Result<MemoryEntry, MemoryError> {
+        // Default: delegate to basic store, then patch fields.
+        // Backends can override for atomic writes.
+        let mut entry = self.store(key, value, tags, source)?;
+        entry.goal_id = params.goal_id;
+        entry.category = params.category;
+        Ok(entry)
+    }
+
     /// Retrieve a single entry by exact key.
     fn recall(&self, key: &str) -> Result<Option<MemoryEntry>, MemoryError>;
 
-    /// Search entries by query parameters (prefix, tags, goal_id).
+    /// Search entries by query parameters (prefix, tags, goal_id, category).
     fn lookup(&self, query: MemoryQuery) -> Result<Vec<MemoryEntry>, MemoryError>;
 
     /// List all entries, optionally limited.

--- a/docs/ADR-modular-decomposition.md
+++ b/docs/ADR-modular-decomposition.md
@@ -1,0 +1,319 @@
+# ADR: Modular Decomposition — TA Core vs. Agent Infrastructure vs. Applications
+
+> **Status**: Proposal (review after v0.5.7)
+> **Author**: Claude (v0.5.6 session)
+> **Context**: Discussion during v0.5.6 implementation about whether TA is trying to do too many things
+
+---
+
+## The Question
+
+TA's plan through v1.0 conflates three distinct concerns into a single project:
+
+1. **TA Core** — the mediation/governance layer (the actual thesis)
+2. **Agent Infrastructure** — general-purpose tools any agent system needs
+3. **Applications** — products built on top of TA
+
+Should these be separated into independent, composable layers?
+
+---
+
+## Current State
+
+Everything lives in one workspace under `crates/`. As of v0.5.6:
+
+```
+crates/
+  ta-audit          # Core: append-only hash-chained audit log
+  ta-changeset      # Core: draft/PR package model, review channels
+  ta-credentials    # Infra: credential broker, identity abstraction
+  ta-daemon         # Core: MCP server binary
+  ta-goal           # Core: goal lifecycle state machine, events
+  ta-mcp-gateway    # Core: MCP tool handlers, policy enforcement
+  ta-memory         # Infra: persistent memory store + auto-capture
+  ta-policy         # Core: default-deny capability engine
+  ta-sandbox        # Infra: sandbox runner (placeholder)
+  ta-submit         # Core: submit adapter trait
+  ta-workspace      # Core: staging workspace, overlay, change store
+  ta-connectors/    # Core: filesystem, web, mock connectors
+```
+
+The problem: `ta-memory` and `ta-credentials` have almost no dependencies on TA core types. They're general-purpose agent infrastructure that happens to live in TA's workspace.
+
+---
+
+## Detailed Analysis: What's Core vs. What's Not
+
+### TA Core (the thesis: "all agent actions are mediated")
+
+These crates directly implement TA's unique value proposition — staging isolation, policy enforcement, human-in-the-loop review, and audit trail:
+
+| Crate | Role | Dependencies on other TA crates |
+|-------|------|---------------------------------|
+| `ta-policy` | Default-deny capability engine | None |
+| `ta-audit` | Hash-chained append-only audit log | None |
+| `ta-workspace` | Staging workspace, overlay, change store | None |
+| `ta-changeset` | Draft/PR packages, review channels, interactions | None |
+| `ta-goal` | Goal lifecycle state machine, event dispatch | None |
+| `ta-submit` | Submit adapter trait (git, etc.) | None |
+| `ta-mcp-gateway` | MCP tool handlers wiring everything together | All of the above |
+| `ta-daemon` | Binary that runs the MCP server | `ta-mcp-gateway` |
+| `ta-connectors/*` | Filesystem/web/mock resource connectors | `ta-changeset`, `ta-workspace` |
+
+**These should stay in TA.** They *are* TA.
+
+### Agent Infrastructure (general-purpose, not TA-specific)
+
+These solve problems that every agent system faces, regardless of whether TA's governance layer is involved:
+
+#### `ta-memory` — Does it add value over RuVector?
+
+**What ta-memory provides today:**
+- `MemoryStore` trait abstracting storage backends
+- `FsMemoryStore` — zero-dependency JSON file backend
+- `RuVectorStore` — HNSW-indexed semantic search backend (wraps ruvector-core)
+- `MemoryEntry` — structured entries with key, value, tags, source, goal_id, category
+- `AutoCapture` — lifecycle event → memory entry conversion
+- `build_memory_context_section()` — formats entries for agent prompt injection
+- Config parsing from `.ta/workflow.toml`
+
+**What ruvector-core provides:**
+- `VectorDB` — HNSW-indexed vector database
+- `VectorEntry` — id + vector + metadata (HashMap<String, Value>)
+- `SearchQuery` — k-NN similarity search
+- Distance metrics (cosine, euclidean, dot product)
+- Persistence to `.rvf` files
+
+**The gap ta-memory fills over raw ruvector:**
+
+| Capability | ruvector-core | ta-memory |
+|-----------|--------------|-----------|
+| Vector storage + search | Yes | Yes (delegates to ruvector) |
+| Structured entry model (key, tags, source, category) | No (raw metadata HashMap) | Yes |
+| Exact-key recall | No (vector search only) | Yes |
+| Tag-based filtering | No | Yes |
+| Zero-dependency fallback (JSON files) | No | Yes (FsMemoryStore) |
+| Lifecycle auto-capture (goal complete, draft reject) | No | Yes |
+| Agent prompt injection formatting | No | Yes |
+| Config-driven capture rules | No | Yes |
+| Framework-agnostic source tracking | No | Yes |
+
+**Verdict:** ta-memory adds meaningful value over raw ruvector. ruvector is a vector database; ta-memory is an **agent knowledge store** that can use ruvector as a backend. The structured entry model, tag-based queries, auto-capture, and prompt injection are agent-specific concerns that don't belong in a vector DB library.
+
+**However**, ta-memory doesn't need to live inside TA. It could be:
+- A standalone crate (`agent-memory` or `ruvector-memory`) that TA depends on
+- Published independently for use by Claude Code plugins, Codex extensions, etc.
+- The auto-capture module could stay in TA (it references TA concepts like goals/drafts) while the core store is extracted
+
+**Recommended split:**
+```
+agent-memory/           # Standalone crate (publishable)
+  src/
+    store.rs            # MemoryStore trait, MemoryEntry, MemoryQuery
+    fs_store.rs         # FsMemoryStore (zero-dep JSON backend)
+    ruvector_store.rs   # RuVectorStore (semantic search backend)
+    error.rs
+
+ta-memory/              # TA-specific layer (stays in TA workspace)
+  src/
+    auto_capture.rs     # GoalCompleteEvent, DraftRejectEvent, etc.
+    context_inject.rs   # build_memory_context_section()
+    config.rs           # AutoCaptureConfig from workflow.toml
+  [dependencies]
+    agent-memory = "..."
+```
+
+#### `ta-credentials` — Credential Broker
+
+**What it does:** Manages secrets, OAuth flows, and identity abstraction so agents never hold raw credentials.
+
+**Is it TA-specific?** No. Every agent system that accesses external APIs needs credential management. Claude Code has its own, Codex has its own, etc.
+
+**Should it be extracted?** Yes, but less urgently than memory. Credential management is deeply tied to MCP server patterns — it could become a standalone MCP server that TA (and others) connect to:
+
+```
+agent-credentials/      # Standalone MCP server
+  # Manages secrets, OAuth, identity abstraction
+  # Any MCP client can connect, not just TA
+
+ta integrates via:
+  # .ta/workflow.toml
+  [credentials]
+  provider = "agent-credentials"  # or "ta-builtin" for backwards compat
+```
+
+#### Cost Tracking (v0.6.1, not yet implemented)
+
+**Is it TA-specific?** No. Token budget management is a general agent ops concern.
+
+**Recommendation:** Implement as a standalone crate from the start. TA's event system can feed it data, but the tracking/budgeting logic shouldn't couple to TA's goal model.
+
+```
+agent-budget/           # Standalone crate
+  # Token counting, cost estimation, budget enforcement
+  # Pluggable provider model (Anthropic, OpenAI, etc.)
+
+ta-budget/              # TA integration layer
+  # Hooks into goal lifecycle events
+  # Budget policy enforcement via ta-policy
+```
+
+#### Sandbox Runner (v0.9.2, not yet implemented)
+
+**Is it TA-specific?** No. Agent sandboxing (OCI/gVisor, network policy, CWD enforcement) is infrastructure.
+
+**Recommendation:** Standalone from the start. TA configures and invokes it, but the sandbox itself is reusable.
+
+### Applications (built on TA, not part of TA)
+
+These are products/use-cases that compose TA with domain-specific logic:
+
+| Feature | Plan Phase | Why it's an application, not TA |
+|---------|-----------|-------------------------------|
+| Domain workflow templates | v0.7.1 | Email, finance, social media are use cases |
+| Virtual Office Runtime | v1.0 | Orchestration product that depends on TA |
+| Community Memory | v0.8.1 | Distributed knowledge sharing is its own product |
+| Guided Setup | v0.7.0 | Onboarding UX, could be a separate CLI tool |
+
+**Recommendation:** These become separate repos:
+
+```
+ta-office/              # Virtual office runtime
+  # Role definitions, trigger system, orchestration
+  # Depends on: ta (core), agent-memory, agent-credentials
+
+ta-templates/           # Domain workflow templates
+  # sw-engineer, email-assistant, home-finance, etc.
+  # Each template is a directory of YAML configs
+  # Depends on: ta (core) for the config format
+
+ta-community/           # Community memory registry
+  # Opt-in knowledge sharing across TA instances
+  # Depends on: agent-memory, ruvector (for sync)
+```
+
+---
+
+## Proposed Architecture
+
+```
+Layer 3: Applications (separate repos)
+┌─────────────┐ ┌──────────────┐ ┌───────────────┐
+│  ta-office   │ │ ta-templates │ │ ta-community  │
+│ (v1.0)       │ │ (v0.7.1)     │ │ (v0.8.1)      │
+└──────┬───────┘ └──────┬───────┘ └───────┬───────┘
+       │                │                  │
+Layer 2: TA Core (this repo)
+┌──────┴────────────────┴──────────────────┴───────┐
+│  ta-core                                          │
+│  ├── ta-policy       (capability engine)          │
+│  ├── ta-audit        (hash-chained log)           │
+│  ├── ta-workspace    (staging isolation)           │
+│  ├── ta-changeset    (draft/review model)          │
+│  ├── ta-goal         (lifecycle state machine)     │
+│  ├── ta-submit       (submit adapters)             │
+│  ├── ta-mcp-gateway  (MCP server, tool handlers)   │
+│  ├── ta-connectors/* (resource connectors)         │
+│  └── ta-cli          (CLI binary)                  │
+│                                                    │
+│  TA-specific integration layers:                   │
+│  ├── ta-memory       (auto-capture, context inject)│
+│  ├── ta-budget       (budget policy enforcement)   │
+│  └── ta-sandbox-cfg  (sandbox config + policy)     │
+└──────┬────────────────┬──────────────────┬────────┘
+       │                │                  │
+Layer 1: Agent Infrastructure (standalone crates, publishable)
+┌──────┴───────┐ ┌──────┴──────┐ ┌────────┴───────┐
+│ agent-memory │ │ agent-creds │ │ agent-sandbox  │
+│              │ │             │ │                │
+│ MemoryStore  │ │ SecretStore │ │ SandboxRunner  │
+│ FsBackend    │ │ OAuth flows │ │ OCI/gVisor     │
+│ RuVector     │ │ Identity    │ │ Network policy │
+└──────┬───────┘ └─────────────┘ └────────────────┘
+       │
+┌──────┴───────┐
+│ ruvector-core│  (already a separate crate)
+│ HNSW vectors │
+└──────────────┘
+```
+
+---
+
+## Migration Path
+
+This doesn't need to happen all at once. A phased approach:
+
+### Phase A: After v0.5.7 (memory features complete)
+1. Extract `agent-memory` from `ta-memory` (store trait + backends)
+2. `ta-memory` becomes a thin layer: auto-capture + context injection + config
+3. Publish `agent-memory` as a standalone crate
+4. No breaking changes to TA — `ta-memory` re-exports everything
+
+### Phase B: Before v0.6 (supervisor + cost tracking)
+1. Implement cost tracking as `agent-budget` from the start
+2. `ta-budget` is the TA integration layer
+3. Evaluate extracting `ta-credentials` → `agent-credentials`
+
+### Phase C: Before v0.7 (templates + setup)
+1. Create `ta-templates` as a separate repo
+2. `ta setup` references templates from the external repo
+3. Domain-specific MCP server configs live in template packages
+
+### Phase D: Before v1.0 (virtual office)
+1. Create `ta-office` as a separate repo
+2. Virtual office runtime composes TA core + agent infrastructure
+3. TA core stays focused on mediation/governance
+
+---
+
+## Benefits of This Split
+
+1. **TA's thesis stays clear**: "All agent actions are mediated." No dilution from memory stores, finance templates, or office orchestration.
+
+2. **Agent infrastructure gets wider adoption**: `agent-memory` could be used by Claude Code plugins, Codex extensions, LangChain, etc. — not locked to TA users.
+
+3. **Applications can evolve independently**: The virtual office doesn't need to wait for TA core releases. Templates can be community-contributed.
+
+4. **Testing and CI scale better**: TA core tests don't need to build ruvector, Plaid integrations, or OCI runtime dependencies.
+
+5. **Onboarding is simpler**: New contributors see a focused core, not a monolith that does everything from hash-chained audit logs to family office portfolio reporting.
+
+---
+
+## Risks
+
+1. **Coordination overhead**: Multiple repos mean more release coordination. Mitigated by workspace-level version pinning and a CI matrix.
+
+2. **Feature drift**: Extracted crates might evolve in ways TA doesn't expect. Mitigated by TA owning the integration layers and pinning versions.
+
+3. **Premature extraction**: Extracting too early means the interfaces aren't stable yet. The migration path above defers extraction until each feature area is proven (post-v0.5.7 for memory, post-v0.6 for budget/credentials).
+
+---
+
+## Decision Needed
+
+After v0.5.7 ships:
+- [ ] Review this ADR
+- [ ] Decide whether to extract `agent-memory` as Phase A
+- [ ] Decide whether v0.7.1 domain templates should be a separate repo from the start
+- [ ] Decide whether v1.0 virtual office should be planned as a separate project
+
+---
+
+## Appendix: ta-memory vs. ruvector Decision Matrix
+
+| If you need... | Use ruvector-core directly | Use agent-memory | Use ta-memory (TA integration) |
+|---------------|---------------------------|-----------------|-------------------------------|
+| Raw vector storage + k-NN search | Yes | Overkill | Overkill |
+| Structured agent knowledge with tags, categories | No | Yes | Yes |
+| Zero-dependency JSON file fallback | No | Yes | Yes |
+| Semantic search + exact-key recall | Partial (search only) | Yes (both) | Yes (both) |
+| Auto-capture from TA goal/draft events | No | No | Yes |
+| CLAUDE.md context injection | No | No | Yes |
+| Cross-framework source tracking | No | Yes (source field) | Yes |
+| Use outside of TA | Yes | Yes | No (TA-specific) |
+
+The three layers serve different audiences:
+- **ruvector-core**: Anyone who needs a Rust vector database
+- **agent-memory** (proposed): Anyone building AI agents who need persistent knowledge
+- **ta-memory**: TA users who want lifecycle-driven automatic knowledge capture

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -831,18 +831,68 @@ TA returns:  { "rule": "Always use tempfile::tempdir() for filesystem tests" }
 
 This works identically for Claude Code, Codex, or any agent connected via MCP. The agent doesn't need to know which framework stored the entry.
 
+The `ta_context` MCP tool also supports `source` and `category` parameters (v0.5.6):
+
+```
+Agent calls: ta_context {
+  action: "store",
+  key: "test-fixtures",
+  value: {"rule": "Use tempfile::tempdir()"},
+  tags: ["convention", "testing"],
+  source: "claude-code",
+  category: "convention"
+}
+```
+
+And a `search` action for semantic search (requires ruvector backend):
+
+```
+Agent calls: ta_context { action: "search", query: "testing conventions", limit: 5 }
+```
+
+#### Automatic State Capture (v0.5.6)
+
+TA can automatically capture knowledge from lifecycle events so agents don't repeat mistakes and new agents start with context from previous sessions:
+
+```toml
+# .ta/workflow.toml
+[memory.auto_capture]
+on_goal_complete = true        # Store "what worked" from approved drafts
+on_draft_reject = true         # Store rejection reasons to prevent repeated mistakes
+on_human_guidance = true       # Store human feedback as persistent knowledge
+on_repeated_correction = true  # Auto-promote patterns corrected 3+ times
+correction_threshold = 3       # How many repeats before auto-promotion
+max_context_entries = 10       # Max entries injected into agent context
+```
+
+All settings default to `true` (enabled). Create `.ta/workflow.toml` to customize.
+
+**What gets captured automatically:**
+
+| Event | What's stored | Category |
+|-------|--------------|----------|
+| Goal completes | Title, changed files, change summary | history |
+| Draft rejected | What was attempted, rejection reason | history |
+| Human guidance | The guidance text and tags | preference |
+| Repeated correction | Promoted to persistent preference | preference |
+
+#### Context Injection on Launch
+
+When `ta run` launches an agent, it queries the memory store and injects relevant entries into a "Prior Context" section in CLAUDE.md. This means every agent starts with knowledge from all previous sessions, regardless of which framework produced it.
+
 #### What gets stored
 
 | Category | Example | How it's captured |
 |----------|---------|-------------------|
-| **Conventions** | "Use 4-space indent", "Run clippy before commit" | Human stores via CLI or agent stores via MCP |
-| **Architecture** | "Auth is JWT-based, module at src/auth/" | Agent stores during goal work |
-| **Decisions** | "Chose SQLite over Postgres for MVP" | Stored from draft review discussions |
-| **Preferences** | "Human prefers small focused PRs" | Stored from repeated review patterns |
+| **Conventions** | "Use 4-space indent", "Run clippy before commit" | Human guidance, repeated corrections, auto-capture |
+| **Architecture** | "Auth is JWT-based, module at src/auth/" | Goal completion auto-capture, agent via MCP |
+| **History** | "Tried Redis caching, rejected -- too complex for MVP" | Draft rejection auto-capture |
+| **Preferences** | "Human prefers small focused PRs" | Repeated correction auto-promotion |
+| **Relationships** | "config.toml depends on src/config.rs" | Agent stores via MCP |
 
 #### Storage details
 
-Entries are JSON files in `.ta/memory/`, one per key. The filesystem backend is the zero-dependency default. For semantic search (find memories *similar to* a query rather than exact-match), a future phase adds the [ruvector](https://github.com/ruvnet/ruvector) vector database backend -- see [Roadmap](#roadmap).
+Entries are JSON files in `.ta/memory/`, one per key. The filesystem backend is the zero-dependency default. For semantic search, enable the ruvector backend (v0.5.5+).
 
 #### Configuration
 
@@ -1035,7 +1085,8 @@ TA has a working end-to-end workflow: staging isolation, agent wrapping, draft r
 | v0.5.2 | Minimal web review UI | Done |
 | v0.5.3 | ReviewChannel adapters (webhook, Slack/email stubs) | Done |
 | v0.5.4 | Context memory store (filesystem backend) | Done |
-| v0.5.5 | RuVector memory backend (semantic search, HNSW indexing) | Pending |
+| v0.5.5 | RuVector memory backend (semantic search, HNSW indexing) | Done |
+| v0.5.6 | Framework-agnostic agent state (auto-capture, context injection) | Done |
 | v0.5.6 | Framework-agnostic agent state (cross-framework context) | Pending |
 | v0.5.7 | Semantic memory queries and memory dashboard | Pending |
 


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.5.6 — Framework-Agnostic Agent State

**Why**: Implement v0.5.6 — Framework-Agnostic Agent State

**Impact**: 14 file(s) changed

## Changes (14 file(s))

- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/PLAN.md` — Added completed checklist items under v0.5.6 section documenting all implemented features and test counts.
  - Plan tracking policy requires updating PLAN.md with completed work items.
- `~` `fs://workspace/apps/ta-cli/Cargo.toml` — Updated version from 0.5.5-alpha to 0.5.6-alpha.
  - Version bump to match the phase being implemented.
- `~` `fs://workspace/apps/ta-cli/src/commands/context.rs` — Added category: None to MemoryQuery struct initialization to match new required field.
  - MemoryQuery gained a category field in store.rs; existing callers need to provide it.
- `~` `fs://workspace/apps/ta-cli/src/commands/run.rs` — Added build_memory_context_section_for_inject() to query memory store and inject a 'Prior Context' section into CLAUDE.md at agent launch. Added auto_capture_goal_completion() to capture goal completion + change_summary.json into memory after draft build. Updated inject_claude_md() format string to include memory section.
  - Context injection ensures every agent starts with knowledge from prior sessions. Goal completion capture creates the memory entries that future agents will consume.
- `~` `fs://workspace/crates/ta-mcp-gateway/src/server.rs` — Added auto_capture_config field to GatewayState, loaded from .ta/workflow.toml. Wired PrApproved/PrDenied event dispatch into ta_draft submit flow. Auto-captures draft rejections into memory. Extended ta_context MCP tool with source, goal_id, category parameters and new 'search' action. Extended ContextToolParams struct.
  - ta_draft submit now dispatches previously-defined but unwired PrApproved/PrDenied events, auto-captures rejections for agent learning, and ta_context gains framework metadata support for cross-framework recall.
- `~` `fs://workspace/crates/ta-memory/Cargo.toml` — Updated version from 0.5.0-alpha to 0.5.6-alpha.
  - Version bump to match the phase being implemented.
- `+` `fs://workspace/crates/ta-memory/src/auto_capture.rs` — New module implementing automatic state capture: AutoCaptureConfig (parsed from .ta/workflow.toml), AutoCapture struct with on_goal_complete(), on_draft_reject(), on_human_guidance(), check_repeated_correction() handlers. Also includes build_memory_context_section() for CLAUDE.md injection, load_config() for TOML parsing, and 9 unit tests.
  - Core of v0.5.6 — converts lifecycle events (goal completion, draft rejection, human guidance, repeated corrections) into persistent memory entries that any agent framework can access.
- `~` `fs://workspace/crates/ta-memory/src/fs_store.rs` — Implemented store_with_params() that writes goal_id and category to JSON entries. Updated lookup() to filter by category. Delegated store() to store_with_params() with default params.
  - FsMemoryStore needs to persist and query the new category and goal_id fields for framework-agnostic state capture.
- `~` `fs://workspace/crates/ta-memory/src/lib.rs` — Added auto_capture module declaration and re-exports for AutoCapture, AutoCaptureConfig, DraftRejectEvent, GoalCompleteEvent, HumanGuidanceEvent, MemoryCategory, StoreParams.
  - New types need to be publicly accessible from the ta-memory crate.
- `~` `fs://workspace/crates/ta-memory/src/ruvector_store.rs` — Implemented store_with_params() that persists goal_id and category in vector metadata. Updated metadata serialization/deserialization to include category field. Updated lookup() to filter by category.
  - RuVector backend needs parity with FsMemoryStore for the new fields to enable seamless backend switching.
- `~` `fs://workspace/crates/ta-memory/src/store.rs` — Added MemoryCategory enum (convention, architecture, history, preference, relationship, other), StoreParams struct with goal_id and category, and store_with_params() method on MemoryStore trait with default implementation. Added category field to MemoryEntry and MemoryQuery.
  - Framework-agnostic agent state requires classifying memory entries by knowledge type and associating them with specific goals, so different agent frameworks can store and query categorized knowledge.
- `+` `fs://workspace/docs/ADR-modular-decomposition.md`
- `~` `fs://workspace/docs/USAGE.md` — Documented automatic state capture configuration (.ta/workflow.toml), context injection on launch, extended ta_context MCP tool parameters (source, category, search action), and updated roadmap table.
  - New user-facing features require documentation updates per project policy.

## Goal Context

- **Title**: Implement v0.5.6 — Framework-Agnostic Agent State
- **Objective**: Implement v0.5.6 — Framework-Agnostic Agent State
- **Goal ID**: `abea6f5d-534a-46fb-8a4f-5c90eb0505f1`
- **PR ID**: `4a0e8b10-04eb-47e6-8f37-8cbd6a177691`
- **Plan Phase**: `0.5.6`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
