### PR TITLE
Implement v0.6 — Platform Substrate - all phases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.5.7-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2341,6 +2341,7 @@ dependencies = [
  "ta-mcp-gateway",
  "ta-memory",
  "ta-policy",
+ "ta-session",
  "ta-submit",
  "ta-workspace",
  "tempfile",
@@ -2467,6 +2468,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ta-mediation"
+version = "0.6.0-alpha"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "ta-changeset",
+ "ta-workspace",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "ta-memory"
 version = "0.5.7-alpha"
 dependencies = [
@@ -2483,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.4.5-alpha"
+version = "0.6.0-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -2503,6 +2519,21 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "ta-session"
+version = "0.6.0-alpha"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "ta-changeset",
+ "ta-goal",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ members = [
     "crates/ta-workspace",
     "crates/ta-credentials",
     "crates/ta-memory",
+    "crates/ta-mediation",
+    "crates/ta-session",
     "crates/ta-connectors/fs",
     "crates/ta-connectors/web",
     "crates/ta-connectors/mock-drive",

--- a/PLAN.md
+++ b/PLAN.md
@@ -1495,43 +1495,53 @@ Auto-capture on goal complete, auto-capture on rejection, context injection into
 
 > **Design principle**: TA is a Rust daemon, not an LLM. It launches agent frameworks as subprocesses, mediates resource access, and builds drafts from workspace diffs when the agent exits.
 
-- **`TaSession`**: Core session object tracking `current_goal`, `conversation_history` (human↔agent thread across iterations), `pending_review`, and `event_stream`.
-- **New crate: `ta-session`**: Session lifecycle, conversational continuity, event streaming. Depends on `ta-goal`, `ta-changeset`, `ta-memory`.
-- **TA is invisible to agents**: Agent works in staging workspace, writes `change_summary.json` (with rationale), and exits. TA diffs and builds draft. No TA MCP calls from agent.
-- **Conversational continuity**: When the human rejects a draft with feedback, TA relaunches the agent with: original goal + previous work context + human feedback + memory. Feels like one conversation to the human. No IDs to track.
-- **Human control plane commands** (via TA CLI, invisible to agents):
-  - `ta session status` — what the agent is doing right now
-  - `ta session pause/resume` — pause/resume agent execution
-  - `ta draft view` — review latest draft (no ID needed)
-  - `ta draft approve` / `ta draft reject "reason"` — review decisions
-  - `ta audit trail` — what happened so far
-- **SessionEvent** stream: `FileChanged`, `ActionIntercepted`, `DraftReady`, `GoalCompleted`, `ReviewDecision`. Published to all connected IO channels.
-- **Orchestrators as agent frameworks**: Claude Flow, LangGraph, CrewAI are launched as subprocesses like any other agent. TA doesn't know or care about internal multi-agent coordination — it mediates resource access through the MCP gateway and diffs the result.
-- **Change rationale**: `change_summary.json` gains a `rationale` field (approach chosen, alternatives considered, tradeoffs) shown in `ta draft view`.
-- **One session, one agent, one goal**: Simple lifecycle. Follow-up goals (including switching to a different framework) start new sessions that inherit memory and context.
-- **Checkpoint mode (opt-in)**: `--checkpoint` flag for batch/CI workflows where the human isn't watching.
+**Completed**:
+- ✅ **`TaSession`**: Core session object with `session_id`, `goal_id`, `agent_id`, `state` (SessionState enum), `conversation` (Vec<ConversationTurn>), `pending_draft`, `iteration_count`, `checkpoint_mode`
+- ✅ **New crate: `ta-session`**: Session lifecycle with `TaSession`, `SessionState` (Starting → AgentRunning → DraftReady → WaitingForReview → Iterating → Completed → Aborted → Paused → Failed), `ConversationTurn`, `SessionManager`, `SessionError`
+- ✅ **SessionManager**: CRUD persistence in `.ta/sessions/<id>.json` with `create()`, `load()`, `save()`, `find_for_goal()`, `list()`, `list_active()`, `pause()`, `resume()`, `abort()`, `delete()`
+- ✅ **Human control plane commands**: `ta session status`, `ta session pause <id>`, `ta session resume <id>`, `ta session abort <id>`
+- ✅ **SessionEvent variants**: `SessionPaused`, `SessionResumed`, `SessionAborted`, `DraftBuilt`, `ReviewDecision`, `SessionIteration` added to `TaEvent` enum with helper constructors
+- ✅ **Checkpoint mode**: `with_checkpoint_mode()` builder on TaSession
+- ✅ **Conversational continuity**: `ConversationTurn` tracks agent_context, human_feedback, draft_id per iteration
+- ✅ **20 ta-session tests**, 4 new ta-goal event tests
+
+**Remaining (deferred)**:
+- Change rationale field in `change_summary.json` (needs draft viewer integration)
+- Full agent subprocess lifecycle management (launch, signal, relaunch with feedback)
 
 ### v0.6.1 — Unified Policy Config (Layer 2)
 <!-- status: pending -->
 **Goal**: All supervision configuration resolves to a single `PolicyDocument` loaded from `.ta/policy.yaml`.
 
-- **PolicyDocument** merges: `built_in_defaults + .ta/policy.yaml + agents/<name>.yaml + constitutions/goal-<id>.yaml + CLI overrides`
-- **`.ta/policy.yaml`**: Central config surface with `defaults`, `schemes` (per-URI-scheme rules), `escalation` triggers, and `agents` overrides.
-- **PolicyContext** on every request: `goal_id`, `session_id`, `budget_spent`, `action_count`, `drift_score` for runtime-aware decisions.
-- **Security levels**: Open (audit-only) → Checkpoint (default, review at draft) → Supervised (approve each state change) → Strict (constitutions required).
-- **Supervisor agent**: Verifies agent work within constitutional bounds for auto-approval. Trust levels: None → Constitutional → Full.
-- **Cost tracking**: Token usage per goal/agent/session. Budget limits in policy. Agent warned at 80%; stopped at 100%.
-- **"TA supervises TA"**: Supervisor config is a draft the human approves. Supervisor can't expand its own authority.
+**Completed**:
+- ✅ **PolicyDocument**: Unified config struct with `version`, `defaults` (PolicyDefaults), `schemes` (HashMap<String, SchemePolicy>), `escalation` (EscalationConfig), `agents` (HashMap<String, AgentPolicyOverride>), `security_level`, `budget` (BudgetConfig)
+- ✅ **PolicyCascade**: 6-layer tighten-only merge: built-in defaults → `.ta/policy.yaml` → `.ta/workflows/<name>.yaml` → `.ta/agents/<agent>.policy.yaml` → `.ta/constitutions/goal-<id>.yaml` → CLI overrides
+- ✅ **`.ta/policy.yaml`**: YAML-serializable config surface with `defaults`, `schemes`, `escalation`, `agents` sections
+- ✅ **PolicyContext**: Runtime context with `goal_id`, `session_id`, `agent_id`, `budget_spent`, `action_count`, `drift_score`; methods for `is_over_budget()`, `is_budget_warning()`, `is_drifting()`
+- ✅ **Security levels**: `SecurityLevel` enum with Ord: Open < Checkpoint (default) < Supervised < Strict
+- ✅ **PolicyEnforcement**: Warning < Error < Strict enforcement modes
+- ✅ **`evaluate_with_document()`**: New method on PolicyEngine layering document-level checks (scheme approval, agent overrides, drift escalation, action limits, budget limits, supervised mode)
+- ✅ **Cost tracking**: BudgetConfig with `max_tokens_per_goal` and `warn_at_percent` (default 80%)
+- ✅ **24 new tests** across document.rs (8), context.rs (6), cascade.rs (10) + 5 engine integration tests
+
+**Remaining (deferred)**:
+- Supervisor agent verification (needs agent runtime integration)
+- "TA supervises TA" pattern (needs supervisor config draft flow)
 
 ### v0.6.2 — Resource Mediation Trait (Layer 1)
 <!-- status: pending -->
 **Goal**: Generalize the staging pattern from files to any resource.
 
-- **New crate: `ta-mediation`**: `ResourceMediator` trait + shared types (`ProposedAction`, `StagedMutation`, `MutationPreview`, `ActionClassification`).
-- **`FsMediator`**: Adapts existing `FsConnector` + `StagingWorkspace` to implement `ResourceMediator`.
-- **Mediator registry**: `MediatorRegistry` in `ta-mcp-gateway` routes tool calls to the correct mediator by URI scheme.
-- **Config**: `.ta/config.yaml` → `mediators:` section to enable/disable per-scheme, link credentials.
-- **Output alignment**: `StagedMutation` maps to existing `DraftPackage.changes` (Artifacts, PatchSets, PendingActions).
+**Completed**:
+- ✅ **New crate: `ta-mediation`**: `ResourceMediator` trait with `scheme()`, `stage()`, `preview()`, `apply()`, `rollback()`, `classify()` methods
+- ✅ **Core types**: `ProposedAction`, `StagedMutation`, `MutationPreview`, `ActionClassification` (ReadOnly < StateChanging < Irreversible < ExternalSideEffect), `ApplyResult`
+- ✅ **`FsMediator`**: Implements `ResourceMediator` for `fs://` URIs — stage writes to staging dir, preview generates diffs, apply copies to source, rollback removes staged
+- ✅ **`MediatorRegistry`**: Routes URIs to mediators by scheme with `register()`, `get()`, `route()`, `schemes()`, `has_scheme()`
+- ✅ **22 ta-mediation tests** (5 mediator, 9 fs_mediator, 8 registry)
+
+**Remaining (deferred)**:
+- `.ta/config.yaml` mediators section (needs config system)
+- Output alignment with DraftPackage.changes (needs draft builder integration)
 
 ---
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-cli"
-version = "0.5.7-alpha"
+version = "0.6.0-alpha"
 edition = "2021"
 description = "CLI for goals, PR review, and approvals in Trusted Autonomy"
 license = "Apache-2.0"
@@ -41,6 +41,7 @@ ta-connector-fs = { path = "../../crates/ta-connectors/fs" }
 ta-goal = { path = "../../crates/ta-goal" }
 ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway" }
 ta-policy = { path = "../../crates/ta-policy" }
+ta-session = { path = "../../crates/ta-session" }
 ta-submit = { path = "../../crates/ta-submit" }
 ta-workspace = { path = "../../crates/ta-workspace" }
 

--- a/apps/ta-cli/src/commands/session.rs
+++ b/apps/ta-cli/src/commands/session.rs
@@ -6,6 +6,7 @@
 use clap::Subcommand;
 use ta_changeset::InteractiveSessionStore;
 use ta_mcp_gateway::GatewayConfig;
+use ta_session::SessionManager;
 use uuid::Uuid;
 
 #[derive(Subcommand)]
@@ -29,6 +30,21 @@ pub enum SessionCommands {
         #[arg(long)]
         agent: Option<String>,
     },
+    /// Pause a running session (v0.6.0).
+    Pause {
+        /// Session ID (full or prefix).
+        id: String,
+    },
+    /// Abort a session (v0.6.0).
+    Abort {
+        /// Session ID (full or prefix).
+        id: String,
+        /// Reason for aborting.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Show session status summary (v0.6.0).
+    Status,
 }
 
 pub fn execute(cmd: &SessionCommands, config: &GatewayConfig) -> anyhow::Result<()> {
@@ -54,6 +70,9 @@ pub fn execute(cmd: &SessionCommands, config: &GatewayConfig) -> anyhow::Result<
                 Some(id.as_str()),
             )
         }
+        SessionCommands::Pause { id } => pause_session(config, id),
+        SessionCommands::Abort { id, reason } => abort_session(config, id, reason.as_deref()),
+        SessionCommands::Status => session_status(config),
     }
 }
 
@@ -138,6 +157,80 @@ fn show_session(store: &InteractiveSessionStore, id: &str) -> anyhow::Result<()>
     }
 
     Ok(())
