### PR TITLE
Implement v0.7.6 — Interactive Developer Loop ()

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1784,7 +1784,7 @@ New/modified files:
 - ✅ Version bumped to `0.7.5-alpha`
 
 ### v0.7.6 — Interactive Developer Loop (`ta dev`)
-<!-- status: pending -->
+<!-- status: done -->
 **Goal**: Ship `ta dev` — a local interactive channel where an LLM agent orchestrates the development loop using TA's MCP tools. The agent reads the plan, suggests next goals, launches implementation agents, handles draft review, and cuts releases — all from one persistent session.
 
 **Architecture**: `ta dev` is the **local terminal channel** — the same pattern as Slack, Discord, or a web app. It uses a reusable `agents/dev-loop.yaml` config that any channel can consume. `ta dev` is the convenience CLI entry point that skips staging (orchestration, not implementation), auto-selects `--macro --interactive`, and uses the built-in dev-loop agent config.
@@ -1821,6 +1821,13 @@ New/modified files:
 - Remote channels (Slack, web) — those are projects on top
 - New MCP tools — uses existing ta_plan, ta_goal, ta_draft, ta_context
 - Changes to goal lifecycle or draft workflow — orchestration only
+
+#### Completed
+- ✅ `ta dev` CLI command with `--agent` flag, plan auto-read on startup, no staging overlay
+- ✅ `agents/dev-loop.yaml` orchestration agent config with tool permissions and alignment profile
+- ✅ Plan-aware prompt generation (plan summary, pending phase highlight, drafts summary)
+- ✅ Config loading from YAML (project → user → shipped → fallback)
+- ✅ 5 tests: prompt generation, plan summary, drafts summary, config fallback
 
 ### v0.7.7 — Agent Framework Registry & Setup Integration
 <!-- status: pending -->

--- a/agents/dev-loop.yaml
+++ b/agents/dev-loop.yaml
@@ -1,0 +1,53 @@
+# Dev Loop — Orchestration agent config for `ta dev`.
+#
+# This agent coordinates the development loop: reads the plan, suggests next
+# goals, launches implementation agents, handles draft review, and manages
+# releases. It does NOT write code directly.
+#
+# Reusable by any channel (Slack, web app, etc.) via the ChannelRegistry.
+# `ta dev` is the convenience CLI entry point.
+
+name: dev-loop
+description: "Interactive development loop orchestrator — coordinates plan execution, goal launches, draft review, and releases"
+command: claude
+args_template:
+  - "--allowedTools"
+  - "mcp__ta__ta_plan,mcp__ta__ta_goal,mcp__ta__ta_draft,mcp__ta__ta_context,mcp__ta__ta_release,Read,Grep,Glob,WebFetch,WebSearch"
+  - "-p"
+  - "{prompt}"
+injects_context_file: false
+injects_settings: false
+pre_launch: null
+env: {}
+
+# The dev-loop agent is an orchestrator — it reads the project but does not
+# write files directly. Implementation happens in sub-goals with their own
+# staging workspaces.
+alignment:
+  principal: "project-owner"
+  autonomy_envelope:
+    bounded_actions:
+      - "fs_read"
+      - "plan_read"
+      - "plan_update"
+      - "goal_start"
+      - "draft_review"
+      - "release_run"
+      - "context_read"
+    escalation_triggers:
+      - "goal_start"
+      - "release_run"
+    forbidden_actions:
+      - "fs_write_patch"
+      - "fs_apply"
+      - "network_external"
+      - "credential_access"
+  constitution: "default-v1"
+  coordination:
+    allowed_collaborators:
+      - "claude-code"
+      - "codex"
+      - "claude-flow"
+    shared_resources:
+      - "PLAN.md"
+      - ".ta/**"

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-cli"
-version = "0.7.5-alpha"
+version = "0.7.6-alpha"
 edition = "2021"
 description = "CLI for goals, PR review, and approvals in Trusted Autonomy"
 license = "Apache-2.0"