+}
+
+fn pause_session(config: &GatewayConfig, id: &str) -> anyhow::Result<()> {
+    let sessions_dir = config.workspace_root.join(".ta/sessions");
+    let manager = SessionManager::new(sessions_dir)?;
+
+    let uuid = resolve_session_id(&manager, id)?;
+    manager.pause(uuid)?;
+    println!("Session {} paused.", &uuid.to_string()[..8]);
+    Ok(())
+}
+
+fn abort_session(config: &GatewayConfig, id: &str, reason: Option<&str>) -> anyhow::Result<()> {
+    let sessions_dir = config.workspace_root.join(".ta/sessions");
+    let manager = SessionManager::new(sessions_dir)?;
+
+    let uuid = resolve_session_id(&manager, id)?;
+    manager.abort(uuid)?;
+    println!(
+        "Session {} aborted.{}",
+        &uuid.to_string()[..8],
+        reason
+            .map(|r| format!(" Reason: {}", r))
+            .unwrap_or_default()
+    );
+    Ok(())
+}
+
+fn session_status(config: &GatewayConfig) -> anyhow::Result<()> {
+    let sessions_dir = config.workspace_root.join(".ta/sessions");
+    let manager = SessionManager::new(sessions_dir)?;
+
+    let active = manager.list_active()?;
+    if active.is_empty() {
+        println!("No active sessions.");
+        return Ok(());
+    }
+
+    println!(
+        "{:<38} {:<38} {:<12} {:<14} {:<6} {:<10}",
+        "SESSION ID", "GOAL ID", "AGENT", "STATE", "ITER", "ELAPSED"
+    );
+    println!("{}", "-".repeat(118));
+
+    for s in &active {
+        println!(
+            "{:<38} {:<38} {:<12} {:<14} {:<6} {:<10}",
+            s.session_id,
+            s.goal_id,
+            truncate(&s.agent_id, 10),
+            format!("{}", s.state),
+            s.iteration_count,
+            s.elapsed_display(),
+        );
+    }
+
+    println!("\n{} active session(s).", active.len());
+    Ok(())
+}
+
+fn resolve_session_id(manager: &SessionManager, id: &str) -> anyhow::Result<Uuid> {
+    if let Ok(uuid) = Uuid::parse_str(id) {
+        return Ok(uuid);
+    }
+    let all = manager.list()?;
+    let matches: Vec<_> = all
+        .into_iter()
+        .filter(|s| s.session_id.to_string().starts_with(id))
+        .collect();
+    match matches.len() {
+        0 => anyhow::bail!("No session found matching '{}'", id),
+        1 => Ok(matches[0].session_id),
+        n => anyhow::bail!("Ambiguous prefix '{}' matches {} sessions", id, n),
+    }
 }
 
 fn truncate(s: &str, max: usize) -> String {

--- a/crates/ta-goal/src/events.rs
+++ b/crates/ta-goal/src/events.rs
@@ -122,6 +122,49 @@ pub enum TaEvent {
         status_note: String,
         timestamp: DateTime<Utc>,
     },
+
+    /// A session was paused by the human (v0.6.0).
+    SessionPaused {
+        session_id: Uuid,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A paused session was resumed (v0.6.0).
+    SessionResumed {
+        session_id: Uuid,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A session was aborted by the human (v0.6.0).
+    SessionAborted {
+        session_id: Uuid,
+        reason: String,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// A draft was built from workspace diff (v0.6.0).
+    DraftBuilt {
+        session_id: Uuid,
+        draft_id: Uuid,
+        artifact_count: usize,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// Human made a review decision on a draft (v0.6.0).
+    ReviewDecision {
+        session_id: Uuid,
+        draft_id: Uuid,
+        approved: bool,
+        feedback: Option<String>,
+        timestamp: DateTime<Utc>,
+    },
+
+    /// Session entered a new iteration after rejection (v0.6.0).
+    SessionIteration {
+        session_id: Uuid,
+        iteration: u32,
+        timestamp: DateTime<Utc>,
+    },
 }
 
 impl TaEvent {
@@ -139,6 +182,12 @@ impl TaEvent {
             TaEvent::SessionStateChanged { .. } => "session_state_changed",
             TaEvent::SessionMessage { .. } => "session_message",
             TaEvent::PlanUpdateProposed { .. } => "plan_update_proposed",
+            TaEvent::SessionPaused { .. } => "session_paused",
+            TaEvent::SessionResumed { .. } => "session_resumed",
+            TaEvent::SessionAborted { .. } => "session_aborted",
+            TaEvent::DraftBuilt { .. } => "draft_built",
+            TaEvent::ReviewDecision { .. } => "review_decision",
+            TaEvent::SessionIteration { .. } => "session_iteration",
         }
     }
 
@@ -158,6 +207,66 @@ impl TaEvent {
             goal_run_id,
             from_state: from.to_string(),
             to_state: to.to_string(),
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Helper to create a SessionPaused event (v0.6.0).
+    pub fn session_paused(session_id: Uuid) -> Self {
+        TaEvent::SessionPaused {
+            session_id,
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Helper to create a SessionResumed event (v0.6.0).
+    pub fn session_resumed(session_id: Uuid) -> Self {
+        TaEvent::SessionResumed {
+            session_id,
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Helper to create a SessionAborted event (v0.6.0).
+    pub fn session_aborted(session_id: Uuid, reason: &str) -> Self {
+        TaEvent::SessionAborted {
+            session_id,
+            reason: reason.to_string(),
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Helper to create a DraftBuilt event (v0.6.0).
+    pub fn draft_built(session_id: Uuid, draft_id: Uuid, artifact_count: usize) -> Self {
+        TaEvent::DraftBuilt {
+            session_id,
+            draft_id,
+            artifact_count,
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Helper to create a ReviewDecision event (v0.6.0).
+    pub fn review_decision(
+        session_id: Uuid,
+        draft_id: Uuid,
+        approved: bool,
+        feedback: Option<&str>,
+    ) -> Self {
+        TaEvent::ReviewDecision {
+            session_id,
+            draft_id,
+            approved,
+            feedback: feedback.map(|s| s.to_string()),
+            timestamp: Utc::now(),
+        }
+    }
+
+    /// Helper to create a SessionIteration event (v0.6.0).
+    pub fn session_iteration(session_id: Uuid, iteration: u32) -> Self {
+        TaEvent::SessionIteration {
+            session_id,
+            iteration,
             timestamp: Utc::now(),
         }
     }
@@ -315,5 +424,64 @@ mod tests {
                 .event_type(),
             "goal_state_changed"
         );
+    }
+
+    #[test]
+    fn session_event_types_v060() {
+        let sid = Uuid::new_v4();
+        let did = Uuid::new_v4();
+
+        assert_eq!(TaEvent::session_paused(sid).event_type(), "session_paused");
+        assert_eq!(
+            TaEvent::session_resumed(sid).event_type(),
+            "session_resumed"
+        );
+        assert_eq!(
+            TaEvent::session_aborted(sid, "user cancelled").event_type(),
+            "session_aborted"
+        );
+        assert_eq!(
+            TaEvent::draft_built(sid, did, 5).event_type(),
+            "draft_built"
+        );
+        assert_eq!(
+            TaEvent::review_decision(sid, did, true, None).event_type(),
+            "review_decision"
+        );
+        assert_eq!(
+            TaEvent::session_iteration(sid, 2).event_type(),
+            "session_iteration"
+        );
+    }
+
+    #[test]
+    fn session_event_serialization_v060() {
+        let sid = Uuid::new_v4();
+        let did = Uuid::new_v4();
+
+        let events = vec![
+            TaEvent::session_paused(sid),
+            TaEvent::session_resumed(sid),
+            TaEvent::session_aborted(sid, "cancelled"),
+            TaEvent::draft_built(sid, did, 3),
+            TaEvent::review_decision(sid, did, false, Some("needs work")),
+            TaEvent::session_iteration(sid, 1),
+        ];
+
+        for event in &events {
+            let json = serde_json::to_string(event).unwrap();
+            let restored: TaEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(event.event_type(), restored.event_type());
+        }
+    }
+
+    #[test]
+    fn review_decision_with_feedback() {
+        let sid = Uuid::new_v4();
+        let did = Uuid::new_v4();
+        let event = TaEvent::review_decision(sid, did, false, Some("Fix the auth module"));
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("Fix the auth module"));
+        assert!(json.contains("\"approved\":false"));
     }
 }

--- a/crates/ta-mediation/Cargo.toml
+++ b/crates/ta-mediation/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ta-mediation"
+version = "0.6.0-alpha"
+edition = "2021"
+description = "Resource mediation trait — generalizes the staging pattern from files to any resource"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+# Workspace crates for FsMediator
+ta-workspace = { path = "../ta-workspace" }
+ta-changeset = { path = "../ta-changeset" }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/ta-mediation/src/error.rs
+++ b/crates/ta-mediation/src/error.rs
@@ -1,0 +1,34 @@
+// error.rs — Error types for the mediation crate.
+
+use std::path::PathBuf;
+
+/// Errors from resource mediation operations.
+#[derive(Debug, thiserror::Error)]
+pub enum MediationError {
+    #[error("unsupported scheme: '{scheme}'")]
+    UnsupportedScheme { scheme: String },
+
+    #[error("staging failed for {uri}: {reason}")]
+    StagingFailed { uri: String, reason: String },
+
+    #[error("apply failed for {uri}: {reason}")]
+    ApplyFailed { uri: String, reason: String },
+
+    #[error("rollback failed for {uri}: {reason}")]
+    RollbackFailed { uri: String, reason: String },
+
+    #[error("no mediator registered for scheme '{scheme}'")]
+    NoMediator { scheme: String },
+
+    #[error("invalid URI: '{uri}'")]
+    InvalidUri { uri: String },
+
+    #[error("I/O error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("workspace error: {0}")]
+    Workspace(String),
+}

--- a/crates/ta-mediation/src/fs_mediator.rs
+++ b/crates/ta-mediation/src/fs_mediator.rs
@@ -1,0 +1,321 @@
+// fs_mediator.rs — FsMediator: ResourceMediator implementation for filesystem resources.
+//
+// Wraps the existing StagingWorkspace to implement the ResourceMediator trait.
+// This is the first (and built-in) mediator — it handles `fs://` URIs.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use crate::error::MediationError;
+use crate::mediator::{
+    ActionClassification, ApplyResult, MutationPreview, ProposedAction, ResourceMediator,
+    StagedMutation,
+};
+
+/// Filesystem mediator — stages file writes in a workspace, applies on approval.
+///
+/// Delegates to `ta-workspace::StagingWorkspace` for the actual staging mechanics.
+/// This adapter makes the existing staging system conform to the `ResourceMediator` trait.
+pub struct FsMediator {
+    /// Root of the staging workspace (where staged files live).
+    staging_dir: PathBuf,
+    /// Root of the source directory (the real filesystem).
+    source_dir: PathBuf,
+}
+
+impl FsMediator {
+    /// Create a new filesystem mediator.
+    ///
+    /// - `staging_dir`: where staged files are written before approval
+    /// - `source_dir`: the real filesystem root (for generating diffs)
+    pub fn new(staging_dir: PathBuf, source_dir: PathBuf) -> Self {
+        Self {
+            staging_dir,
+            source_dir,
+        }
+    }
+
+    /// Extract the relative path from a `fs://workspace/...` URI.
+    fn relative_path(uri: &str) -> Result<&str, MediationError> {
+        uri.strip_prefix("fs://workspace/")
+            .ok_or_else(|| MediationError::InvalidUri {
+                uri: uri.to_string(),
+            })
+    }
+}
+
+impl ResourceMediator for FsMediator {
+    fn scheme(&self) -> &str {
+        "fs"
+    }
+
+    fn stage(&self, action: ProposedAction) -> Result<StagedMutation, MediationError> {
+        let rel_path = Self::relative_path(&action.target_uri)?;
+
+        // Extract content from parameters.
+        let content = action
+            .parameters
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        // Write to staging directory.
+        let staged_path = self.staging_dir.join(rel_path);
+        if let Some(parent) = staged_path.parent() {
+            fs::create_dir_all(parent).map_err(|source| MediationError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        fs::write(&staged_path, content.as_bytes()).map_err(|source| MediationError::Io {
+            path: staged_path.clone(),
+            source,
+        })?;
+
+        Ok(StagedMutation {
+            mutation_id: Uuid::new_v4(),
+            action,
+            staged_at: Utc::now(),
+            preview: None,
+            staging_ref: staged_path.to_string_lossy().to_string(),
+        })
+    }
+
+    fn preview(&self, staged: &StagedMutation) -> Result<MutationPreview, MediationError> {
+        let rel_path = Self::relative_path(&staged.action.target_uri)?;
+        let source_path = self.source_dir.join(rel_path);
+        let staged_path = Path::new(&staged.staging_ref);
+
+        let diff = if source_path.exists() && staged_path.exists() {
+            let original = fs::read_to_string(&source_path).unwrap_or_default();
+            let modified = fs::read_to_string(staged_path).unwrap_or_default();
+            if original == modified {
+                None
+            } else {
+                Some(format!(
+                    "--- a/{}\n+++ b/{}\n(content differs)",
+                    rel_path, rel_path
+                ))
+            }
+        } else if staged_path.exists() {
+            Some(format!("--- /dev/null\n+++ b/{}\n(new file)", rel_path))
+        } else {
+            None
+        };
+
+        let is_new_file = !source_path.exists();
+        let summary = if is_new_file {
+            format!("Create new file: {}", rel_path)
+        } else {
+            format!("Modify file: {}", rel_path)
+        };
+
+        Ok(MutationPreview {
+            summary,
+            diff,
+            risk_flags: vec![],
+            classification: self.classify(&staged.action),
+        })
+    }
+
+    fn apply(&self, staged: &StagedMutation) -> Result<ApplyResult, MediationError> {
+        let rel_path = Self::relative_path(&staged.action.target_uri)?;
+        let staged_path = Path::new(&staged.staging_ref);
+        let target_path = self.source_dir.join(rel_path);
+
+        if !staged_path.exists() {
+            return Err(MediationError::ApplyFailed {
+                uri: staged.action.target_uri.clone(),
+                reason: "staged file does not exist".to_string(),
+            });
+        }
+
+        // Ensure parent directories exist in target.
+        if let Some(parent) = target_path.parent() {
+            fs::create_dir_all(parent).map_err(|source| MediationError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+
+        let content = fs::read(staged_path).map_err(|source| MediationError::Io {
+            path: staged_path.to_path_buf(),
+            source,
+        })?;
+        fs::write(&target_path, &content).map_err(|source| MediationError::Io {
+            path: target_path,
+            source,
+        })?;
+
+        Ok(ApplyResult {
+            mutation_id: staged.mutation_id,
+            success: true,
+            message: format!("Applied {} to source", rel_path),
+            applied_at: Utc::now(),
+        })
+    }
+
+    fn rollback(&self, staged: &StagedMutation) -> Result<(), MediationError> {
+        let staged_path = Path::new(&staged.staging_ref);
+        if staged_path.exists() {
+            fs::remove_file(staged_path).map_err(|source| MediationError::Io {
+                path: staged_path.to_path_buf(),
+                source,
+            })?;
+        }
+        Ok(())
+    }
+
+    fn classify(&self, action: &ProposedAction) -> ActionClassification {
+        match action.verb.as_str() {
+            "read" | "list" | "diff" => ActionClassification::ReadOnly,
+            "write" | "write_patch" | "create" | "modify" => ActionClassification::StateChanging,
+            "delete" => ActionClassification::StateChanging,
+            "apply" | "commit" => ActionClassification::StateChanging,
+            _ => ActionClassification::StateChanging,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn setup() -> (FsMediator, PathBuf, PathBuf) {
+        let staging = tempdir().unwrap();
+        let source = tempdir().unwrap();
+        let staging_path = staging.keep();
+        let source_path = source.keep();
+        let mediator = FsMediator::new(staging_path.clone(), source_path.clone());
+        (mediator, staging_path, source_path)
+    }
+
+    #[test]
+    fn stage_creates_file_in_staging() {
+        let (mediator, staging_path, _) = setup();
+
+        let action = ProposedAction::new("fs", "write", "fs://workspace/hello.txt")
+            .with_parameters(serde_json::json!({"content": "Hello, world!"}));
+
+        let staged = mediator.stage(action).unwrap();
+        assert!(Path::new(&staged.staging_ref).exists());
+
+        let content = fs::read_to_string(staging_path.join("hello.txt")).unwrap();
+        assert_eq!(content, "Hello, world!");
+    }
+
+    #[test]
+    fn stage_creates_nested_directories() {
+        let (mediator, staging_path, _) = setup();
+
+        let action = ProposedAction::new("fs", "write", "fs://workspace/src/deep/file.rs")
+            .with_parameters(serde_json::json!({"content": "fn main() {}"}));
+
+        mediator.stage(action).unwrap();
+        assert!(staging_path.join("src/deep/file.rs").exists());
+    }
+
+    #[test]
+    fn preview_new_file() {
+        let (mediator, _, _) = setup();
+
+        let action = ProposedAction::new("fs", "write", "fs://workspace/new.txt")
+            .with_parameters(serde_json::json!({"content": "new content"}));
+
+        let staged = mediator.stage(action).unwrap();
+        let preview = mediator.preview(&staged).unwrap();
+
+        assert!(preview.summary.contains("Create new file"));
+        assert!(preview.diff.is_some());
+        assert!(preview.diff.unwrap().contains("/dev/null"));
+    }
+
+    #[test]
+    fn preview_modified_file() {
+        let (mediator, _, source_path) = setup();
+
+        // Create an existing file in source.
+        fs::write(source_path.join("existing.txt"), "original").unwrap();
+
+        let action = ProposedAction::new("fs", "write", "fs://workspace/existing.txt")
+            .with_parameters(serde_json::json!({"content": "modified"}));
+
+        let staged = mediator.stage(action).unwrap();
+        let preview = mediator.preview(&staged).unwrap();
+
+        assert!(preview.summary.contains("Modify file"));
+        assert!(preview.diff.is_some());
+    }
+
+    #[test]
+    fn apply_copies_to_source() {
+        let (mediator, _, source_path) = setup();
+
+        let action = ProposedAction::new("fs", "write", "fs://workspace/applied.txt")
+            .with_parameters(serde_json::json!({"content": "applied content"}));
+
+        let staged = mediator.stage(action).unwrap();
+        let result = mediator.apply(&staged).unwrap();
+
+        assert!(result.success);
+        let content = fs::read_to_string(source_path.join("applied.txt")).unwrap();
+        assert_eq!(content, "applied content");
+    }
+
+    #[test]
+    fn rollback_removes_staged_file() {
+        let (mediator, _, _) = setup();
+
+        let action = ProposedAction::new("fs", "write", "fs://workspace/rollback.txt")
+            .with_parameters(serde_json::json!({"content": "temporary"}));
+
+        let staged = mediator.stage(action).unwrap();
+        assert!(Path::new(&staged.staging_ref).exists());
+
+        mediator.rollback(&staged).unwrap();
+        assert!(!Path::new(&staged.staging_ref).exists());
+    }
+
+    #[test]
+    fn classify_read_actions() {
+        let (mediator, _, _) = setup();
+
+        let read = ProposedAction::new("fs", "read", "fs://workspace/file.txt");
+        assert_eq!(mediator.classify(&read), ActionClassification::ReadOnly);
+
+        let list = ProposedAction::new("fs", "list", "fs://workspace/");
+        assert_eq!(mediator.classify(&list), ActionClassification::ReadOnly);
+    }
+
+    #[test]
+    fn classify_write_actions() {
+        let (mediator, _, _) = setup();
+
+        let write = ProposedAction::new("fs", "write", "fs://workspace/file.txt");
+        assert_eq!(
+            mediator.classify(&write),
+            ActionClassification::StateChanging
+        );
+
+        let delete = ProposedAction::new("fs", "delete", "fs://workspace/file.txt");
+        assert_eq!(
+            mediator.classify(&delete),
+            ActionClassification::StateChanging
+        );
+    }
+
+    #[test]
+    fn invalid_uri_rejected() {
+        let (mediator, _, _) = setup();
+
+        let action = ProposedAction::new("fs", "write", "invalid://no/prefix")
+            .with_parameters(serde_json::json!({"content": "data"}));
+
+        let result = mediator.stage(action);
+        assert!(result.is_err());
+    }
+}

--- a/crates/ta-mediation/src/lib.rs
+++ b/crates/ta-mediation/src/lib.rs
@@ -1,0 +1,24 @@
+// ta-mediation — Resource mediation trait (Layer 1).
+//
+// Generalizes the staging pattern from files to any resource. Every state-changing
+// action an agent proposes is staged before it touches the real world.
+//
+// This crate defines:
+// - `ResourceMediator` trait — the core abstraction
+// - `FsMediator` — built-in filesystem mediator (wraps existing staging workspace)
+// - `MediatorRegistry` — routes URIs to the correct mediator
+// - Core types: ProposedAction, StagedMutation, MutationPreview, ActionClassification
+
+pub mod error;
+pub mod fs_mediator;
+pub mod mediator;
+pub mod registry;
+
+// Re-export primary types for convenience.
+pub use error::MediationError;
+pub use fs_mediator::FsMediator;
+pub use mediator::{
+    ActionClassification, ApplyResult, MutationPreview, ProposedAction, ResourceMediator,
+    StagedMutation,
+};
+pub use registry::MediatorRegistry;

--- a/crates/ta-mediation/src/mediator.rs
+++ b/crates/ta-mediation/src/mediator.rs
@@ -1,0 +1,212 @@
+// mediator.rs — ResourceMediator trait and core types.
+//
+// The central abstraction of Layer 1: every state-changing action an agent
+// proposes is staged before it touches the real world. The ResourceMediator
+// trait generalizes this pattern from files to any resource.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::MediationError;
+
+/// What the agent wants to do — a proposed action on a resource.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProposedAction {
+    /// Unique identifier for this proposed action.
+    pub action_id: Uuid,
+    /// URI scheme: "fs", "email", "db", "api", etc.
+    pub scheme: String,
+    /// Action verb: "write", "send", "delete", "execute", etc.
+    pub verb: String,
+    /// Target resource URI: "fs://workspace/src/main.rs", "email://draft/123", etc.
+    pub target_uri: String,
+    /// Action-specific parameters (tool call arguments, file content, etc.).
+    pub parameters: serde_json::Value,
+    /// When the action was proposed.
+    pub proposed_at: DateTime<Utc>,
+}
+
+impl ProposedAction {
+    /// Create a new proposed action.
+    pub fn new(scheme: &str, verb: &str, target_uri: &str) -> Self {
+        Self {
+            action_id: Uuid::new_v4(),
+            scheme: scheme.to_string(),
+            verb: verb.to_string(),
+            target_uri: target_uri.to_string(),
+            parameters: serde_json::Value::Null,
+            proposed_at: Utc::now(),
+        }
+    }
+
+    /// Attach parameters to the action.
+    pub fn with_parameters(mut self, params: serde_json::Value) -> Self {
+        self.parameters = params;
+        self
+    }
+}
+
+/// The staged version of a proposed action — held until approved.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StagedMutation {
+    /// Unique identifier for this staged mutation.
+    pub mutation_id: Uuid,
+    /// The original proposed action.
+    pub action: ProposedAction,
+    /// When the action was staged.
+    pub staged_at: DateTime<Utc>,
+    /// Human-readable preview (generated lazily or eagerly).
+    pub preview: Option<MutationPreview>,
+    /// Where the staged data lives (path, ref, or opaque handle).
+    pub staging_ref: String,
+}
+
+/// Human-readable preview of a staged mutation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MutationPreview {
+    /// One-line summary of what will happen.
+    pub summary: String,
+    /// Diff or detailed description (optional for non-file resources).
+    pub diff: Option<String>,
+    /// Risk flags detected during staging.
+    pub risk_flags: Vec<String>,
+    /// How risky is this action?
+    pub classification: ActionClassification,
+}
+
+/// Risk classification for a proposed action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionClassification {
+    /// No state change — safe to auto-approve.
+    ReadOnly,
+    /// Changes local state that can be reverted.
+    StateChanging,
+    /// Cannot be undone (e.g., send email, delete production data).
+    Irreversible,
+    /// Touches systems outside TA's control.
+    ExternalSideEffect,
+}
+
+impl std::fmt::Display for ActionClassification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ActionClassification::ReadOnly => write!(f, "read_only"),
+            ActionClassification::StateChanging => write!(f, "state_changing"),
+            ActionClassification::Irreversible => write!(f, "irreversible"),
+            ActionClassification::ExternalSideEffect => write!(f, "external_side_effect"),
+        }
+    }
+}
+
+/// Result of applying a staged mutation to the real resource.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApplyResult {
+    /// The mutation that was applied.
+    pub mutation_id: Uuid,
+    /// Whether the apply succeeded.
+    pub success: bool,
+    /// Human-readable message about what happened.
+    pub message: String,
+    /// When the apply occurred.
+    pub applied_at: DateTime<Utc>,
+}
+
+/// The core trait: stage, preview, apply, rollback for any resource type.
+///
+/// Implementations exist per URI scheme:
+/// - `FsMediator` for `fs://` (files)
+/// - Future: `EmailMediator` for `email://`, `DbMediator` for `db://`, etc.
+pub trait ResourceMediator: Send + Sync {
+    /// Which URI scheme this mediator handles (e.g., "fs", "email", "db").
+    fn scheme(&self) -> &str;
+
+    /// Stage a proposed action — capture the mutation without applying it.
+    fn stage(&self, action: ProposedAction) -> Result<StagedMutation, MediationError>;
+
+    /// Generate a human-readable preview of a staged mutation.
+    fn preview(&self, staged: &StagedMutation) -> Result<MutationPreview, MediationError>;
+
+    /// Apply a staged mutation to the real resource (after human approval).
+    fn apply(&self, staged: &StagedMutation) -> Result<ApplyResult, MediationError>;
+
+    /// Roll back a staged mutation (remove from staging without applying).
+    fn rollback(&self, staged: &StagedMutation) -> Result<(), MediationError>;
+
+    /// Classify how risky a proposed action is (used for policy decisions).
+    fn classify(&self, action: &ProposedAction) -> ActionClassification;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proposed_action_builder() {
+        let action = ProposedAction::new("fs", "write", "fs://workspace/test.txt")
+            .with_parameters(serde_json::json!({"content": "hello"}));
+
+        assert_eq!(action.scheme, "fs");
+        assert_eq!(action.verb, "write");
+        assert_eq!(action.target_uri, "fs://workspace/test.txt");
+        assert_eq!(action.parameters["content"], "hello");
+    }
+
+    #[test]
+    fn action_classification_serialization_round_trip() {
+        for classification in [
+            ActionClassification::ReadOnly,
+            ActionClassification::StateChanging,
+            ActionClassification::Irreversible,
+            ActionClassification::ExternalSideEffect,
+        ] {
+            let json = serde_json::to_string(&classification).unwrap();
+            let restored: ActionClassification = serde_json::from_str(&json).unwrap();
+            assert_eq!(restored, classification);
+        }
+    }
+
+    #[test]
+    fn staged_mutation_serialization_round_trip() {
+        let action = ProposedAction::new("fs", "write", "fs://workspace/main.rs");
+        let staged = StagedMutation {
+            mutation_id: Uuid::new_v4(),
+            action,
+            staged_at: Utc::now(),
+            preview: Some(MutationPreview {
+                summary: "Write main.rs".to_string(),
+                diff: Some("+fn main() {}".to_string()),
+                risk_flags: vec![],
+                classification: ActionClassification::StateChanging,
+            }),
+            staging_ref: "/tmp/staging/main.rs".to_string(),
+        };
+
+        let json = serde_json::to_string(&staged).unwrap();
+        let restored: StagedMutation = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.mutation_id, staged.mutation_id);
+        assert!(restored.preview.is_some());
+    }
+
+    #[test]
+    fn apply_result_serialization() {
+        let result = ApplyResult {
+            mutation_id: Uuid::new_v4(),
+            success: true,
+            message: "Applied successfully".to_string(),
+            applied_at: Utc::now(),
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("\"success\":true"));
+    }
+
+    #[test]
+    fn action_classification_display() {
+        assert_eq!(format!("{}", ActionClassification::ReadOnly), "read_only");
+        assert_eq!(
+            format!("{}", ActionClassification::ExternalSideEffect),
+            "external_side_effect"
+        );
+    }
+}

--- a/crates/ta-mediation/src/registry.rs
+++ b/crates/ta-mediation/src/registry.rs
@@ -1,0 +1,218 @@
+// registry.rs — MediatorRegistry: routes URIs to the correct ResourceMediator.
+//
+// The registry is the single point where all mediators are registered at startup.
+// When a tool call arrives, the MCP gateway extracts the URI scheme and asks
+// the registry for the right mediator.
+
+use std::collections::HashMap;
+
+use crate::error::MediationError;
+use crate::mediator::ResourceMediator;
+
+/// Registry of ResourceMediator implementations, keyed by URI scheme.
+pub struct MediatorRegistry {
+    mediators: HashMap<String, Box<dyn ResourceMediator>>,
+}
+
+impl MediatorRegistry {
+    /// Create a new empty registry.
+    pub fn new() -> Self {
+        Self {
+            mediators: HashMap::new(),
+        }
+    }
+
+    /// Register a mediator for its scheme.
+    ///
+    /// If a mediator for the same scheme already exists, it is replaced.
+    pub fn register(&mut self, mediator: Box<dyn ResourceMediator>) {
+        let scheme = mediator.scheme().to_string();
+        self.mediators.insert(scheme, mediator);
+    }
+
+    /// Get a mediator by scheme name.
+    pub fn get(&self, scheme: &str) -> Option<&dyn ResourceMediator> {
+        self.mediators.get(scheme).map(|m| m.as_ref())
+    }
+
+    /// Route a URI to the correct mediator by extracting its scheme.
+    ///
+    /// Parses `scheme://...` from the URI and looks up the mediator.
+    pub fn route(&self, uri: &str) -> Result<&dyn ResourceMediator, MediationError> {
+        let scheme = extract_scheme(uri).ok_or_else(|| MediationError::InvalidUri {
+            uri: uri.to_string(),
+        })?;
+
+        self.get(scheme).ok_or_else(|| MediationError::NoMediator {
+            scheme: scheme.to_string(),
+        })
+    }
+
+    /// List all registered scheme names.
+    pub fn schemes(&self) -> Vec<&str> {
+        self.mediators.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Check if a scheme is registered.
+    pub fn has_scheme(&self, scheme: &str) -> bool {
+        self.mediators.contains_key(scheme)
+    }
+
+    /// Number of registered mediators.
+    pub fn len(&self) -> usize {
+        self.mediators.len()
+    }
+
+    /// Whether the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.mediators.is_empty()
+    }
+}
+
+impl Default for MediatorRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Extract the scheme from a URI (e.g., "fs" from "fs://workspace/file.txt").
+fn extract_scheme(uri: &str) -> Option<&str> {
+    uri.find("://").map(|pos| &uri[..pos])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mediator::{
+        ActionClassification, ApplyResult, MutationPreview, ProposedAction, StagedMutation,
+    };
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    /// A minimal test mediator for registry tests.
+    struct MockMediator {
+        scheme_name: String,
+    }
+
+    impl MockMediator {
+        fn new(scheme: &str) -> Self {
+            Self {
+                scheme_name: scheme.to_string(),
+            }
+        }
+    }
+
+    impl ResourceMediator for MockMediator {
+        fn scheme(&self) -> &str {
+            &self.scheme_name
+        }
+
+        fn stage(&self, action: ProposedAction) -> Result<StagedMutation, MediationError> {
+            Ok(StagedMutation {
+                mutation_id: Uuid::new_v4(),
+                action,
+                staged_at: Utc::now(),
+                preview: None,
+                staging_ref: "mock-ref".to_string(),
+            })
+        }
+
+        fn preview(&self, _staged: &StagedMutation) -> Result<MutationPreview, MediationError> {
+            Ok(MutationPreview {
+                summary: "mock preview".to_string(),
+                diff: None,
+                risk_flags: vec![],
+                classification: ActionClassification::ReadOnly,
+            })
+        }
+
+        fn apply(&self, staged: &StagedMutation) -> Result<ApplyResult, MediationError> {
+            Ok(ApplyResult {
+                mutation_id: staged.mutation_id,
+                success: true,
+                message: "mock apply".to_string(),
+                applied_at: Utc::now(),
+            })
+        }
+
+        fn rollback(&self, _staged: &StagedMutation) -> Result<(), MediationError> {
+            Ok(())
+        }
+
+        fn classify(&self, _action: &ProposedAction) -> ActionClassification {
+            ActionClassification::ReadOnly
+        }
+    }
+
+    #[test]
+    fn register_and_get() {
+        let mut registry = MediatorRegistry::new();
+        registry.register(Box::new(MockMediator::new("fs")));
+
+        assert!(registry.get("fs").is_some());
+        assert!(registry.get("email").is_none());
+    }
+
+    #[test]
+    fn route_by_uri() {
+        let mut registry = MediatorRegistry::new();
+        registry.register(Box::new(MockMediator::new("fs")));
+        registry.register(Box::new(MockMediator::new("email")));
+
+        let mediator = registry.route("fs://workspace/file.txt").unwrap();
+        assert_eq!(mediator.scheme(), "fs");
+
+        let mediator = registry.route("email://draft/123").unwrap();
+        assert_eq!(mediator.scheme(), "email");
+    }
+
+    #[test]
+    fn route_unknown_scheme_errors() {
+        let registry = MediatorRegistry::new();
+        let result = registry.route("db://table/users");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn route_invalid_uri_errors() {
+        let registry = MediatorRegistry::new();
+        let result = registry.route("no-scheme-here");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn schemes_list() {
+        let mut registry = MediatorRegistry::new();
+        registry.register(Box::new(MockMediator::new("fs")));
+        registry.register(Box::new(MockMediator::new("email")));
+
+        let schemes = registry.schemes();
+        assert_eq!(schemes.len(), 2);
+        assert!(schemes.contains(&"fs"));
+        assert!(schemes.contains(&"email"));
+    }
+
+    #[test]
+    fn replace_existing_mediator() {
+        let mut registry = MediatorRegistry::new();
+        registry.register(Box::new(MockMediator::new("fs")));
+        registry.register(Box::new(MockMediator::new("fs")));
+
+        assert_eq!(registry.len(), 1);
+    }
+
+    #[test]
+    fn empty_registry() {
+        let registry = MediatorRegistry::new();
+        assert!(registry.is_empty());
+        assert_eq!(registry.len(), 0);
+    }
+
+    #[test]
+    fn extract_scheme_works() {
+        assert_eq!(extract_scheme("fs://workspace/file"), Some("fs"));
+        assert_eq!(extract_scheme("email://draft/123"), Some("email"));
+        assert_eq!(extract_scheme("db://table/users"), Some("db"));
+        assert_eq!(extract_scheme("no-scheme"), None);
+    }
+}

--- a/crates/ta-policy/Cargo.toml
+++ b/crates/ta-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-policy"
-version = "0.4.5-alpha"
+version = "0.6.0-alpha"
 edition = "2021"
 description = "Capability manifests and policy evaluation for Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-policy/src/cascade.rs
+++ b/crates/ta-policy/src/cascade.rs
@@ -1,0 +1,444 @@
+// cascade.rs — PolicyCascade: loads and merges policy from multiple layers.
+//
+// The 6-layer policy cascade (each layer tightens, never loosens):
+//   1. Built-in defaults (hardcoded)
+//   2. .ta/policy.yaml (project config)
+//   3. .ta/workflows/<name>.yaml (workflow overrides)
+//   4. agents/<name>.yaml (agent profile)
+//   5. .ta/constitutions/goal-<id>.yaml (goal constitution)
+//   6. CLI overrides (flags)
+//
+// The merge rule: each layer can add restrictions (verbs to approval_required,
+// increase security_level, add escalation triggers) — never remove them.
+
+use std::fs;
+use std::path::Path;
+
+use uuid::Uuid;
+
+use crate::document::{PolicyDocument, SecurityLevel};
+use crate::error::PolicyError;
+
+/// CLI-level overrides passed as flags.
+#[derive(Debug, Clone, Default)]
+pub struct CliOverrides {
+    /// Override the security level (e.g., --strict, --open).
+    pub security_level: Option<SecurityLevel>,
+    /// Force auto-approve mode (e.g., --auto-approve).
+    pub auto_approve: Option<bool>,
+}
+
+/// Loads and merges policy from all 6 cascade layers.
+pub struct PolicyCascade;
+
+impl PolicyCascade {
+    /// Load the fully-merged policy document for a given context.
+    ///
+    /// - `project_root`: path to the project (containing `.ta/`)
+    /// - `agent_id`: which agent's profile to apply
+    /// - `goal_id`: which goal's constitution to apply (if any)
+    /// - `workflow`: which workflow overrides to apply (if any)
+    /// - `overrides`: CLI-level flags
+    pub fn load(
+        project_root: &Path,
+        agent_id: &str,
+        goal_id: Option<Uuid>,
+        workflow: Option<&str>,
+        overrides: &CliOverrides,
+    ) -> Result<PolicyDocument, PolicyError> {
+        // Layer 1: Built-in defaults.
+        let mut doc = PolicyDocument::default();
+
+        // Layer 2: Project policy (.ta/policy.yaml).
+        let project_policy_path = project_root.join(".ta/policy.yaml");
+        if project_policy_path.exists() {
+            let project_doc = Self::load_yaml(&project_policy_path)?;
+            Self::merge(&mut doc, &project_doc);
+        }
+
+        // Layer 3: Workflow policy (.ta/workflows/<name>.yaml).
+        if let Some(wf) = workflow {
+            let workflow_path = project_root.join(format!(".ta/workflows/{}.yaml", wf));
+            if workflow_path.exists() {
+                let wf_doc = Self::load_yaml(&workflow_path)?;
+                Self::merge(&mut doc, &wf_doc);
+            }
+        }
+
+        // Layer 4: Agent profile (agents/<name>.yaml → policy section).
+        let agent_policy_path = project_root.join(format!(".ta/agents/{}.policy.yaml", agent_id));
+        if agent_policy_path.exists() {
+            let agent_doc = Self::load_yaml(&agent_policy_path)?;
+            Self::merge(&mut doc, &agent_doc);
+        }
+
+        // Layer 5: Goal constitution (.ta/constitutions/goal-<id>.yaml).
+        if let Some(gid) = goal_id {
+            let constitution_path =
+                project_root.join(format!(".ta/constitutions/goal-{}.yaml", gid));
+            if constitution_path.exists() {
+                let const_doc = Self::load_yaml(&constitution_path)?;
+                Self::merge(&mut doc, &const_doc);
+            }
+        }
+
+        // Layer 6: CLI overrides.
+        if let Some(level) = overrides.security_level {
+            if level > doc.security_level {
+                doc.security_level = level;
+            }
+        }
+        if let Some(auto) = overrides.auto_approve {
+            if !auto {
+                doc.defaults.auto_approve.read_only = false;
+                doc.defaults.auto_approve.internal_tools = false;
+            }
+        }
+
+        Ok(doc)
+    }
+
+    /// Load a PolicyDocument from a YAML file.
+    fn load_yaml(path: &Path) -> Result<PolicyDocument, PolicyError> {
+        let content = fs::read_to_string(path).map_err(|e| PolicyError::IoError {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+        let doc: PolicyDocument = serde_yaml::from_str(&content).map_err(|e| {
+            PolicyError::ConfigError(format!("invalid policy YAML at {}: {}", path.display(), e))
+        })?;
+        Ok(doc)
+    }
+
+    /// Merge an overlay document onto a base document (tighten-only).
+    ///
+    /// The overlay can add restrictions but never remove them:
+    /// - Security level: only increase (Open < Checkpoint < Supervised < Strict)
+    /// - Enforcement: only increase (Warning < Error < Strict)
+    /// - Scheme policies: merge approval_required lists (union, not replace)
+    /// - Escalation: add patterns, lower thresholds
+    /// - Agent overrides: merge additively
+    fn merge(base: &mut PolicyDocument, overlay: &PolicyDocument) {
+        // Security level: only tighten.
+        if overlay.security_level > base.security_level {
+            base.security_level = overlay.security_level;
+        }
+
+        // Enforcement: only tighten.
+        if overlay.defaults.enforcement > base.defaults.enforcement {
+            base.defaults.enforcement = overlay.defaults.enforcement;
+        }
+
+        // Auto-approve: overlay can disable but not enable.
+        if !overlay.defaults.auto_approve.read_only {
+            base.defaults.auto_approve.read_only = false;
+        }
+        if !overlay.defaults.auto_approve.internal_tools {
+            base.defaults.auto_approve.internal_tools = false;
+        }
+
+        // Scheme policies: merge additively.
+        for (scheme, overlay_policy) in &overlay.schemes {
+            let base_policy = base.schemes.entry(scheme.clone()).or_default();
+
+            // Add approval verbs (union).
+            for verb in &overlay_policy.approval_required {
+                if !base_policy.approval_required.contains(verb) {
+                    base_policy.approval_required.push(verb.clone());
+                }
+            }
+
+            // Credential requirement can only be tightened (false → true).
+            if overlay_policy.credential_required {
+                base_policy.credential_required = true;
+            }
+
+            // Action limit: take the lower value.
+            match (
+                base_policy.max_actions_per_session,
+                overlay_policy.max_actions_per_session,
+            ) {
+                (None, Some(v)) => base_policy.max_actions_per_session = Some(v),
+                (Some(base_v), Some(overlay_v)) if overlay_v < base_v => {
+                    base_policy.max_actions_per_session = Some(overlay_v);
+                }
+                _ => {}
+            }
+        }
+
+        // Escalation: tighten thresholds, add patterns.
+        if let Some(overlay_thresh) = overlay.escalation.drift_threshold {
+            match base.escalation.drift_threshold {
+                None => base.escalation.drift_threshold = Some(overlay_thresh),
+                Some(base_thresh) if overlay_thresh < base_thresh => {
+                    base.escalation.drift_threshold = Some(overlay_thresh);
+                }
+                _ => {}
+            }
+        }
+        if let Some(overlay_limit) = overlay.escalation.action_count_limit {
+            match base.escalation.action_count_limit {
+                None => base.escalation.action_count_limit = Some(overlay_limit),
+                Some(base_limit) if overlay_limit < base_limit => {
+                    base.escalation.action_count_limit = Some(overlay_limit);
+                }
+                _ => {}
+            }
+        }
+        for pattern in &overlay.escalation.patterns {
+            if !base.escalation.patterns.contains(pattern) {
+                base.escalation.patterns.push(pattern.clone());
+            }
+        }
+
+        // Agent overrides: merge additively.
+        for (agent, overlay_override) in &overlay.agents {
+            let base_override = base.agents.entry(agent.clone()).or_default();
+
+            for verb in &overlay_override.additional_approval_required {
+                if !base_override.additional_approval_required.contains(verb) {
+                    base_override
+                        .additional_approval_required
+                        .push(verb.clone());
+                }
+            }
+            for action in &overlay_override.forbidden_actions {
+                if !base_override.forbidden_actions.contains(action) {
+                    base_override.forbidden_actions.push(action.clone());
+                }
+            }
+            if let Some(level) = overlay_override.security_level {
+                match base_override.security_level {
+                    None => base_override.security_level = Some(level),
+                    Some(base_level) if level > base_level => {
+                        base_override.security_level = Some(level);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Budget: take the lower limit.
+        if let Some(overlay_budget) = &overlay.budget {
+            match &mut base.budget {
+                None => base.budget = Some(overlay_budget.clone()),
+                Some(base_budget) => {
+                    match (
+                        base_budget.max_tokens_per_goal,
+                        overlay_budget.max_tokens_per_goal,
+                    ) {
+                        (None, Some(v)) => base_budget.max_tokens_per_goal = Some(v),
+                        (Some(bv), Some(ov)) if ov < bv => {
+                            base_budget.max_tokens_per_goal = Some(ov);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
+mod tests {
+    use super::*;
+    use crate::document::{BudgetConfig, SchemePolicy};
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_defaults_without_config_file() {
+        let temp = TempDir::new().unwrap();
+        let doc = PolicyCascade::load(temp.path(), "agent-1", None, None, &CliOverrides::default())
+            .unwrap();
+
+        assert_eq!(doc.security_level, SecurityLevel::Checkpoint);
+        assert!(doc.defaults.auto_approve.read_only);
+    }
+
+    #[test]
+    fn load_from_project_policy_yaml() {
+        let temp = TempDir::new().unwrap();
+        let ta_dir = temp.path().join(".ta");
+        fs::create_dir_all(&ta_dir).unwrap();
+
+        let yaml = r#"
+security_level: supervised
+schemes:
+  fs:
+    approval_required: [apply, delete]
+  email:
+    approval_required: [send]
+    credential_required: true
+"#;
+        fs::write(ta_dir.join("policy.yaml"), yaml).unwrap();
+
+        let doc = PolicyCascade::load(temp.path(), "agent-1", None, None, &CliOverrides::default())
+            .unwrap();
+
+        assert_eq!(doc.security_level, SecurityLevel::Supervised);
+        assert_eq!(doc.schemes["fs"].approval_required, vec!["apply", "delete"]);
+        assert!(doc.schemes["email"].credential_required);
+    }
+
+    #[test]
+    fn merge_tightens_security_level() {
+        let mut base = PolicyDocument::default(); // Checkpoint
+        let overlay = PolicyDocument {
+            security_level: SecurityLevel::Supervised,
+            ..Default::default()
+        };
+
+        PolicyCascade::merge(&mut base, &overlay);
+        assert_eq!(base.security_level, SecurityLevel::Supervised);
+    }
+
+    #[test]
+    fn merge_cannot_loosen_security_level() {
+        let mut base = PolicyDocument {
+            security_level: SecurityLevel::Supervised,
+            ..Default::default()
+        };
+        let overlay = PolicyDocument {
+            security_level: SecurityLevel::Open,
+            ..Default::default()
+        };
+
+        PolicyCascade::merge(&mut base, &overlay);
+        assert_eq!(base.security_level, SecurityLevel::Supervised); // unchanged
+    }
+
+    #[test]
+    fn merge_unions_approval_verbs() {
+        let mut base = PolicyDocument::default();
+        base.schemes.insert(
+            "fs".to_string(),
+            SchemePolicy {
+                approval_required: vec!["apply".to_string()],
+                ..Default::default()
+            },
+        );
+
+        let mut overlay = PolicyDocument::default();
+        overlay.schemes.insert(
+            "fs".to_string(),
+            SchemePolicy {
+                approval_required: vec!["apply".to_string(), "delete".to_string()],
+                ..Default::default()
+            },
+        );
+
+        PolicyCascade::merge(&mut base, &overlay);
+        let fs_policy = &base.schemes["fs"];
+        assert!(fs_policy.approval_required.contains(&"apply".to_string()));
+        assert!(fs_policy.approval_required.contains(&"delete".to_string()));
+        assert_eq!(fs_policy.approval_required.len(), 2); // no duplicates
+    }
+
+    #[test]
+    fn merge_takes_lower_action_limit() {
+        let mut base = PolicyDocument::default();
+        base.schemes.insert(
+            "email".to_string(),
+            SchemePolicy {
+                max_actions_per_session: Some(100),
+                ..Default::default()
+            },
+        );
+
+        let mut overlay = PolicyDocument::default();
+        overlay.schemes.insert(
+            "email".to_string(),
+            SchemePolicy {
+                max_actions_per_session: Some(50),
+                ..Default::default()
+            },
+        );
+
+        PolicyCascade::merge(&mut base, &overlay);
+        assert_eq!(base.schemes["email"].max_actions_per_session, Some(50));
+    }
+
+    #[test]
+    fn merge_adds_escalation_patterns() {
+        let mut base = PolicyDocument::default();
+        base.escalation.patterns.push("new_dependency".to_string());
+
+        let mut overlay = PolicyDocument::default();
+        overlay
+            .escalation
+            .patterns
+            .push("config_change".to_string());
+        overlay
+            .escalation
+            .patterns
+            .push("new_dependency".to_string()); // duplicate
+
+        PolicyCascade::merge(&mut base, &overlay);
+        assert_eq!(base.escalation.patterns.len(), 2);
+    }
+
+    #[test]
+    fn merge_lowers_drift_threshold() {
+        let mut base = PolicyDocument::default();
+        base.escalation.drift_threshold = Some(0.8);
+
+        let mut overlay = PolicyDocument::default();
+        overlay.escalation.drift_threshold = Some(0.5);
+
+        PolicyCascade::merge(&mut base, &overlay);
+        assert_eq!(base.escalation.drift_threshold, Some(0.5));
+    }
+
+    #[test]
+    fn cli_overrides_tighten_only() {
+        let temp = TempDir::new().unwrap();
+
+        // CLI raises security to Strict.
+        let overrides = CliOverrides {
+            security_level: Some(SecurityLevel::Strict),
+            auto_approve: None,
+        };
+
+        let doc = PolicyCascade::load(temp.path(), "agent", None, None, &overrides).unwrap();
+        assert_eq!(doc.security_level, SecurityLevel::Strict);
+    }
+
+    #[test]
+    fn cli_override_cannot_lower_project_level() {
+        let temp = TempDir::new().unwrap();
+        let ta_dir = temp.path().join(".ta");
+        fs::create_dir_all(&ta_dir).unwrap();
+        fs::write(ta_dir.join("policy.yaml"), "security_level: supervised\n").unwrap();
+
+        // CLI tries to set Open (lower than Supervised).
+        let overrides = CliOverrides {
+            security_level: Some(SecurityLevel::Open),
+            auto_approve: None,
+        };
+
+        let doc = PolicyCascade::load(temp.path(), "agent", None, None, &overrides).unwrap();
+        assert_eq!(doc.security_level, SecurityLevel::Supervised); // stays supervised
+    }
+
+    #[test]
+    fn merge_budget_takes_lower() {
+        let mut base = PolicyDocument::default();
+        base.budget = Some(BudgetConfig {
+            max_tokens_per_goal: Some(1_000_000),
+            warn_at_percent: 80,
+        });
+
+        let mut overlay = PolicyDocument::default();
+        overlay.budget = Some(BudgetConfig {
+            max_tokens_per_goal: Some(500_000),
+            warn_at_percent: 80,
+        });
+
+        PolicyCascade::merge(&mut base, &overlay);
+        assert_eq!(
+            base.budget.as_ref().unwrap().max_tokens_per_goal,
+            Some(500_000)
+        );
+    }
+}

--- a/crates/ta-policy/src/context.rs
+++ b/crates/ta-policy/src/context.rs
@@ -1,0 +1,152 @@
+// context.rs — PolicyContext: runtime context for policy evaluation.
+//
+// The PolicyContext carries runtime state that policy rules can use for
+// decisions: how much budget has been spent, how many actions the agent
+// has taken, and the current drift score.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Runtime context passed alongside every policy evaluation request.
+///
+/// This allows policy rules to make decisions based on the current state
+/// of the session, not just static grants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyContext {
+    /// The goal being worked on (if any).
+    pub goal_id: Option<Uuid>,
+    /// The session ID (if in a session).
+    pub session_id: Option<Uuid>,
+    /// The agent making the request.
+    pub agent_id: String,
+    /// Tokens spent so far in this goal.
+    pub budget_spent: u64,
+    /// Actions taken so far in this session.
+    pub action_count: u32,
+    /// Current behavioral drift score (0.0 = no drift, 1.0 = max drift).
+    pub drift_score: Option<f64>,
+}
+
+impl PolicyContext {
+    /// Create a minimal context with just an agent ID.
+    pub fn new(agent_id: &str) -> Self {
+        Self {
+            goal_id: None,
+            session_id: None,
+            agent_id: agent_id.to_string(),
+            budget_spent: 0,
+            action_count: 0,
+            drift_score: None,
+        }
+    }
+
+    /// Set the goal ID.
+    pub fn with_goal(mut self, goal_id: Uuid) -> Self {
+        self.goal_id = Some(goal_id);
+        self
+    }
+
+    /// Set the session ID.
+    pub fn with_session(mut self, session_id: Uuid) -> Self {
+        self.session_id = Some(session_id);
+        self
+    }
+
+    /// Check if the budget limit has been exceeded.
+    pub fn is_over_budget(&self, limit: Option<u64>) -> bool {
+        match limit {
+            Some(max) => self.budget_spent >= max,
+            None => false,
+        }
+    }
+
+    /// Check if the budget warning threshold has been hit.
+    pub fn is_budget_warning(&self, limit: Option<u64>, warn_percent: u8) -> bool {
+        match limit {
+            Some(max) if max > 0 => {
+                let threshold = (max as f64 * warn_percent as f64 / 100.0) as u64;
+                self.budget_spent >= threshold
+            }
+            _ => false,
+        }
+    }
+
+    /// Check if drift score exceeds a threshold.
+    pub fn is_drifting(&self, threshold: Option<f64>) -> bool {
+        match (self.drift_score, threshold) {
+            (Some(score), Some(thresh)) => score >= thresh,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_context_has_defaults() {
+        let ctx = PolicyContext::new("agent-1");
+        assert_eq!(ctx.agent_id, "agent-1");
+        assert!(ctx.goal_id.is_none());
+        assert_eq!(ctx.budget_spent, 0);
+        assert_eq!(ctx.action_count, 0);
+    }
+
+    #[test]
+    fn budget_check() {
+        let mut ctx = PolicyContext::new("agent");
+        ctx.budget_spent = 450_000;
+
+        assert!(!ctx.is_over_budget(Some(500_000)));
+        assert!(ctx.is_over_budget(Some(400_000)));
+        assert!(!ctx.is_over_budget(None));
+    }
+
+    #[test]
+    fn budget_warning() {
+        let mut ctx = PolicyContext::new("agent");
+        ctx.budget_spent = 420_000;
+
+        // 80% of 500,000 = 400,000 → 420k exceeds warning
+        assert!(ctx.is_budget_warning(Some(500_000), 80));
+        // 90% of 500,000 = 450,000 → 420k doesn't exceed
+        assert!(!ctx.is_budget_warning(Some(500_000), 90));
+        // No limit → no warning
+        assert!(!ctx.is_budget_warning(None, 80));
+    }
+
+    #[test]
+    fn drift_check() {
+        let mut ctx = PolicyContext::new("agent");
+
+        // No drift score → not drifting
+        assert!(!ctx.is_drifting(Some(0.5)));
+
+        ctx.drift_score = Some(0.7);
+        assert!(ctx.is_drifting(Some(0.5)));
+        assert!(!ctx.is_drifting(Some(0.8)));
+        assert!(!ctx.is_drifting(None));
+    }
+
+    #[test]
+    fn builder_pattern() {
+        let goal_id = Uuid::new_v4();
+        let session_id = Uuid::new_v4();
+
+        let ctx = PolicyContext::new("agent")
+            .with_goal(goal_id)
+            .with_session(session_id);
+
+        assert_eq!(ctx.goal_id, Some(goal_id));
+        assert_eq!(ctx.session_id, Some(session_id));
+    }
+
+    #[test]
+    fn serialization_round_trip() {
+        let ctx = PolicyContext::new("agent").with_goal(Uuid::new_v4());
+        let json = serde_json::to_string(&ctx).unwrap();
+        let restored: PolicyContext = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.agent_id, ctx.agent_id);
+    }
+}

--- a/crates/ta-policy/src/document.rs
+++ b/crates/ta-policy/src/document.rs
@@ -1,0 +1,340 @@
+// document.rs — PolicyDocument: the unified policy configuration surface.
+//
+// All supervision configuration resolves to a single PolicyDocument. This is
+// the merged result of the 6-layer policy cascade (see cascade.rs).
+//
+// Users configure policy via `.ta/policy.yaml`. The cascade merges built-in
+// defaults, project config, workflow overrides, agent profiles, goal
+// constitutions, and CLI flags into one document.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// The unified policy document — the merged result of all policy layers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyDocument {
+    /// Schema version for forward compatibility.
+    #[serde(default = "default_version")]
+    pub version: String,
+
+    /// Global defaults applied to all agents and goals.
+    #[serde(default)]
+    pub defaults: PolicyDefaults,
+
+    /// Per-URI-scheme policy rules (e.g., fs, email, db, api).
+    #[serde(default)]
+    pub schemes: HashMap<String, SchemePolicy>,
+
+    /// Escalation triggers — conditions that force human review.
+    #[serde(default)]
+    pub escalation: EscalationConfig,
+
+    /// Per-agent policy overrides.
+    #[serde(default)]
+    pub agents: HashMap<String, AgentPolicyOverride>,
+
+    /// Security level controls review stringency.
+    #[serde(default)]
+    pub security_level: SecurityLevel,
+
+    /// Optional budget limits.
+    #[serde(default)]
+    pub budget: Option<BudgetConfig>,
+}
+
+fn default_version() -> String {
+    "1".to_string()
+}
+
+impl Default for PolicyDocument {
+    fn default() -> Self {
+        Self {
+            version: default_version(),
+            defaults: PolicyDefaults::default(),
+            schemes: HashMap::new(),
+            escalation: EscalationConfig::default(),
+            agents: HashMap::new(),
+            security_level: SecurityLevel::default(),
+            budget: None,
+        }
+    }
+}
+
+/// Global policy defaults.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PolicyDefaults {
+    /// How strict enforcement is at the project level.
+    #[serde(default)]
+    pub enforcement: PolicyEnforcement,
+
+    /// What can be auto-approved without human review.
+    #[serde(default)]
+    pub auto_approve: AutoApproveConfig,
+}
+
+/// Enforcement strictness (project-level).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyEnforcement {
+    /// Log policy decisions but don't block.
+    Warning,
+    /// Block on policy violations (default).
+    #[default]
+    Error,
+    /// Block and require constitutions for every goal.
+    Strict,
+}
+
+impl std::fmt::Display for PolicyEnforcement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PolicyEnforcement::Warning => write!(f, "warning"),
+            PolicyEnforcement::Error => write!(f, "error"),
+            PolicyEnforcement::Strict => write!(f, "strict"),
+        }
+    }
+}
+
+/// Auto-approval configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AutoApproveConfig {
+    /// Auto-approve read-only actions (no state change).
+    #[serde(default = "default_true")]
+    pub read_only: bool,
+
+    /// Auto-approve internal TA tool calls (ta_* MCP tools).
+    #[serde(default = "default_true")]
+    pub internal_tools: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for AutoApproveConfig {
+    fn default() -> Self {
+        Self {
+            read_only: true,
+            internal_tools: true,
+        }
+    }
+}
+
+/// Per-URI-scheme policy rules.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SchemePolicy {
+    /// Verbs that require human approval for this scheme.
+    #[serde(default)]
+    pub approval_required: Vec<String>,
+
+    /// Whether this scheme requires a credential to be configured.
+    #[serde(default)]
+    pub credential_required: bool,
+
+    /// Max actions per session (None = unlimited).
+    #[serde(default)]
+    pub max_actions_per_session: Option<u32>,
+}
+
+/// Escalation triggers — conditions that force human review.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct EscalationConfig {
+    /// Trigger escalation when drift score exceeds this threshold (0.0-1.0).
+    #[serde(default)]
+    pub drift_threshold: Option<f64>,
+
+    /// Trigger escalation when action count exceeds this limit.
+    #[serde(default)]
+    pub action_count_limit: Option<u32>,
+
+    /// Custom escalation trigger patterns.
+    #[serde(default)]
+    pub patterns: Vec<String>,
+}
+
+/// Per-agent policy overrides.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AgentPolicyOverride {
+    /// Additional verbs that require approval for this agent.
+    #[serde(default)]
+    pub additional_approval_required: Vec<String>,
+
+    /// Actions this agent is explicitly forbidden from.
+    #[serde(default)]
+    pub forbidden_actions: Vec<String>,
+
+    /// Override the security level for this agent.
+    #[serde(default)]
+    pub security_level: Option<SecurityLevel>,
+}
+
+/// Security level — controls how strictly TA mediates actions.
+///
+/// Ordered from least to most restrictive. The cascade can only increase
+/// the security level, never decrease it.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default, Hash,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum SecurityLevel {
+    /// Audit-only: log everything, block nothing.
+    Open,
+    /// Review at draft boundaries (default).
+    #[default]
+    Checkpoint,
+    /// Approve each state-changing action individually.
+    Supervised,
+    /// Constitutions required; every action evaluated against declared intent.
+    Strict,
+}
+
+impl std::fmt::Display for SecurityLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SecurityLevel::Open => write!(f, "open"),
+            SecurityLevel::Checkpoint => write!(f, "checkpoint"),
+            SecurityLevel::Supervised => write!(f, "supervised"),
+            SecurityLevel::Strict => write!(f, "strict"),
+        }
+    }
+}
+
+/// Budget configuration — limits on resource usage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BudgetConfig {
+    /// Maximum tokens per goal (None = unlimited).
+    #[serde(default)]
+    pub max_tokens_per_goal: Option<u64>,
+
+    /// Warn agent when this percentage of budget is spent.
+    #[serde(default = "default_warn_percent")]
+    pub warn_at_percent: u8,
+}
+
+fn default_warn_percent() -> u8 {
+    80
+}
+
+impl Default for BudgetConfig {
+    fn default() -> Self {
+        Self {
+            max_tokens_per_goal: None,
+            warn_at_percent: 80,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_document_is_checkpoint() {
+        let doc = PolicyDocument::default();
+        assert_eq!(doc.security_level, SecurityLevel::Checkpoint);
+        assert_eq!(doc.defaults.enforcement, PolicyEnforcement::Error);
+        assert!(doc.defaults.auto_approve.read_only);
+    }
+
+    #[test]
+    fn yaml_round_trip() {
+        let yaml = r#"
+version: "1"
+defaults:
+  enforcement: strict
+  auto_approve:
+    read_only: true
+    internal_tools: false
+schemes:
+  fs:
+    approval_required: [apply, delete]
+  email:
+    approval_required: [send, delete]
+    credential_required: true
+    max_actions_per_session: 10
+escalation:
+  drift_threshold: 0.7
+  action_count_limit: 100
+  patterns:
+    - new_dependency
+    - config_change
+security_level: supervised
+budget:
+  max_tokens_per_goal: 500000
+  warn_at_percent: 80
+"#;
+        let doc: PolicyDocument = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(doc.defaults.enforcement, PolicyEnforcement::Strict);
+        assert!(!doc.defaults.auto_approve.internal_tools);
+        assert_eq!(doc.schemes.len(), 2);
+        assert_eq!(doc.schemes["fs"].approval_required, vec!["apply", "delete"]);
+        assert!(doc.schemes["email"].credential_required);
+        assert_eq!(doc.schemes["email"].max_actions_per_session, Some(10));
+        assert_eq!(doc.escalation.drift_threshold, Some(0.7));
+        assert_eq!(doc.escalation.action_count_limit, Some(100));
+        assert_eq!(doc.security_level, SecurityLevel::Supervised);
+        assert_eq!(
+            doc.budget.as_ref().unwrap().max_tokens_per_goal,
+            Some(500000)
+        );
+
+        // Re-serialize and parse again to verify round-trip.
+        let yaml_out = serde_yaml::to_string(&doc).unwrap();
+        let doc2: PolicyDocument = serde_yaml::from_str(&yaml_out).unwrap();
+        assert_eq!(doc2.security_level, doc.security_level);
+    }
+
+    #[test]
+    fn security_level_ordering() {
+        assert!(SecurityLevel::Open < SecurityLevel::Checkpoint);
+        assert!(SecurityLevel::Checkpoint < SecurityLevel::Supervised);
+        assert!(SecurityLevel::Supervised < SecurityLevel::Strict);
+    }
+
+    #[test]
+    fn enforcement_ordering() {
+        assert!(PolicyEnforcement::Warning < PolicyEnforcement::Error);
+        assert!(PolicyEnforcement::Error < PolicyEnforcement::Strict);
+    }
+
+    #[test]
+    fn agent_override_deserialization() {
+        let yaml = r#"
+additional_approval_required:
+  - write
+forbidden_actions:
+  - network_external
+security_level: strict
+"#;
+        let override_: AgentPolicyOverride = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(override_.additional_approval_required, vec!["write"]);
+        assert_eq!(override_.forbidden_actions, vec!["network_external"]);
+        assert_eq!(override_.security_level, Some(SecurityLevel::Strict));
+    }
+
+    #[test]
+    fn budget_defaults() {
+        let budget = BudgetConfig::default();
+        assert!(budget.max_tokens_per_goal.is_none());
+        assert_eq!(budget.warn_at_percent, 80);
+    }
+
+    #[test]
+    fn security_level_display() {
+        assert_eq!(format!("{}", SecurityLevel::Open), "open");
+        assert_eq!(format!("{}", SecurityLevel::Checkpoint), "checkpoint");
+        assert_eq!(format!("{}", SecurityLevel::Supervised), "supervised");
+        assert_eq!(format!("{}", SecurityLevel::Strict), "strict");
+    }
+
+    #[test]
+    fn minimal_yaml_parses_with_defaults() {
+        let yaml = "{}";
+        let doc: PolicyDocument = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(doc.version, "1");
+        assert_eq!(doc.security_level, SecurityLevel::Checkpoint);
+        assert!(doc.schemes.is_empty());
+    }
+}

--- a/crates/ta-policy/src/engine.rs
+++ b/crates/ta-policy/src/engine.rs
@@ -357,6 +357,145 @@ impl Default for PolicyEngine {
     }
 }
 
+// ── v0.6.1 PolicyDocument-aware evaluation ──
+
+impl PolicyEngine {
+    /// Evaluate a request against both the manifest-based engine AND a PolicyDocument.
+    ///
+    /// This is the v0.6.1 entry point. It layers document-level policy checks
+    /// on top of the existing manifest-based evaluation:
+    ///
+    /// 1. Run the existing `evaluate()` (manifest + grants)
+    /// 2. Check document-level scheme policies (additional approval verbs)
+    /// 3. Check escalation triggers (drift, budget, action count)
+    /// 4. Check security level (Supervised = approve each state change)
+    ///
+    /// The result is the most restrictive decision from all checks.
+    pub fn evaluate_with_document(
+        &self,
+        request: &PolicyRequest,
+        document: &crate::document::PolicyDocument,
+        context: &crate::context::PolicyContext,
+    ) -> PolicyDecision {
+        // Step 1: Run the existing manifest-based evaluation.
+        let base_decision = self.evaluate(request);
+
+        // If the base decision is Deny, no further checks needed.
+        if matches!(base_decision, PolicyDecision::Deny { .. }) {
+            return base_decision;
+        }
+
+        // Step 2: Check scheme-level approval requirements from the document.
+        let scheme = extract_uri_scheme(&request.target_uri);
+        if let Some(scheme_policy) = scheme.and_then(|s| document.schemes.get(s)) {
+            if scheme_policy.approval_required.contains(&request.verb) {
+                return PolicyDecision::RequireApproval {
+                    reason: format!(
+                        "scheme '{}' requires approval for verb '{}'",
+                        scheme.unwrap_or("unknown"),
+                        request.verb
+                    ),
+                };
+            }
+
+            // Check action count limit.
+            if let Some(max) = scheme_policy.max_actions_per_session {
+                if context.action_count >= max {
+                    return PolicyDecision::Deny {
+                        reason: format!(
+                            "action count limit ({}) exceeded for scheme '{}'",
+                            max,
+                            scheme.unwrap_or("unknown")
+                        ),
+                    };
+                }
+            }
+        }
+
+        // Step 3: Check agent-specific overrides.
+        if let Some(agent_override) = document.agents.get(&request.agent_id) {
+            if agent_override
+                .additional_approval_required
+                .contains(&request.verb)
+            {
+                return PolicyDecision::RequireApproval {
+                    reason: format!(
+                        "agent '{}' requires approval for verb '{}'",
+                        request.agent_id, request.verb
+                    ),
+                };
+            }
+            // Check forbidden actions.
+            let action_key = format!("{}_{}", request.tool, request.verb);
+            if agent_override.forbidden_actions.contains(&action_key) {
+                return PolicyDecision::Deny {
+                    reason: format!(
+                        "action '{}' is forbidden for agent '{}'",
+                        action_key, request.agent_id
+                    ),
+                };
+            }
+        }
+
+        // Step 4: Check escalation triggers.
+        if context.is_drifting(document.escalation.drift_threshold) {
+            return PolicyDecision::RequireApproval {
+                reason: format!(
+                    "drift score ({:.2}) exceeds threshold ({:.2})",
+                    context.drift_score.unwrap_or(0.0),
+                    document.escalation.drift_threshold.unwrap_or(0.0)
+                ),
+            };
+        }
+
+        if let Some(limit) = document.escalation.action_count_limit {
+            if context.action_count >= limit {
+                return PolicyDecision::RequireApproval {
+                    reason: format!(
+                        "action count ({}) reached escalation limit ({})",
+                        context.action_count, limit
+                    ),
+                };
+            }
+        }
+
+        // Step 5: Check budget.
+        if let Some(ref budget) = document.budget {
+            if context.is_over_budget(budget.max_tokens_per_goal) {
+                return PolicyDecision::Deny {
+                    reason: format!(
+                        "budget exceeded: {} tokens spent (limit: {})",
+                        context.budget_spent,
+                        budget.max_tokens_per_goal.unwrap_or(0)
+                    ),
+                };
+            }
+        }
+
+        // Step 6: Security level = Supervised means every state-changing action
+        // requires approval (not just "apply"/"commit"/"send"/"post").
+        if document.security_level == crate::document::SecurityLevel::Supervised
+            && !matches!(base_decision, PolicyDecision::RequireApproval { .. })
+        {
+            // In supervised mode, non-read actions require approval.
+            let read_verbs = ["read", "list", "diff", "status", "search"];
+            if !read_verbs.contains(&request.verb.as_str()) {
+                return PolicyDecision::RequireApproval {
+                    reason: "supervised mode: all state-changing actions require approval"
+                        .to_string(),
+                };
+            }
+        }
+
+        base_decision
+    }
+}
+
+/// Extract the URI scheme from a target URI (e.g., "fs" from "fs://workspace/file").
+fn extract_uri_scheme(uri: &str) -> Option<&str> {
+    uri.find("://").map(|pos| &uri[..pos])
+}
+
 /// Check if any grant in the manifest matches the request.
 ///
 /// A grant matches if:
@@ -393,6 +532,7 @@ fn contains_path_traversal(uri: &str) -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
 mod tests {
     use super::*;
     use crate::capability::{CapabilityGrant, CapabilityManifest};
@@ -873,5 +1013,174 @@ mod tests {
         assert_eq!(restored.decision, trace.decision);
         assert_eq!(restored.steps.len(), trace.steps.len());
         assert_eq!(restored.grants_checked.len(), trace.grants_checked.len());
+    }
+
+    // ── v0.6.1 PolicyDocument-aware evaluation tests ──
+
+    #[test]
+    fn document_scheme_approval_overrides_allow() {
+        use crate::context::PolicyContext;
+        use crate::document::{PolicyDocument, SchemePolicy};
+
+        let mut engine = PolicyEngine::new();
+        engine.load_manifest(test_manifest(
+            "agent-1",
+            vec![grant("fs", "write_patch", "fs://workspace/**")],
+        ));
+
+        // Base evaluation would Allow write_patch.
+        let request = PolicyRequest {
+            agent_id: "agent-1".to_string(),
+            tool: "fs".to_string(),
+            verb: "write_patch".to_string(),
+            target_uri: "fs://workspace/src/main.rs".to_string(),
+        };
+        assert_eq!(engine.evaluate(&request), PolicyDecision::Allow);
+
+        // But the document says fs.write_patch requires approval.
+        let mut doc = PolicyDocument::default();
+        doc.schemes.insert(
+            "fs".to_string(),
+            SchemePolicy {
+                approval_required: vec!["write_patch".to_string()],
+                ..Default::default()
+            },
+        );
+        let ctx = PolicyContext::new("agent-1");
+
+        let decision = engine.evaluate_with_document(&request, &doc, &ctx);
+        match decision {
+            PolicyDecision::RequireApproval { reason } => {
+                assert!(reason.contains("write_patch"));
+            }
+            other => panic!("expected RequireApproval, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn document_supervised_mode_requires_approval_for_writes() {
+        use crate::context::PolicyContext;
+        use crate::document::{PolicyDocument, SecurityLevel};
+
+        let mut engine = PolicyEngine::new();
+        engine.load_manifest(test_manifest(
+            "agent-1",
+            vec![grant("fs", "write_patch", "fs://workspace/**")],
+        ));
+
+        let mut doc = PolicyDocument::default();
+        doc.security_level = SecurityLevel::Supervised;
+        let ctx = PolicyContext::new("agent-1");
+
+        let request = PolicyRequest {
+            agent_id: "agent-1".to_string(),
+            tool: "fs".to_string(),
+            verb: "write_patch".to_string(),
+            target_uri: "fs://workspace/src/main.rs".to_string(),
+        };
+
+        let decision = engine.evaluate_with_document(&request, &doc, &ctx);
+        match decision {
+            PolicyDecision::RequireApproval { reason } => {
+                assert!(reason.contains("supervised"));
+            }
+            other => panic!("expected RequireApproval, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn document_supervised_mode_allows_reads() {
+        use crate::context::PolicyContext;
+        use crate::document::{PolicyDocument, SecurityLevel};
+
+        let mut engine = PolicyEngine::new();
+        engine.load_manifest(test_manifest(
+            "agent-1",
+            vec![grant("fs", "read", "fs://workspace/**")],
+        ));
+
+        let mut doc = PolicyDocument::default();
+        doc.security_level = SecurityLevel::Supervised;
+        let ctx = PolicyContext::new("agent-1");
+
+        let request = PolicyRequest {
+            agent_id: "agent-1".to_string(),
+            tool: "fs".to_string(),
+            verb: "read".to_string(),
+            target_uri: "fs://workspace/src/main.rs".to_string(),
+        };
+
+        // Reads should still be allowed in supervised mode.
+        let decision = engine.evaluate_with_document(&request, &doc, &ctx);
+        assert_eq!(decision, PolicyDecision::Allow);
+    }
+
+    #[test]
+    fn document_budget_exceeded_denies() {
+        use crate::context::PolicyContext;
+        use crate::document::{BudgetConfig, PolicyDocument};
+
+        let mut engine = PolicyEngine::new();
+        engine.load_manifest(test_manifest(
+            "agent-1",
+            vec![grant("fs", "read", "fs://workspace/**")],
+        ));
+
+        let mut doc = PolicyDocument::default();
+        doc.budget = Some(BudgetConfig {
+            max_tokens_per_goal: Some(100_000),
+            warn_at_percent: 80,
+        });
+
+        let mut ctx = PolicyContext::new("agent-1");
+        ctx.budget_spent = 150_000; // over budget
+
+        let request = PolicyRequest {
+            agent_id: "agent-1".to_string(),
+            tool: "fs".to_string(),
+            verb: "read".to_string(),
+            target_uri: "fs://workspace/file.txt".to_string(),
+        };
+
+        let decision = engine.evaluate_with_document(&request, &doc, &ctx);
+        match decision {
+            PolicyDecision::Deny { reason } => {
+                assert!(reason.contains("budget"));
+            }
+            other => panic!("expected Deny, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn document_drift_escalation() {
+        use crate::context::PolicyContext;
+        use crate::document::PolicyDocument;
+
+        let mut engine = PolicyEngine::new();
+        engine.load_manifest(test_manifest(
+            "agent-1",
+            vec![grant("fs", "read", "fs://workspace/**")],
+        ));
+
+        let mut doc = PolicyDocument::default();
+        doc.escalation.drift_threshold = Some(0.5);
+
+        let mut ctx = PolicyContext::new("agent-1");
+        ctx.drift_score = Some(0.7); // above threshold
+
+        let request = PolicyRequest {
+            agent_id: "agent-1".to_string(),
+            tool: "fs".to_string(),
+            verb: "read".to_string(),
+            target_uri: "fs://workspace/file.txt".to_string(),
+        };
+
+        let decision = engine.evaluate_with_document(&request, &doc, &ctx);
+        match decision {
+            PolicyDecision::RequireApproval { reason } => {
+                assert!(reason.contains("drift"));
+            }
+            other => panic!("expected RequireApproval, got {:?}", other),
+        }
     }
 }

--- a/crates/ta-policy/src/error.rs
+++ b/crates/ta-policy/src/error.rs
@@ -23,4 +23,15 @@ pub enum PolicyError {
     /// The target URI contains path traversal sequences (security violation).
     #[error("path traversal detected in target URI: '{uri}'")]
     PathTraversal { uri: String },
+
+    /// I/O error reading a policy file.
+    #[error("I/O error at {path}: {source}")]
+    IoError {
+        path: String,
+        source: std::io::Error,
+    },
+
+    /// Configuration error in a policy YAML file.
+    #[error("policy config error: {0}")]
+    ConfigError(String),
 }

--- a/crates/ta-policy/src/lib.rs
+++ b/crates/ta-policy/src/lib.rs
@@ -25,8 +25,11 @@
 
 pub mod alignment;
 pub mod capability;
+pub mod cascade;
 pub mod compiler;
 pub mod constitution;
+pub mod context;
+pub mod document;
 pub mod engine;
 pub mod error;
 pub mod exemption;
@@ -36,10 +39,16 @@ pub use alignment::{
     ProposedAgent,
 };
 pub use capability::{CapabilityGrant, CapabilityManifest};
+pub use cascade::{CliOverrides, PolicyCascade};
 pub use compiler::{CompilerError, CompilerOptions, PolicyCompiler};
 pub use constitution::{
     AccessConstitution, ConstitutionEntry, ConstitutionError, ConstitutionStore,
     ConstitutionValidation, EnforcementMode,
+};
+pub use context::PolicyContext;
+pub use document::{
+    AgentPolicyOverride, AutoApproveConfig, BudgetConfig, EscalationConfig, PolicyDefaults,
+    PolicyDocument, PolicyEnforcement, SchemePolicy, SecurityLevel,
 };
 pub use engine::{EvaluationStep, EvaluationTrace, PolicyDecision, PolicyEngine, PolicyRequest};
 pub use error::PolicyError;

--- a/crates/ta-session/Cargo.toml
+++ b/crates/ta-session/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ta-session"
+version = "0.6.0-alpha"
+edition = "2021"
+description = "Session & Human Control Plane — continuous conversation lifecycle for TA goals"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+# Workspace crates
+ta-goal = { path = "../ta-goal" }
+ta-changeset = { path = "../ta-changeset" }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/ta-session/src/error.rs
+++ b/crates/ta-session/src/error.rs
@@ -1,0 +1,23 @@
+// error.rs — Error types for the session crate.
+
+/// Errors from session operations.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionError {
+    #[error("session not found: {session_id}")]
+    NotFound { session_id: String },
+
+    #[error("invalid state transition from {from} to {to}")]
+    InvalidTransition { from: String, to: String },
+
+    #[error("session already exists for goal {goal_id}")]
+    AlreadyExists { goal_id: String },
+
+    #[error("I/O error at {path}: {source}")]
+    Io {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+}

--- a/crates/ta-session/src/lib.rs
+++ b/crates/ta-session/src/lib.rs
@@ -1,0 +1,11 @@
+// ta-session — Session & Human Control Plane (Layer 3).
+//
+// Placeholder — implementation coming in Phase 3.
+
+pub mod error;
+pub mod manager;
+pub mod session;
+
+pub use error::SessionError;
+pub use manager::SessionManager;
+pub use session::{ConversationTurn, SessionState, TaSession};

--- a/crates/ta-session/src/manager.rs
+++ b/crates/ta-session/src/manager.rs
@@ -1,0 +1,263 @@
+// manager.rs — SessionManager: CRUD for TaSession instances.
+//
+// Stores sessions as JSON files in .ta/sessions/<session-id>.json.
+
+use std::fs;
+use std::path::PathBuf;
+
+use uuid::Uuid;
+
+use crate::error::SessionError;
+use crate::session::{SessionState, TaSession};
+
+/// Persistent storage and lifecycle management for TaSession instances.
+pub struct SessionManager {
+    sessions_dir: PathBuf,
+}
+
+impl SessionManager {
+    /// Create a new session manager with the given storage directory.
+    pub fn new(sessions_dir: PathBuf) -> Result<Self, SessionError> {
+        fs::create_dir_all(&sessions_dir).map_err(|source| SessionError::Io {
+            path: sessions_dir.display().to_string(),
+            source,
+        })?;
+        Ok(Self { sessions_dir })
+    }
+
+    /// Create and persist a new session for a goal.
+    pub fn create(&self, goal_id: Uuid, agent_id: &str) -> Result<TaSession, SessionError> {
+        let session = TaSession::new(goal_id, agent_id);
+        self.save(&session)?;
+        Ok(session)
+    }
+
+    /// Save a session to disk.
+    pub fn save(&self, session: &TaSession) -> Result<(), SessionError> {
+        let path = self.session_path(session.session_id);
+        let json = serde_json::to_string_pretty(session)?;
+        fs::write(&path, json).map_err(|source| SessionError::Io {
+            path: path.display().to_string(),
+            source,
+        })?;
+        Ok(())
+    }
+
+    /// Load a session from disk by ID.
+    pub fn load(&self, session_id: Uuid) -> Result<TaSession, SessionError> {
+        let path = self.session_path(session_id);
+        if !path.exists() {
+            return Err(SessionError::NotFound {
+                session_id: session_id.to_string(),
+            });
+        }
+        let json = fs::read_to_string(&path).map_err(|source| SessionError::Io {
+            path: path.display().to_string(),
+            source,
+        })?;
+        let session = serde_json::from_str(&json)?;
+        Ok(session)
+    }
+
+    /// Find the active session for a goal (if any).
+    pub fn find_for_goal(&self, goal_id: Uuid) -> Result<Option<TaSession>, SessionError> {
+        let sessions = self.list()?;
+        Ok(sessions
+            .into_iter()
+            .find(|s| s.goal_id == goal_id && s.is_active()))
+    }
+
+    /// List all sessions, sorted by most recently updated.
+    pub fn list(&self) -> Result<Vec<TaSession>, SessionError> {
+        let mut sessions = Vec::new();
+        if !self.sessions_dir.exists() {
+            return Ok(sessions);
+        }
+
+        for entry in fs::read_dir(&self.sessions_dir).map_err(|source| SessionError::Io {
+            path: self.sessions_dir.display().to_string(),
+            source,
+        })? {
+            let entry = entry.map_err(|source| SessionError::Io {
+                path: self.sessions_dir.display().to_string(),
+                source,
+            })?;
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "json") {
+                if let Ok(json) = fs::read_to_string(&path) {
+                    if let Ok(session) = serde_json::from_str::<TaSession>(&json) {
+                        sessions.push(session);
+                    }
+                }
+            }
+        }
+
+        sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        Ok(sessions)
+    }
+
+    /// List only active sessions (not completed, aborted, or failed).
+    pub fn list_active(&self) -> Result<Vec<TaSession>, SessionError> {
+        Ok(self.list()?.into_iter().filter(|s| s.is_active()).collect())
+    }
+
+    /// Pause a session (transition to Paused state).
+    pub fn pause(&self, session_id: Uuid) -> Result<TaSession, SessionError> {
+        let mut session = self.load(session_id)?;
+        session.transition(SessionState::Paused)?;
+        self.save(&session)?;
+        Ok(session)
+    }
+
+    /// Resume a paused session (transition back to AgentRunning).
+    pub fn resume(&self, session_id: Uuid) -> Result<TaSession, SessionError> {
+        let mut session = self.load(session_id)?;
+        session.transition(SessionState::AgentRunning)?;
+        self.save(&session)?;
+        Ok(session)
+    }
+
+    /// Abort a session.
+    pub fn abort(&self, session_id: Uuid) -> Result<TaSession, SessionError> {
+        let mut session = self.load(session_id)?;
+        session.transition(SessionState::Aborted)?;
+        self.save(&session)?;
+        Ok(session)
+    }
+
+    /// Delete a session from disk.
+    pub fn delete(&self, session_id: Uuid) -> Result<(), SessionError> {
+        let path = self.session_path(session_id);
+        if path.exists() {
+            fs::remove_file(&path).map_err(|source| SessionError::Io {
+                path: path.display().to_string(),
+                source,
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Check if a session exists.
+    pub fn exists(&self, session_id: Uuid) -> bool {
+        self.session_path(session_id).exists()
+    }
+
+    fn session_path(&self, session_id: Uuid) -> PathBuf {
+        self.sessions_dir.join(format!("{}.json", session_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn create_and_load_session() {
+        let temp = TempDir::new().unwrap();
+        let manager = SessionManager::new(temp.path().to_path_buf()).unwrap();
+
+        let goal_id = Uuid::new_v4();
+        let session = manager.create(goal_id, "claude-code").unwrap();
+
+        let loaded = manager.load(session.session_id).unwrap();
+        assert_eq!(loaded.session_id, session.session_id);
+        assert_eq!(loaded.goal_id, goal_id);
+        assert_eq!(loaded.agent_id, "claude-code");
+    }
+
+    #[test]
+    fn list_sessions() {
+        let temp = TempDir::new().unwrap();
+        let manager = SessionManager::new(temp.path().to_path_buf()).unwrap();
+
+        manager.create(Uuid::new_v4(), "agent-1").unwrap();
+        manager.create(Uuid::new_v4(), "agent-2").unwrap();
+
+        let sessions = manager.list().unwrap();
+        assert_eq!(sessions.len(), 2);
+    }
+
+    #[test]
+    fn list_active_filters_completed() {
+        let temp = TempDir::new().unwrap();
+        let manager = SessionManager::new(temp.path().to_path_buf()).unwrap();
+
+        let s1 = manager.create(Uuid::new_v4(), "agent-1").unwrap();
+        let s2 = manager.create(Uuid::new_v4(), "agent-2").unwrap();
+
+        // Complete s2
+        let mut s2_loaded = manager.load(s2.session_id).unwrap();
+        s2_loaded.state = SessionState::Completed;
+        manager.save(&s2_loaded).unwrap();
+
+        let active = manager.list_active().unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].session_id, s1.session_id);
+    }
+
+    #[test]
+    fn find_for_goal() {
+        let temp = TempDir::new().unwrap();
+        let manager = SessionManager::new(temp.path().to_path_buf()).unwrap();
+
+        let goal_id = Uuid::new_v4();
+        let session = manager.create(goal_id, "agent").unwrap();
+
+        let found = manager.find_for_goal(goal_id).unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().session_id, session.session_id);
+
+        let not_found = manager.find_for_goal(Uuid::new_v4()).unwrap();
+        assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn pause_and_resume() {
+        let temp = TempDir::new().unwrap();
+        let manager = SessionManager::new(temp.path().to_path_buf()).unwrap();
+
+        let mut session = manager.create(Uuid::new_v4(), "agent").unwrap();
+        session.transition(SessionState::AgentRunning).unwrap();
+        manager.save(&session).unwrap();
+
+        let paused = manager.pause(session.session_id).unwrap();
+        assert_eq!(paused.state, SessionState::Paused);
+
+        let resumed = manager.resume(session.session_id).unwrap();
+        assert_eq!(resumed.state, SessionState::AgentRunning);
+    }
+
+    #[test]
+    fn abort_session() {
+        let temp = TempDir::new().unwrap();
+        let manager = SessionManager::new(temp.path().to_path_buf()).unwrap();
+
+        let mut session = manager.create(Uuid::new_v4(), "agent").unwrap();
+        session.transition(SessionState::AgentRunning).unwrap();
+        manager.save(&session).unwrap();
+
+        let aborted = manager.abort(session.session_id).unwrap();
+        assert_eq!(aborted.state, SessionState::Aborted);
+        assert!(!aborted.is_active());
+    }
+
+    #[test]
+    fn delete_session() {
+        let temp = TempDir::new().unwrap();
+        let manager = SessionManager::new(temp.path().to_path_buf()).unwrap();
+
+        let session = manager.create(Uuid::new_v4(), "agent").unwrap();
+        assert!(manager.exists(session.session_id));
+
+        manager.delete(session.session_id).unwrap();
+        assert!(!manager.exists(session.session_id));
+    }
+
+    #[test]
+    fn load_nonexistent_returns_error() {
+        let temp = TempDir::new().unwrap();
+        let manager = SessionManager::new(temp.path().to_path_buf()).unwrap();
+        assert!(manager.load(Uuid::new_v4()).is_err());
+    }
+}

--- a/crates/ta-session/src/session.rs
+++ b/crates/ta-session/src/session.rs
@@ -1,0 +1,366 @@
+// session.rs — TaSession: the core session object (stub for workspace build).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::SessionError;
+
+/// The core session object — one session per goal.
+///
+/// Tracks the full lifecycle from agent launch through review iterations
+/// to final approval. Provides conversational continuity: when the human
+/// rejects a draft with feedback, TA relaunches the agent with context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaSession {
+    pub session_id: Uuid,
+    pub goal_id: Uuid,
+    pub agent_id: String,
+    pub state: SessionState,
+    pub conversation: Vec<ConversationTurn>,
+    pub pending_draft: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub iteration_count: u32,
+    pub checkpoint_mode: bool,
+}
+
+/// Session lifecycle states.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionState {
+    /// Session created, agent not yet launched.
+    Starting,
+    /// Agent is executing in the staging workspace.
+    AgentRunning,
+    /// Agent exited, draft has been built.
+    DraftReady,
+    /// Draft submitted, waiting for human review.
+    WaitingForReview,
+    /// Human rejected, preparing to relaunch with feedback.
+    Iterating,
+    /// Draft approved and applied — session complete.
+    Completed,
+    /// Human aborted the session.
+    Aborted,
+    /// Session paused by human.
+    Paused,
+    /// An error occurred.
+    Failed { reason: String },
+}
+
+impl std::fmt::Display for SessionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionState::Starting => write!(f, "starting"),
+            SessionState::AgentRunning => write!(f, "agent_running"),
+            SessionState::DraftReady => write!(f, "draft_ready"),
+            SessionState::WaitingForReview => write!(f, "waiting_for_review"),
+            SessionState::Iterating => write!(f, "iterating"),
+            SessionState::Completed => write!(f, "completed"),
+            SessionState::Aborted => write!(f, "aborted"),
+            SessionState::Paused => write!(f, "paused"),
+            SessionState::Failed { reason } => write!(f, "failed: {}", reason),
+        }
+    }
+}
+
+/// A single turn in the human↔agent conversation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationTurn {
+    pub turn_id: Uuid,
+    pub iteration: u32,
+    pub agent_context: Option<String>,
+    pub human_feedback: Option<String>,
+    pub draft_id: Option<Uuid>,
+    pub timestamp: DateTime<Utc>,
+}
+
+impl TaSession {
+    /// Create a new session for a goal.
+    pub fn new(goal_id: Uuid, agent_id: &str) -> Self {
+        let now = Utc::now();
+        Self {
+            session_id: Uuid::new_v4(),
+            goal_id,
+            agent_id: agent_id.to_string(),
+            state: SessionState::Starting,
+            conversation: Vec::new(),
+            pending_draft: None,
+            created_at: now,
+            updated_at: now,
+            iteration_count: 0,
+            checkpoint_mode: false,
+        }
+    }
+
+    /// Enable checkpoint mode (for batch/CI workflows).
+    pub fn with_checkpoint_mode(mut self) -> Self {
+        self.checkpoint_mode = true;
+        self
+    }
+
+    /// Transition to a new state, validating the transition.
+    pub fn transition(&mut self, new_state: SessionState) -> Result<(), SessionError> {
+        let valid = matches!(
+            (&self.state, &new_state),
+            // Normal forward flow
+            (SessionState::Starting, SessionState::AgentRunning)
+                | (SessionState::AgentRunning, SessionState::DraftReady)
+                | (SessionState::DraftReady, SessionState::WaitingForReview)
+                | (SessionState::WaitingForReview, SessionState::Completed)
+                | (SessionState::WaitingForReview, SessionState::Iterating)
+                | (SessionState::Iterating, SessionState::AgentRunning)
+                // Pause/resume
+                | (SessionState::AgentRunning, SessionState::Paused)
+                | (SessionState::Paused, SessionState::AgentRunning)
+                // Abort from any active state
+                | (SessionState::Starting, SessionState::Aborted)
+                | (SessionState::AgentRunning, SessionState::Aborted)
+                | (SessionState::DraftReady, SessionState::Aborted)
+                | (SessionState::WaitingForReview, SessionState::Aborted)
+                | (SessionState::Iterating, SessionState::Aborted)
+                | (SessionState::Paused, SessionState::Aborted)
+                // Fail from any active state
+                | (SessionState::Starting, SessionState::Failed { .. })
+                | (SessionState::AgentRunning, SessionState::Failed { .. })
+                | (SessionState::DraftReady, SessionState::Failed { .. })
+                | (SessionState::WaitingForReview, SessionState::Failed { .. })
+                | (SessionState::Iterating, SessionState::Failed { .. })
+                | (SessionState::Paused, SessionState::Failed { .. })
+        );
+
+        if !valid {
+            return Err(SessionError::InvalidTransition {
+                from: self.state.to_string(),
+                to: new_state.to_string(),
+            });
+        }
+
+        self.state = new_state;
+        self.updated_at = Utc::now();
+        Ok(())
+    }
+
+    /// Record a new conversation turn.
+    pub fn add_turn(
+        &mut self,
+        agent_context: Option<String>,
+        human_feedback: Option<String>,
+        draft_id: Option<Uuid>,
+    ) {
+        self.iteration_count += 1;
+        self.conversation.push(ConversationTurn {
+            turn_id: Uuid::new_v4(),
+            iteration: self.iteration_count,
+            agent_context,
+            human_feedback,
+            draft_id,
+            timestamp: Utc::now(),
+        });
+        self.updated_at = Utc::now();
+    }
+
+    /// Set the pending draft ID.
+    pub fn set_pending_draft(&mut self, draft_id: Uuid) {
+        self.pending_draft = Some(draft_id);
+        self.updated_at = Utc::now();
+    }
+
+    /// Clear the pending draft.
+    pub fn clear_pending_draft(&mut self) {
+        self.pending_draft = None;
+        self.updated_at = Utc::now();
+    }
+
+    /// Check if the session is in an active state (can still progress).
+    pub fn is_active(&self) -> bool {
+        !matches!(
+            self.state,
+            SessionState::Completed | SessionState::Aborted | SessionState::Failed { .. }
+        )
+    }
+
+    /// Get elapsed time since session start.
+    pub fn elapsed(&self) -> chrono::Duration {
+        Utc::now() - self.created_at
+    }
+
+    /// Format elapsed time as a human-readable string.
+    pub fn elapsed_display(&self) -> String {
+        let dur = self.elapsed();
+        let secs = dur.num_seconds();
+        if secs < 60 {
+            format!("{}s", secs)
+        } else if secs < 3600 {
+            format!("{}m {}s", secs / 60, secs % 60)
+        } else {
+            format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_session_starts_in_starting_state() {
+        let session = TaSession::new(Uuid::new_v4(), "claude-code");
+        assert_eq!(session.state, SessionState::Starting);
+        assert!(session.is_active());
+        assert_eq!(session.iteration_count, 0);
+        assert!(session.conversation.is_empty());
+    }
+
+    #[test]
+    fn normal_lifecycle_flow() {
+        let mut session = TaSession::new(Uuid::new_v4(), "claude-code");
+
+        session.transition(SessionState::AgentRunning).unwrap();
+        assert_eq!(session.state, SessionState::AgentRunning);
+
+        session.transition(SessionState::DraftReady).unwrap();
+        assert_eq!(session.state, SessionState::DraftReady);
+
+        session.transition(SessionState::WaitingForReview).unwrap();
+        assert_eq!(session.state, SessionState::WaitingForReview);
+
+        session.transition(SessionState::Completed).unwrap();
+        assert_eq!(session.state, SessionState::Completed);
+        assert!(!session.is_active());
+    }
+
+    #[test]
+    fn iteration_loop() {
+        let mut session = TaSession::new(Uuid::new_v4(), "claude-code");
+
+        // First iteration
+        session.transition(SessionState::AgentRunning).unwrap();
+        session.transition(SessionState::DraftReady).unwrap();
+        session.transition(SessionState::WaitingForReview).unwrap();
+
+        // Human rejects → iterate
+        session.transition(SessionState::Iterating).unwrap();
+        session.transition(SessionState::AgentRunning).unwrap();
+
+        // Second iteration
+        session.transition(SessionState::DraftReady).unwrap();
+        session.transition(SessionState::WaitingForReview).unwrap();
+        session.transition(SessionState::Completed).unwrap();
+    }
+
+    #[test]
+    fn pause_and_resume() {
+        let mut session = TaSession::new(Uuid::new_v4(), "claude-code");
+        session.transition(SessionState::AgentRunning).unwrap();
+
+        session.transition(SessionState::Paused).unwrap();
+        assert_eq!(session.state, SessionState::Paused);
+        assert!(session.is_active());
+
+        session.transition(SessionState::AgentRunning).unwrap();
+        assert_eq!(session.state, SessionState::AgentRunning);
+    }
+
+    #[test]
+    fn abort_from_active_states() {
+        for initial in [
+            SessionState::Starting,
+            SessionState::AgentRunning,
+            SessionState::DraftReady,
+            SessionState::WaitingForReview,
+            SessionState::Iterating,
+            SessionState::Paused,
+        ] {
+            let mut session = TaSession::new(Uuid::new_v4(), "agent");
+            session.state = initial;
+            session.transition(SessionState::Aborted).unwrap();
+            assert!(!session.is_active());
+        }
+    }
+
+    #[test]
+    fn invalid_transition_rejected() {
+        let mut session = TaSession::new(Uuid::new_v4(), "agent");
+        session.transition(SessionState::Completed).unwrap_err();
+
+        let mut session2 = TaSession::new(Uuid::new_v4(), "agent");
+        session2.state = SessionState::Completed;
+        session2.transition(SessionState::AgentRunning).unwrap_err();
+    }
+
+    #[test]
+    fn add_turn_increments_iteration() {
+        let mut session = TaSession::new(Uuid::new_v4(), "agent");
+        session.add_turn(Some("context".to_string()), None, None);
+        assert_eq!(session.iteration_count, 1);
+        assert_eq!(session.conversation.len(), 1);
+        assert_eq!(session.conversation[0].iteration, 1);
+
+        session.add_turn(None, Some("fix the bug".to_string()), None);
+        assert_eq!(session.iteration_count, 2);
+        assert_eq!(session.conversation[1].iteration, 2);
+    }
+
+    #[test]
+    fn pending_draft_management() {
+        let mut session = TaSession::new(Uuid::new_v4(), "agent");
+        assert!(session.pending_draft.is_none());
+
+        let draft_id = Uuid::new_v4();
+        session.set_pending_draft(draft_id);
+        assert_eq!(session.pending_draft, Some(draft_id));
+
+        session.clear_pending_draft();
+        assert!(session.pending_draft.is_none());
+    }
+
+    #[test]
+    fn serialization_round_trip() {
+        let mut session = TaSession::new(Uuid::new_v4(), "claude-code");
+        session.add_turn(Some("initial context".to_string()), None, None);
+        session.set_pending_draft(Uuid::new_v4());
+
+        let json = serde_json::to_string(&session).unwrap();
+        let restored: TaSession = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.session_id, session.session_id);
+        assert_eq!(restored.goal_id, session.goal_id);
+        assert_eq!(restored.agent_id, session.agent_id);
+        assert_eq!(restored.iteration_count, 1);
+        assert_eq!(restored.conversation.len(), 1);
+    }
+
+    #[test]
+    fn checkpoint_mode() {
+        let session = TaSession::new(Uuid::new_v4(), "agent").with_checkpoint_mode();
+        assert!(session.checkpoint_mode);
+    }
+
+    #[test]
+    fn session_state_display() {
+        assert_eq!(format!("{}", SessionState::Starting), "starting");
+        assert_eq!(format!("{}", SessionState::AgentRunning), "agent_running");
+        assert_eq!(
+            format!("{}", SessionState::WaitingForReview),
+            "waiting_for_review"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                SessionState::Failed {
+                    reason: "oops".to_string()
+                }
+            ),
+            "failed: oops"
+        );
+    }
+
+    #[test]
+    fn elapsed_display_formatting() {
+        let session = TaSession::new(Uuid::new_v4(), "agent");
+        let display = session.elapsed_display();
+        assert!(display.ends_with('s'));
+    }
+}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: v0.5.0-alpha
+**Version**: v0.6.0-alpha
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 
@@ -1065,13 +1065,103 @@ When using Claude Flow as your agent:
 
 See `examples/claude-settings.json` for a complete optimized configuration.
 
+### Session Lifecycle (v0.6.0)
+
+TA sessions track the full conversation lifecycle for a goal, including review iterations. Each session records what the agent was told, what it produced, and how the human responded.
+
+```bash
+# View active sessions with state, iteration count, and elapsed time
+ta session status
+
+# Pause a running session
+ta session pause <session-id>
+
+# Resume a paused session
+ta session resume <session-id>
+
+# Abort a session
+ta session abort <session-id> --reason "No longer needed"
+
+# List all sessions (including completed/aborted)
+ta session list --all
+
+# Show session details and conversation history
+ta session show <session-id>
+```
+
+Session states: `Starting` → `AgentRunning` → `DraftReady` → `WaitingForReview` → `Completed` (or `Iterating` → back to `AgentRunning` on rejection, or `Paused`/`Aborted`/`Failed`).
+
+Sessions are stored in `.ta/sessions/<session-id>.json` and emit events (`SessionPaused`, `SessionResumed`, `SessionAborted`, `DraftBuilt`, `ReviewDecision`, `SessionIteration`) to the event stream.
+
+### Unified Policy Config (v0.6.1)
+
+All supervision configuration resolves to a single `PolicyDocument` loaded from `.ta/policy.yaml`. Configuration is merged from 6 layers, where each layer can tighten but never loosen restrictions.
+
+```yaml
+# .ta/policy.yaml
+security_level: checkpoint   # open | checkpoint | supervised | strict
+
+defaults:
+  enforcement: warning        # warning | error | strict
+  auto_approve:
+    read_only: true
+    internal_tools: true
+
+schemes:
+  fs:
+    approval_required: [apply, delete]
+  email:
+    approval_required: [send]
+    credential_required: true
+    max_actions_per_session: 50
+
+escalation:
+  drift_threshold: 0.7
+  action_count_limit: 200
+  patterns:
+    - new_dependency
+    - security_sensitive
+
+agents:
+  claude-code:
+    additional_approval_required: [network_external]
+    forbidden_actions: [credential_access]
+
+budget:
+  max_tokens_per_goal: 1000000
+  warn_at_percent: 80
+```
+
+**Merge cascade** (each layer tightens, never loosens):
+1. Built-in defaults (Checkpoint level, auto-approve read-only)
+2. `.ta/policy.yaml` (project config)
+3. `.ta/workflows/<name>.yaml` (workflow overrides)
+4. `.ta/agents/<agent>.policy.yaml` (agent-specific)
+5. `.ta/constitutions/goal-<id>.yaml` (goal constitution)
+6. CLI overrides (`--strict`, `--auto-approve=false`)
+
+**Security levels**:
+- **Open**: Audit-only, no approvals required
+- **Checkpoint** (default): Review at draft submission
+- **Supervised**: Approve each state-changing action
+- **Strict**: Constitutions required for all goals
+
+### Resource Mediation (v0.6.2)
+
+The `ResourceMediator` trait generalizes TA's staging pattern from files to any resource type. Each mediator handles a URI scheme (`fs://`, `email://`, `db://`, etc.) and provides stage → preview → apply → rollback operations.
+
+Built-in mediators:
+- **FsMediator** (`fs://`): File system staging (wraps existing staging workspace)
+
+The `MediatorRegistry` routes actions to the correct mediator by URI scheme. Future mediators (API, database, email) implement the same trait.
+
 ---
 
 ## Roadmap
 
 ### What's Done
 
-TA has a working end-to-end workflow: staging isolation, agent wrapping, draft review with per-artifact approval, follow-up iterations, macro goals with inner-loop review, interactive sessions, plan tracking, release pipelines, behavioral drift detection, access constitutions, alignment profiles, decision observability, credential management, MCP tool call interception, web review UI, webhook review channels, and persistent context memory.
+TA has a working end-to-end workflow: staging isolation, agent wrapping, draft review with per-artifact approval, follow-up iterations, macro goals with inner-loop review, interactive sessions, plan tracking, release pipelines, behavioral drift detection, access constitutions, alignment profiles, decision observability, credential management, MCP tool call interception, web review UI, webhook review channels, persistent context memory, session lifecycle management, unified policy configuration, and resource mediation.
 
 ### Phase Status
 
@@ -1116,40 +1206,33 @@ TA has a working end-to-end workflow: staging isolation, agent wrapping, draft r
 | v0.5.2 | Minimal web review UI | Done |
 | v0.5.3 | ReviewChannel adapters (webhook) | Done |
 | v0.5.4 | Context memory store | Done |
-
-### v0.5 -- MCP Interception & External Actions
-
-| Phase | Description | Status |
-|-------|-------------|--------|
-| v0.5.0 | Credential broker and identity abstraction | Done |
-| v0.5.1 | MCP tool call interception | Done |
-| v0.5.2 | Minimal web review UI | Done |
-| v0.5.3 | ReviewChannel adapters (webhook, Slack/email stubs) | Done |
-| v0.5.4 | Context memory store (filesystem backend) | Done |
 | v0.5.5 | RuVector memory backend (semantic search, HNSW indexing) | Done |
 | v0.5.6 | Framework-agnostic agent state (auto-capture, context injection) | Done |
-| v0.5.6 | Framework-agnostic agent state (cross-framework context) | Pending |
-| v0.5.7 | Semantic memory queries and memory dashboard | Pending |
+| v0.5.7 | Semantic memory queries and memory dashboard | Done |
+| v0.6.0 | Session & human control plane | Done |
+| v0.6.1 | Unified policy config | Done |
+| v0.6.2 | Resource mediation trait | Done |
 
-### What's Next (v0.6+)
-
-| Phase | Description | Status |
-|-------|-------------|--------|
-| v0.6.0 | Supervisor agent and constitutional auto-approval | Pending |
-| v0.6.1 | Cost tracking and budget limits | Pending |
-
-### Vision (v0.7+)
+### v0.6 -- Platform Substrate
 
 | Phase | Description | Status |
 |-------|-------------|--------|
-| v0.7.0 | Agent-guided setup (`ta setup`) | Pending |
-| v0.7.1 | Domain workflow templates (finance, email, social) | Pending |
-| v0.8.0 | Event system and orchestration API | Pending |
+| v0.6.0 | Session & human control plane (TaSession, SessionManager, CLI commands) | Done |
+| v0.6.1 | Unified policy config (PolicyDocument, PolicyCascade, PolicyContext) | Done |
+| v0.6.2 | Resource mediation trait (ResourceMediator, FsMediator, MediatorRegistry) | Done |
+
+### What's Next (v0.7+)
+
+| Phase | Description | Status |
+|-------|-------------|--------|
+| v0.7.0 | Channel registry (pluggable IO channels) | Pending |
+| v0.7.1 | API mediator (MCP tool call staging) | Pending |
+| v0.7.2 | Agent-guided setup (`ta setup`) | Pending |
+| v0.8.0 | Event system and subscription API | Pending |
 | v0.8.1 | Community memory (shared knowledge across instances) | Pending |
 | v0.9.0 | Distribution and packaging (desktop, cloud, web UI) | Pending |
 | v0.9.1 | Native Windows support | Pending |
 | v0.9.2 | Sandbox runner (optional kernel-level isolation) | Pending |
-| v1.0.0 | Virtual office runtime (roles, triggers, orchestration) | Pending |
 
 See [PLAN.md](../PLAN.md) for full details on each phase.
 


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.6 — Platform Substrate - all phases

**Why**: Implement v0.6 — Platform Substrate - all phases

**Impact**: 25 file(s) changed

## Changes (25 file(s))

- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/Cargo.toml` — Added ta-mediation and ta-session to workspace members list
  - New crates must be registered as workspace members
- `~` `fs://workspace/PLAN.md` — Added Completed sections to v0.6.0, v0.6.1, v0.6.2 phases listing all implemented items with checkmarks. Added Remaining (deferred) items for each phase.
  - Plan progress tracking must reflect what was actually implemented vs deferred
- `~` `fs://workspace/apps/ta-cli/Cargo.toml` — Bumped version from 0.5.7-alpha to 0.6.0-alpha. Added ta-session dependency.
  - Version bump for v0.6 release and new session management dependency
- `~` `fs://workspace/apps/ta-cli/src/commands/session.rs` — Added Pause, Abort, and Status subcommands to SessionCommands. Added pause_session(), abort_session(), session_status(), resolve_session_id() functions using ta-session::SessionManager.
  - v0.6.0 human control plane commands: ta session pause/abort/status for session lifecycle management
- `~` `fs://workspace/crates/ta-goal/src/events.rs` — Added 6 new TaEvent variants: SessionPaused, SessionResumed, SessionAborted, DraftBuilt, ReviewDecision, SessionIteration. Added helper constructors for each. Added event_type() match arms. 4 new tests.
  - v0.6.0 session lifecycle needs events published to the event stream for observability
- `+` `fs://workspace/crates/ta-mediation/Cargo.toml` — New crate manifest for ta-mediation v0.6.0-alpha with dependencies on serde, uuid, chrono, thiserror, tracing, ta-workspace, ta-changeset
  - v0.6.2 Resource Mediation Trait requires a new crate to house the ResourceMediator trait and shared types
- `+` `fs://workspace/crates/ta-mediation/src/error.rs` — MediationError enum with variants: UnsupportedScheme, StagingFailed, ApplyFailed, RollbackFailed, NoMediator, InvalidUri, Io, Workspace
  - Error types needed by ResourceMediator implementations and MediatorRegistry
- `+` `fs://workspace/crates/ta-mediation/src/fs_mediator.rs` — FsMediator implementing ResourceMediator for fs:// URIs — stage writes to staging dir, preview generates diffs, apply copies to source, rollback removes staged files, classify maps read verbs to ReadOnly. 9 tests.
  - First concrete ResourceMediator implementation, proving the trait works for the existing file staging pattern
- `+` `fs://workspace/crates/ta-mediation/src/lib.rs` — Module declarations and public re-exports for error, mediator, fs_mediator, registry types
  - Crate entry point organizing the ta-mediation public API
- `+` `fs://workspace/crates/ta-mediation/src/mediator.rs` — Core types (ProposedAction, StagedMutation, MutationPreview, ActionClassification, ApplyResult) and ResourceMediator trait with 6 methods (scheme, stage, preview, apply, rollback, classify). 5 tests.
  - The ResourceMediator trait is the central abstraction for v0.6.2, generalizing the file staging pattern to any resource type
- `+` `fs://workspace/crates/ta-mediation/src/registry.rs` — MediatorRegistry routing URIs to mediators by scheme, with register(), get(), route(), schemes(), has_scheme(), len(), is_empty() and extract_scheme() helper. 8 tests.
  - Central routing layer that connects URI-based resource references to the correct ResourceMediator implementation
- `~` `fs://workspace/crates/ta-policy/Cargo.toml` — Bumped version from 0.4.5-alpha to 0.6.0-alpha
  - Version bump for v0.6 release
- `+` `fs://workspace/crates/ta-policy/src/cascade.rs` — PolicyCascade loading and merging PolicyDocument from 6 layers (built-in → project → workflow → agent → constitution → CLI), CliOverrides struct. Tighten-only merge: security level only increases, approval verbs union, action limits take lower, escalation thresholds take lower. 10 tests.
  - v0.6.1 6-layer cascade is the merge mechanism that produces a single PolicyDocument from multiple configuration sources
- `+` `fs://workspace/crates/ta-policy/src/context.rs` — PolicyContext runtime state with goal_id, session_id, agent_id, budget_spent, action_count, drift_score and helper methods (is_over_budget, is_budget_warning, is_drifting). 6 tests.
  - Policy evaluation needs runtime context (budget, drift, action count) alongside static grants for v0.6.1 runtime-aware decisions
- `+` `fs://workspace/crates/ta-policy/src/document.rs` — PolicyDocument unified config surface with SecurityLevel enum (Open<Checkpoint<Supervised<Strict), PolicyDefaults, PolicyEnforcement (Warning<Error<Strict), AutoApproveConfig, SchemePolicy, EscalationConfig, AgentPolicyOverride, BudgetConfig. 8 tests.
  - v0.6.1 needs a single PolicyDocument struct that all supervision config resolves to, with ordered security levels for tighten-only merging
- `~` `fs://workspace/crates/ta-policy/src/engine.rs` — Added evaluate_with_document() method layering document-level checks (scheme approval, agent overrides/forbidden actions, drift escalation, action count limits, budget limits, supervised mode) on top of manifest-based evaluation. Added extract_uri_scheme() helper. 5 new tests.
  - The PolicyEngine needs a document-aware evaluation path that uses the unified PolicyDocument for runtime policy decisions
- `~` `fs://workspace/crates/ta-policy/src/error.rs` — Added IoError variant (path + source) and ConfigError variant for YAML parse errors
  - PolicyCascade needs to report I/O errors when loading YAML files and config parse errors
- `~` `fs://workspace/crates/ta-policy/src/lib.rs` — Added cascade, context, document module declarations and public re-exports for PolicyCascade, CliOverrides, PolicyContext, PolicyDocument, PolicyDefaults, PolicyEnforcement, AutoApproveConfig, SchemePolicy, EscalationConfig, AgentPolicyOverride, SecurityLevel, BudgetConfig
  - New modules need to be exposed as part of the ta-policy public API
- `+` `fs://workspace/crates/ta-session/Cargo.toml` — New crate manifest for ta-session v0.6.0-alpha with dependencies on serde, uuid, chrono, thiserror, tracing, ta-goal, ta-changeset
  - v0.6.0 Session & Human Control Plane requires a new crate for session lifecycle management
- `+` `fs://workspace/crates/ta-session/src/error.rs` — SessionError enum with variants: NotFound, InvalidTransition, AlreadyExists, Io, Serialization
  - Error types for session lifecycle operations
- `+` `fs://workspace/crates/ta-session/src/lib.rs` — Module declarations and public re-exports for TaSession, SessionState, ConversationTurn, SessionManager, SessionError
  - Crate entry point organizing the ta-session public API
- `+` `fs://workspace/crates/ta-session/src/manager.rs` — SessionManager for CRUD persistence in .ta/sessions/<id>.json with create(), load(), save(), find_for_goal(), list(), list_active(), pause(), resume(), abort(), delete(), exists(). 8 tests.
  - Persistent storage and lifecycle operations for TaSession objects
- `+` `fs://workspace/crates/ta-session/src/session.rs` — TaSession struct with SessionState enum (Starting/AgentRunning/DraftReady/WaitingForReview/Iterating/Completed/Aborted/Paused/Failed), ConversationTurn for tracking agent_context and human_feedback, state transition enforcement, checkpoint mode. 12 tests.
  - Core session object tracking conversational continuity across review iterations — the 'one conversation' model for human-agent interaction
- `~` `fs://workspace/docs/USAGE.md` — Updated version to v0.6.0-alpha. Added Session Lifecycle (v0.6.0), Unified Policy Config (v0.6.1), Resource Mediation (v0.6.2) documentation sections. Updated roadmap tables to mark v0.6 phases as Done and align v0.7+ phase descriptions with restructured plan.
  - User-facing documentation must cover new commands (ta session pause/abort/status), .ta/policy.yaml configuration, and ResourceMediator extension point

## Goal Context

- **Title**: Implement v0.6 — Platform Substrate - all phases
- **Objective**: Implement v0.6 — Platform Substrate - all phases
- **Goal ID**: `fda52e38-f87b-49c2-9de6-f1ea17a3b017`
- **PR ID**: `bc87621b-7f2e-41f4-a9b7-564474d14f88`
- **Plan Phase**: `N/A`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