--- a/apps/ta-cli/src/commands/dev.rs
+++ b/apps/ta-cli/src/commands/dev.rs
@@ -1,0 +1,351 @@
+// dev.rs — Interactive developer loop (`ta dev`).
+//
+// Launches an orchestration agent that coordinates the development loop:
+// reads the plan, suggests next goals, launches implementation agents,
+// handles draft review, and manages releases — all from one persistent session.
+//
+// Unlike `ta run`, `ta dev` does NOT create a staging workspace. The agent
+// operates in the project directory with read-only access, using TA's MCP
+// tools (ta_plan, ta_goal, ta_draft, ta_context) for all actions.
+
+use std::path::Path;
+
+use ta_mcp_gateway::GatewayConfig;
+
+use super::plan;
+
+/// Minimal agent config for the dev-loop orchestrator.
+#[derive(serde::Deserialize, Clone, Debug)]
+struct DevLoopConfig {
+    command: String,
+    args_template: Vec<String>,
+    #[serde(default)]
+    env: std::collections::HashMap<String, String>,
+}
+
+/// Build the system prompt for the dev-loop agent.
+///
+/// Includes plan status, pending phases, and instructions for using MCP tools.
+fn build_dev_prompt(project_root: &Path, config: &GatewayConfig) -> String {
+    let mut prompt = String::new();
+
+    prompt.push_str(
+        "You are the TA development orchestrator. Your job is to coordinate the development loop \
+         for this project using TA's MCP tools. You do NOT write code directly — you launch \
+         implementation agents via sub-goals.\n\n",
+    );
+
+    prompt.push_str("## Your Capabilities\n\n");
+    prompt.push_str(
+        "- **Read the plan**: Use `ta_plan` with action \"read\" to see project status\n",
+    );
+    prompt.push_str(
+        "- **Start goals**: Use `ta_goal` with action \"start\" to launch implementation agents\n",
+    );
+    prompt.push_str(
+        "- **Review drafts**: Use `ta_draft` to list, view, approve, or deny agent work\n",
+    );
+    prompt.push_str("- **Search memory**: Use `ta_context` to search project memory and context\n");
+    prompt.push_str("- **Cut releases**: Use `ta_release` to run the release pipeline\n\n");
+
+    prompt.push_str("## Workflow\n\n");
+    prompt.push_str("1. Show the current plan status and next pending phase\n");
+    prompt.push_str("2. When the user says \"run that\" or names a phase, launch a sub-goal\n");
+    prompt.push_str("3. When an implementation agent finishes, review its draft\n");
+    prompt.push_str("4. Approve good work, deny and re-launch if needed\n");
+    prompt.push_str("5. Cut releases when milestones are reached\n\n");
+
+    prompt.push_str("## Natural Language Commands\n\n");
+    prompt.push_str("Respond to conversational requests like:\n");
+    prompt.push_str("- \"what's next\" → show next pending phase\n");
+    prompt.push_str("- \"status\" or \"show plan\" → display plan progress\n");
+    prompt.push_str("- \"run v0.7.6\" or \"run that\" → launch a goal for the phase\n");
+    prompt.push_str("- \"show drafts\" → list pending drafts\n");
+    prompt.push_str("- \"approve <id>\" → approve a draft\n");
+    prompt.push_str("- \"release\" → run the release pipeline\n");
+    prompt.push_str("- \"context search X\" → search project memory\n\n");
+
+    // Include current plan status.
+    let plan_section = build_plan_summary(project_root);
+    if !plan_section.is_empty() {
+        prompt.push_str("## Current Plan Status\n\n");
+        prompt.push_str(&plan_section);
+        prompt.push('\n');
+    }
+
+    // Include pending drafts summary.
+    let drafts_section = build_drafts_summary(config);
+    if !drafts_section.is_empty() {
+        prompt.push_str("## Pending Drafts\n\n");
+        prompt.push_str(&drafts_section);
+        prompt.push('\n');
+    }
+
+    prompt
+}
+
+/// Build a summary of plan progress for the dev-loop prompt.
+fn build_plan_summary(project_root: &Path) -> String {
+    let phases = match plan::load_plan(project_root) {
+        Ok(p) => p,
+        Err(_) => return "No PLAN.md found.\n".to_string(),
+    };
+
+    if phases.is_empty() {
+        return "Plan is empty.\n".to_string();
+    }
+
+    let total = phases.len();
+    let done = phases
+        .iter()
+        .filter(|p| p.status == plan::PlanStatus::Done)
+        .count();
+    let pending: Vec<_> = phases
+        .iter()
+        .filter(|p| p.status != plan::PlanStatus::Done)
+        .collect();
+
+    let mut summary = format!("Progress: {}/{} phases complete.\n\n", done, total);
+
+    // Show the checklist.
+    let checklist = plan::format_plan_checklist(&phases, None);
+    summary.push_str(&checklist);
+    summary.push('\n');
+
+    // Highlight next pending phase.
+    if let Some(next) = pending.first() {
+        summary.push_str(&format!(
+            "\nNext pending: **{} — {}**\n",
+            next.id, next.title
+        ));
+    }
+
+    summary
+}
+
+/// Build a summary of pending drafts for the dev-loop prompt.
+fn build_drafts_summary(config: &GatewayConfig) -> String {
+    use ta_changeset::draft_package::{DraftPackage, DraftStatus};
+
+    let dir = &config.pr_packages_dir;
+    if !dir.exists() {
+        return String::new();
+    }
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return String::new(),
+    };
+
+    let mut pending = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "json") {
+            if let Ok(json) = std::fs::read_to_string(&path) {
+                if let Ok(pkg) = serde_json::from_str::<DraftPackage>(&json) {
+                    if matches!(pkg.status, DraftStatus::PendingReview) {
+                        pending.push(pkg);
+                    }
+                }
+            }
+        }
+    }
+
+    if pending.is_empty() {
+        return "No pending drafts.\n".to_string();
+    }
+
+    let mut summary = format!("{} draft(s) pending review:\n", pending.len());
+    for draft in &pending {
+        summary.push_str(&format!(
+            "- {} — {} ({})\n",
+            &draft.package_id.to_string()[..8],
+            draft.summary.what_changed,
+            draft.status
+        ));
+    }
+
+    summary
+}
+
+/// Load agent config for the dev-loop agent from YAML or fall back to defaults.
+fn load_dev_config(project_root: &Path) -> DevLoopConfig {
+    let filename = "dev-loop.yaml";
+
+    // 1. Project override: .ta/agents/dev-loop.yaml
+    let project_path = project_root.join(".ta").join("agents").join(filename);
+    if let Some(config) = try_load_config(&project_path) {
+        return config;
+    }
+
+    // 2. User override: ~/.config/ta/agents/dev-loop.yaml
+    if let Some(home) = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE")) {
+        let user_path = std::path::PathBuf::from(home)
+            .join(".config")
+            .join("ta")
+            .join("agents")
+            .join(filename);
+        if let Some(config) = try_load_config(&user_path) {
+            return config;
+        }
+    }
+
+    // 3. Shipped defaults: <binary-dir>/agents/dev-loop.yaml
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(bin_dir) = exe.parent() {
+            let shipped_path = bin_dir.join("agents").join(filename);
+            if let Some(config) = try_load_config(&shipped_path) {
+                return config;
+            }
+        }
+    }
+
+    // 4. Hard-coded fallback.
+    DevLoopConfig {
+        command: "claude".to_string(),
+        args_template: vec![
+            "--allowedTools".to_string(),
+            "mcp__ta__ta_plan,mcp__ta__ta_goal,mcp__ta__ta_draft,mcp__ta__ta_context,mcp__ta__ta_release,Read,Grep,Glob,WebFetch,WebSearch".to_string(),
+            "-p".to_string(),
+            "{prompt}".to_string(),
+        ],
+        env: Default::default(),
+    }
+}
+
+fn try_load_config(path: &Path) -> Option<DevLoopConfig> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_yaml::from_str(&content).ok()
+}
+
+pub fn execute(
+    config: &GatewayConfig,
+    project_root: &Path,
+    agent: Option<&str>,
+) -> anyhow::Result<()> {
+    let project_root = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+
+    println!("Starting interactive developer loop...");
+    println!("  Project: {}", project_root.display());
+
+    // Build the orchestration prompt with plan status.
+    let prompt = build_dev_prompt(&project_root, config);
+
+    // Load agent config (dev-loop.yaml or fallback).
+    let agent_config = if let Some(agent_id) = agent {
+        DevLoopConfig {
+            command: agent_id.to_string(),
+            args_template: vec!["-p".to_string(), "{prompt}".to_string()],
+            env: Default::default(),
+        }
+    } else {
+        load_dev_config(&project_root)
+    };
+
+    println!("  Agent: {}", agent_config.command);
+    println!("  Mode: orchestration (no staging overlay)");
+    println!();
+
+    // Launch the agent in the project directory (not a staging workspace).
+    let args: Vec<String> = agent_config
+        .args_template
+        .iter()
+        .map(|t| t.replace("{prompt}", &prompt))
+        .collect();
+
+    let mut cmd = std::process::Command::new(&agent_config.command);
+    cmd.current_dir(&project_root);
+    cmd.args(&args);
+
+    for (key, value) in &agent_config.env {
+        cmd.env(key, value);
+    }
+
+    match cmd.status() {
+        Ok(exit) => {
+            if exit.success() {
+                println!("\nDev session ended.");
+            } else {
+                println!("\nDev session ended with status {}.", exit);
+            }
+        }
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                eprintln!(
+                    "\n'{}' command not found. Install it or specify --agent.",
+                    agent_config.command
+                );
+                eprintln!("  Example: ta dev --agent codex");
+                return Ok(());
+            }
+            return Err(anyhow::anyhow!(
+                "Failed to launch {}: {}",
+                agent_config.command,
+                e
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_dev_prompt_includes_capabilities() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = GatewayConfig::for_project(dir.path());
+        let prompt = build_dev_prompt(dir.path(), &config);
+        assert!(prompt.contains("Your Capabilities"));
+        assert!(prompt.contains("ta_plan"));
+        assert!(prompt.contains("ta_goal"));
+        assert!(prompt.contains("ta_draft"));
+    }
+
+    #[test]
+    fn test_build_dev_prompt_no_plan() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = GatewayConfig::for_project(dir.path());
+        let prompt = build_dev_prompt(dir.path(), &config);
+        assert!(prompt.contains("No PLAN.md found"));
+    }
+
+    #[test]
+    fn test_build_plan_summary_with_plan() {
+        let dir = tempfile::tempdir().unwrap();
+        let plan_content = "\
+# Plan\n\
+\n\
+### v0.1 — First Phase\n\
+<!-- status: done -->\n\
+\n\
+### v0.2 — Second Phase\n\
+<!-- status: pending -->\n\
+";
+        std::fs::write(dir.path().join("PLAN.md"), plan_content).unwrap();
+        let summary = build_plan_summary(dir.path());
+        assert!(summary.contains("1/2 phases complete"));
+        assert!(summary.contains("Next pending"));
+    }
+
+    #[test]
+    fn test_build_drafts_summary_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = GatewayConfig::for_project(dir.path());
+        let summary = build_drafts_summary(&config);
+        // Either empty or "No pending drafts" — both acceptable.
+        assert!(summary.is_empty() || summary.contains("No pending"));
+    }
+
+    #[test]
+    fn test_load_dev_config_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = load_dev_config(dir.path());
+        assert_eq!(config.command, "claude");
+        assert!(config.args_template.contains(&"-p".to_string()));
+    }
+}

--- a/apps/ta-cli/src/commands/mod.rs
+++ b/apps/ta-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod adapter;
 pub mod audit;
 pub mod context;
 pub mod credentials;
+pub mod dev;
 pub mod draft;
 pub mod goal;
 pub mod init;

--- a/apps/ta-cli/src/main.rs
+++ b/apps/ta-cli/src/main.rs
@@ -117,6 +117,13 @@ enum Commands {
         #[command(subcommand)]
         command: commands::credentials::CredentialsCommands,
     },
+    /// Interactive developer loop — orchestrate plan execution, goal launches,
+    /// draft review, and releases from one persistent session.
+    Dev {
+        /// Agent system to use for orchestration (defaults to dev-loop config).
+        #[arg(long)]
+        agent: Option<String>,
+    },
     /// Interactive setup wizard for TA configuration.
     Setup {
         #[command(subcommand)]
@@ -227,6 +234,7 @@ fn main() -> anyhow::Result<()> {
             *macro_goal,
             resume.as_deref(),
         ),
+        Commands::Dev { agent } => commands::dev::execute(&config, &project_root, agent.as_deref()),
         Commands::Session { command } => commands::session::execute(command, &config),
         Commands::Plan { command } => commands::plan::execute(command, &config),
         Commands::Context { command } => commands::context::execute(command, &config),

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -371,6 +371,33 @@ ta run "Build the v0.7 features" --source . --macro --interactive --phase v0.7.0
 
 You see the agent working in real-time, can inject guidance, and review each logical unit of change as it's submitted. This is the recommended mode for implementing plan phases.
 
+### Interactive Developer Loop (`ta dev`)
+
+`ta dev` launches an orchestration agent that coordinates the entire development loop from a single persistent session. Unlike `ta run`, the dev agent does NOT write code — it reads the plan, suggests goals, launches implementation agents, reviews drafts, and manages releases.
+
+```bash
+# Start the dev loop (uses built-in dev-loop agent config)
+ta dev
+
+# Use a custom agent for orchestration
+ta dev --agent codex
+```
+
+The dev agent automatically:
+- Reads PLAN.md and shows progress on startup
+- Highlights the next pending phase
+- Lists any pending drafts awaiting review
+
+You interact with it using natural language:
+- "what's next" — show next pending phase
+- "run v0.7.6" — launch a sub-goal for that phase
+- "show drafts" — list drafts pending review
+- "approve abc123" — approve a draft
+- "release" — run the release pipeline
+- "context search X" — search project memory
+
+The dev-loop agent config lives at `agents/dev-loop.yaml` and can be overridden per-project (`.ta/agents/dev-loop.yaml`) or per-user (`~/.config/ta/agents/dev-loop.yaml`).
+
 ### Plan-Linked Goals
 
 Link goals to `PLAN.md` phases for automatic tracking:


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.7.6 — Interactive Developer Loop (ta dev)

**Why**: A simple entry point for session based interactive development

**Impact**: 7 file(s) changed

## Changes (7 file(s))

- `~` `fs://workspace/PLAN.md` — Added Completed section to v0.7.6 phase listing all 5 implemented items with checkmarks: CLI command, agent config, plan-aware prompt, config loading, tests.
  - Plan progress tracking must reflect what was actually implemented.
- `+` `fs://workspace/agents/dev-loop.yaml` — Orchestration agent config with claude command, --allowedTools restricting to MCP tools + read-only file tools, alignment profile forbidding fs_write_patch and fs_apply, coordination with claude-code/codex/claude-flow collaborators.
  - The dev-loop agent needs a reusable config that any channel (CLI, Slack, web) can consume. The alignment profile enforces that the orchestrator only reads — implementation happens in sub-goals.
- `~` `fs://workspace/apps/ta-cli/Cargo.toml` — Bumped version from 0.7.5-alpha to 0.7.6-alpha.
  - Version bump for v0.7.6 release.
- `+` `fs://workspace/apps/ta-cli/src/commands/dev.rs` — New `ta dev` command module: builds an orchestration prompt with plan summary, pending phase highlights, and drafts summary; loads dev-loop agent config from YAML (project → user → shipped → fallback); launches the agent in the project directory without staging; 5 tests covering prompt generation, plan summary, drafts summary, and config fallback.
  - v0.7.6 requires an interactive developer loop where an LLM agent orchestrates plan execution using TA's MCP tools without writing code directly.
- `~` `fs://workspace/apps/ta-cli/src/commands/mod.rs` — Added `pub mod dev;` declaration to register the new dev command module.
  - New module must be declared in the commands module for the compiler to find it.
- `~` `fs://workspace/apps/ta-cli/src/main.rs` — Added `Dev` variant to Commands enum with optional `--agent` flag. Added match arm dispatching to `commands::dev::execute()`.
  - Wire the `ta dev` subcommand into the CLI dispatch.
- `~` `fs://workspace/docs/USAGE.md` — Added 'Interactive Developer Loop (`ta dev`)' section with usage examples, natural language commands, agent config override locations, and explanation of orchestration-only mode.
  - User-facing documentation must cover the new `ta dev` command and workflow.

## Goal Context

- **Title**: Implement v0.7.6 — Interactive Developer Loop ()
- **Objective**: Implement v0.7.6 — Interactive Developer Loop ()
- **Goal ID**: `30effa0b-3a0a-43aa-b033-a436ee95913e`
- **PR ID**: `e2d91c50-b831-42f9-96db-fa0a7dbbd12e`
- **Plan Phase**: `0.7.6`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
