### PR TITLE
Implement v0.9.7 — Daemon API Expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2412,20 +2434,26 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.7.5-alpha"
+version = "0.9.7-alpha"
 dependencies = [
  "anyhow",
+ "async-stream",
  "axum",
  "chrono",
  "clap",
+ "rand 0.8.5",
  "rmcp",
  "serde",
  "serde_json",
  "ta-changeset",
+ "ta-events",
+ "ta-goal",
  "ta-mcp-gateway",
  "ta-memory",
  "tempfile",
  "tokio",
+ "tokio-stream",
+ "toml",
  "tower",
  "tower-http",
  "tracing",
@@ -2711,6 +2739,18 @@ checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,5 +76,15 @@ libc = "0.2"
 axum = "0.8"
 tower-http = { version = "0.6", features = ["cors"] }
 
+# TOML config parsing — used for daemon.toml and shell.toml (v0.9.7).
+toml = "0.8"
+
+# Random number generation — used for auth token generation (v0.9.7).
+rand = "0.8"
+
+# Stream utilities — used for SSE event streams (v0.9.7).
+tokio-stream = { version = "0.1", features = ["sync"] }
+async-stream = "0.3"
+
 # Testing utilities
 tempfile = "3"

--- a/PLAN.md
+++ b/PLAN.md
@@ -2342,7 +2342,7 @@ passing the cursor from the previous response returns only *new* events. Add a t
 ---
 
 ### v0.9.7 — Daemon API Expansion
-<!-- status: pending -->
+<!-- status: done -->
 **Goal**: Promote the TA daemon from a draft-review web UI to a full API server that any interface (terminal, web, Discord, Slack, email) can connect to for commands, agent conversations, and event streams.
 
 #### Architecture
@@ -2542,6 +2542,28 @@ passing the cursor from the previous response returns only *new* events. Add a t
    - `POST /api/input` — unified endpoint: daemon checks routing table, dispatches to `/api/cmd` or `/api/agent/ask` accordingly. Clients don't need to know the routing rules — they just send the raw input.
 
 9. **Unix socket for local clients**: In addition to HTTP, the daemon listens on `.ta/daemon.sock` (Unix domain socket). Local clients (`ta shell`, web UI) connect here for zero-config, zero-auth, low-latency access. Remote clients use HTTP with bearer token auth.
+
+#### Completed
+- [x] Command execution API (`POST /api/cmd`) with allowlist validation, write scope enforcement, configurable timeout
+- [x] Agent session API (`/api/agent/start`, `/api/agent/ask`, `/api/agent/sessions`, `DELETE /api/agent/:id`) with session lifecycle management and max session limits
+- [x] SSE event stream API (`GET /api/events`) with cursor-based replay (`?since=`) and event type filtering (`?types=`)
+- [x] Project status API (`GET /api/status`) with JSON dashboard (project, version, phase, agents, drafts, events)
+- [x] Bearer token authentication middleware with scopes (read/write/admin), local bypass for 127.0.0.1
+- [x] Token store (`TokenStore`) with create/validate/revoke persisted in `.ta/daemon-tokens.json`
+- [x] Daemon configuration (`.ta/daemon.toml`) with server, auth, commands, agent, routing sections
+- [x] Configurable input routing (`.ta/shell.toml`) with prefix-based routes and shortcut expansion
+- [x] Unified input endpoint (`POST /api/input`) dispatching to cmd or agent via routing table
+- [x] Route listing endpoint (`GET /api/routes`) for tab completion
+- [x] Combined router merging new API routes with existing draft/memory web UI routes
+- [x] API-only mode (`--api` flag) and co-hosted MCP+API mode
+- [x] Default template files (`templates/daemon.toml`, `templates/shell.toml`)
+- [x] Version bumps: ta-daemon 0.9.7-alpha, ta-cli 0.9.7-alpha
+- [x] 35 tests: config roundtrip, token CRUD, session lifecycle/limits, input routing, glob matching, status parsing, auth scopes
+
+#### Remaining (deferred)
+- Unix domain socket listener (`.ta/daemon.sock`) — deferred until `ta shell` (v0.9.8) needs it
+- Full headless agent subprocess wiring in `/api/agent/ask` — deferred until `ta shell` provides client-side rendering
+- Bridge template updates (`discord-bridge-api.js`, `slack-bridge-api.js`) — deferred to channel phases (v0.10.x)
 
 #### Version: `0.9.7-alpha`
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ta-cli"
-version = "0.9.6-alpha"
+version = "0.9.7-alpha"
 edition = "2021"
 description = "CLI for goals, PR review, and approvals in Trusted Autonomy"
 license = "Apache-2.0"

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ta-daemon"
-version = "0.7.5-alpha"
+version = "0.9.7-alpha"
 edition = "2021"
-description = "MCP server daemon for Trusted Autonomy"
+description = "MCP server daemon and HTTP API for Trusted Autonomy"
 license = "Apache-2.0"
 
 [dependencies]
@@ -10,6 +10,7 @@ clap = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
 rmcp = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
@@ -18,11 +19,16 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }
+toml = { workspace = true }
+rand = { workspace = true }
+async-stream = { workspace = true }
 
 # Internal crates
 ta-mcp-gateway = { path = "../ta-mcp-gateway" }
 ta-changeset = { path = "../ta-changeset" }
 ta-memory = { path = "../ta-memory" }
+ta-events = { path = "../ta-events" }
+ta-goal = { path = "../ta-goal" }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/ta-daemon/src/api/agent.rs
+++ b/crates/ta-daemon/src/api/agent.rs
@@ -1,0 +1,301 @@
+// api/agent.rs — Agent session management API.
+//
+// Manages headless agent subprocesses that persist across requests.
+// The daemon owns the agent's lifecycle.
+//
+// Endpoints:
+//   POST   /api/agent/start     — Start a new agent session
+//   POST   /api/agent/ask       — Send a prompt to an agent session
+//   GET    /api/agent/sessions  — List active sessions
+//   DELETE /api/agent/:id       — Stop an agent session
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Extension;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use crate::api::auth::{require_write, CallerIdentity};
+use crate::api::AppState;
+
+/// An active agent session managed by the daemon.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentSession {
+    pub session_id: String,
+    pub agent: String,
+    pub status: SessionStatus,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub last_active: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    Starting,
+    Running,
+    Idle,
+    Stopped,
+}
+
+/// Manages active agent sessions.
+pub struct AgentSessionManager {
+    sessions: Mutex<HashMap<String, AgentSession>>,
+    max_sessions: usize,
+}
+
+impl AgentSessionManager {
+    pub fn new(max_sessions: usize) -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+            max_sessions,
+        }
+    }
+
+    pub async fn create_session(&self, agent: String) -> Result<AgentSession, String> {
+        let mut sessions = self.sessions.lock().await;
+
+        // Check session limit.
+        let active_count = sessions
+            .values()
+            .filter(|s| s.status != SessionStatus::Stopped)
+            .count();
+        if active_count >= self.max_sessions {
+            return Err(format!("Maximum sessions ({}) reached", self.max_sessions));
+        }
+
+        let session_id = format!("sess-{}", &Uuid::new_v4().to_string()[..8]);
+        let now = chrono::Utc::now();
+        let session = AgentSession {
+            session_id: session_id.clone(),
+            agent,
+            status: SessionStatus::Running,
+            created_at: now,
+            last_active: now,
+        };
+
+        sessions.insert(session_id, session.clone());
+        Ok(session)
+    }
+
+    pub async fn get_session(&self, session_id: &str) -> Option<AgentSession> {
+        self.sessions.lock().await.get(session_id).cloned()
+    }
+
+    pub async fn list_sessions(&self) -> Vec<AgentSession> {
+        self.sessions.lock().await.values().cloned().collect()
+    }
+
+    pub async fn stop_session(&self, session_id: &str) -> bool {
+        let mut sessions = self.sessions.lock().await;
+        if let Some(session) = sessions.get_mut(session_id) {
+            session.status = SessionStatus::Stopped;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub async fn touch_session(&self, session_id: &str) {
+        let mut sessions = self.sessions.lock().await;
+        if let Some(session) = sessions.get_mut(session_id) {
+            session.last_active = chrono::Utc::now();
+        }
+    }
+}
+
+// ── Request/response types ──────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct StartSessionRequest {
+    pub agent: Option<String>,
+    pub context: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StartSessionResponse {
+    pub session_id: String,
+    pub status: String,
+    pub agent: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct AskRequest {
+    pub session_id: String,
+    pub prompt: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AskResponse {
+    pub session_id: String,
+    pub response: String,
+}
+
+// ── Handlers ────────────────────────────────────────────────────
+
+/// `POST /api/agent/start` — Start a new agent session.
+pub async fn start_session(
+    State(state): State<Arc<AppState>>,
+    Extension(identity): Extension<CallerIdentity>,
+    Json(body): Json<StartSessionRequest>,
+) -> impl IntoResponse {
+    if let Err(e) = require_write(&identity) {
+        return e.into_response();
+    }
+
+    let agent = body
+        .agent
+        .unwrap_or_else(|| state.daemon_config.agent.default_agent.clone());
+
+    match state.agent_sessions.create_session(agent.clone()).await {
+        Ok(session) => (
+            StatusCode::CREATED,
+            Json(StartSessionResponse {
+                session_id: session.session_id,
+                status: "running".to_string(),
+                agent,
+            }),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(serde_json::json!({"error": e})),
+        )
+            .into_response(),
+    }
+}
+
+/// `POST /api/agent/ask` — Send a prompt to an agent session.
+///
+/// In this initial implementation, the daemon acknowledges the prompt.
+/// Full agent subprocess integration (launching headless claude-code, streaming
+/// responses via SSE) is deferred to a follow-up when `ta shell` provides the
+/// client-side rendering.
+pub async fn ask_agent(
+    State(state): State<Arc<AppState>>,
+    Extension(identity): Extension<CallerIdentity>,
+    Json(body): Json<AskRequest>,
+) -> impl IntoResponse {
+    if let Err(e) = require_write(&identity) {
+        return e.into_response();
+    }
+
+    let session = state.agent_sessions.get_session(&body.session_id).await;
+    match session {
+        Some(s) if s.status == SessionStatus::Running => {
+            state.agent_sessions.touch_session(&body.session_id).await;
+            // Placeholder: echo the prompt. Full agent subprocess wiring is
+            // implemented when `ta shell` (v0.9.8) provides the client side.
+            Json(AskResponse {
+                session_id: body.session_id,
+                response: format!(
+                    "[Agent session {} ({})]: Received prompt. \
+                     Full agent subprocess integration is available via `ta shell`.",
+                    s.session_id, s.agent
+                ),
+            })
+            .into_response()
+        }
+        Some(_) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "session is not running"})),
+        )
+            .into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "session not found"})),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /api/agent/sessions` — List active agent sessions.
+pub async fn list_sessions(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let sessions = state.agent_sessions.list_sessions().await;
+    Json(sessions)
+}
+
+/// `DELETE /api/agent/:id` — Stop an agent session.
+pub async fn stop_session(
+    State(state): State<Arc<AppState>>,
+    Extension(identity): Extension<CallerIdentity>,
+    Path(session_id): Path<String>,
+) -> impl IntoResponse {
+    if let Err(e) = require_write(&identity) {
+        return e.into_response();
+    }
+
+    if state.agent_sessions.stop_session(&session_id).await {
+        Json(serde_json::json!({"session_id": session_id, "status": "stopped"})).into_response()
+    } else {
+        (StatusCode::NOT_FOUND, "session not found").into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn session_lifecycle() {
+        let mgr = AgentSessionManager::new(3);
+
+        // Create a session.
+        let s = mgr.create_session("claude-code".into()).await.unwrap();
+        assert!(s.session_id.starts_with("sess-"));
+        assert_eq!(s.status, SessionStatus::Running);
+
+        // List sessions.
+        let sessions = mgr.list_sessions().await;
+        assert_eq!(sessions.len(), 1);
+
+        // Get session.
+        let found = mgr.get_session(&s.session_id).await;
+        assert!(found.is_some());
+
+        // Touch session.
+        mgr.touch_session(&s.session_id).await;
+
+        // Stop session.
+        assert!(mgr.stop_session(&s.session_id).await);
+        let stopped = mgr.get_session(&s.session_id).await.unwrap();
+        assert_eq!(stopped.status, SessionStatus::Stopped);
+
+        // Stop unknown session.
+        assert!(!mgr.stop_session("nonexistent").await);
+    }
+
+    #[tokio::test]
+    async fn session_limit_enforced() {
+        let mgr = AgentSessionManager::new(2);
+
+        mgr.create_session("a1".into()).await.unwrap();
+        mgr.create_session("a2".into()).await.unwrap();
+
+        // Third should fail.
+        let result = mgr.create_session("a3".into()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn stopped_sessions_dont_count_toward_limit() {
+        let mgr = AgentSessionManager::new(2);
+
+        let s1 = mgr.create_session("a1".into()).await.unwrap();
+        mgr.create_session("a2".into()).await.unwrap();
+
+        // Stop one.
+        mgr.stop_session(&s1.session_id).await;
+
+        // Now we should be able to create another.
+        let result = mgr.create_session("a3".into()).await;
+        assert!(result.is_ok());
+    }
+}

--- a/crates/ta-daemon/src/api/auth.rs
+++ b/crates/ta-daemon/src/api/auth.rs
@@ -1,0 +1,132 @@
+// api/auth.rs — Bearer token authentication middleware.
+
+use std::sync::Arc;
+
+use axum::extract::{ConnectInfo, Request, State};
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+use crate::api::AppState;
+use crate::config::TokenScope;
+
+/// Authenticated caller identity attached to request extensions.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct CallerIdentity {
+    pub scope: TokenScope,
+    pub label: Option<String>,
+    pub is_local: bool,
+}
+
+/// Authentication middleware: checks Bearer token or local bypass.
+pub async fn auth_middleware(
+    State(state): State<Arc<AppState>>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let config = &state.daemon_config.auth;
+
+    // Check if connection is local (127.0.0.1).
+    let is_local = request
+        .extensions()
+        .get::<ConnectInfo<std::net::SocketAddr>>()
+        .map(|ci| ci.0.ip().is_loopback())
+        .unwrap_or(true); // Default to local if no connect info (e.g., tests).
+
+    // Local bypass: skip auth for loopback connections.
+    if is_local && config.local_bypass {
+        request.extensions_mut().insert(CallerIdentity {
+            scope: TokenScope::Admin,
+            label: Some("local".to_string()),
+            is_local: true,
+        });
+        return next.run(request).await;
+    }
+
+    // If auth is not required, grant read access.
+    if !config.require_token {
+        request.extensions_mut().insert(CallerIdentity {
+            scope: TokenScope::Admin,
+            label: None,
+            is_local,
+        });
+        return next.run(request).await;
+    }
+
+    // Extract Bearer token from Authorization header.
+    let auth_header = request
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok());
+
+    let token = match auth_header {
+        Some(h) if h.starts_with("Bearer ") => &h[7..],
+        _ => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                [("WWW-Authenticate", "Bearer")],
+                "Missing or invalid Authorization header",
+            )
+                .into_response();
+        }
+    };
+
+    // Validate token.
+    match state.token_store.validate(token) {
+        Some(record) => {
+            request.extensions_mut().insert(CallerIdentity {
+                scope: record.scope,
+                label: record.label,
+                is_local,
+            });
+            next.run(request).await
+        }
+        None => (StatusCode::UNAUTHORIZED, "Invalid token").into_response(),
+    }
+}
+
+/// Helper to require write scope on a handler.
+pub fn require_write(identity: &CallerIdentity) -> Result<(), (StatusCode, &'static str)> {
+    if identity.scope.allows_write() {
+        Ok(())
+    } else {
+        Err((StatusCode::FORBIDDEN, "Write scope required"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn caller_identity_local_admin() {
+        let id = CallerIdentity {
+            scope: TokenScope::Admin,
+            label: Some("local".into()),
+            is_local: true,
+        };
+        assert!(id.scope.allows_write());
+        assert!(id.scope.allows_admin());
+    }
+
+    #[test]
+    fn require_write_read_scope_fails() {
+        let id = CallerIdentity {
+            scope: TokenScope::Read,
+            label: None,
+            is_local: false,
+        };
+        assert!(require_write(&id).is_err());
+    }
+
+    #[test]
+    fn require_write_write_scope_ok() {
+        let id = CallerIdentity {
+            scope: TokenScope::Write,
+            label: None,
+            is_local: false,
+        };
+        assert!(require_write(&id).is_ok());
+    }
+}

--- a/crates/ta-daemon/src/api/cmd.rs
+++ b/crates/ta-daemon/src/api/cmd.rs
@@ -1,0 +1,202 @@
+// api/cmd.rs — Command execution endpoint (`POST /api/cmd`).
+//
+// Executes `ta` CLI commands by forking the `ta` binary and capturing output.
+// Commands are validated against the allowlist in daemon.toml.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Extension;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::api::auth::{require_write, CallerIdentity};
+use crate::api::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct CmdRequest {
+    pub command: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CmdResponse {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// `POST /api/cmd` — Execute a `ta` CLI command.
+pub async fn execute_command(
+    State(state): State<Arc<AppState>>,
+    Extension(identity): Extension<CallerIdentity>,
+    Json(body): Json<CmdRequest>,
+) -> impl IntoResponse {
+    let command_str = body.command.trim();
+    if command_str.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "command is required"})),
+        )
+            .into_response();
+    }
+
+    // Check if command is allowed.
+    if !is_command_allowed(command_str, &state.daemon_config.commands.allowed) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "command not in allowlist"})),
+        )
+            .into_response();
+    }
+
+    // Check write scope for write commands.
+    if is_write_command(command_str, &state.daemon_config.commands.write_commands) {
+        if let Err(e) = require_write(&identity) {
+            return e.into_response();
+        }
+    }
+
+    // Parse the command into args. Strip leading "ta " if present.
+    let args_str = command_str.strip_prefix("ta ").unwrap_or(command_str);
+
+    let args: Vec<&str> = args_str.split_whitespace().collect();
+    if args.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "empty command after parsing"})),
+        )
+            .into_response();
+    }
+
+    // Find the `ta` binary. Prefer the one adjacent to the current binary.
+    let ta_binary = find_ta_binary();
+
+    let timeout = std::time::Duration::from_secs(state.daemon_config.commands.timeout_secs);
+
+    match run_command(&ta_binary, &args, &state.project_root, timeout).await {
+        Ok(response) => Json(response).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": e})),
+        )
+            .into_response(),
+    }
+}
+
+async fn run_command(
+    binary: &str,
+    args: &[&str],
+    working_dir: &std::path::Path,
+    timeout: std::time::Duration,
+) -> Result<CmdResponse, String> {
+    let result = tokio::time::timeout(timeout, async {
+        tokio::process::Command::new(binary)
+            .args(args)
+            .arg("--project-root")
+            .arg(working_dir)
+            .current_dir(working_dir)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output()
+            .await
+    })
+    .await;
+
+    match result {
+        Ok(Ok(output)) => Ok(CmdResponse {
+            exit_code: output.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        }),
+        Ok(Err(e)) => Err(format!("Failed to execute command: {}", e)),
+        Err(_) => Err("Command timed out".to_string()),
+    }
+}
+
+fn find_ta_binary() -> String {
+    // Try adjacent to current binary first.
+    if let Ok(current) = std::env::current_exe() {
+        if let Some(dir) = current.parent() {
+            let ta_path = dir.join("ta");
+            if ta_path.exists() {
+                return ta_path.to_string_lossy().to_string();
+            }
+        }
+    }
+    // Fall back to PATH.
+    "ta".to_string()
+}
+
+/// Check if a command matches the allowlist using simple glob patterns.
+fn is_command_allowed(command: &str, allowlist: &[String]) -> bool {
+    if allowlist.is_empty() {
+        return true; // No allowlist = allow everything.
+    }
+    allowlist.iter().any(|pattern| glob_match(pattern, command))
+}
+
+/// Check if a command is classified as a write command.
+fn is_write_command(command: &str, write_patterns: &[String]) -> bool {
+    write_patterns
+        .iter()
+        .any(|pattern| glob_match(pattern, command))
+}
+
+/// Simple glob matching: `*` matches any sequence of characters.
+fn glob_match(pattern: &str, input: &str) -> bool {
+    if let Some(prefix) = pattern.strip_suffix(" *") {
+        input.starts_with(prefix)
+    } else if pattern == "*" {
+        true
+    } else {
+        pattern == input
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_match_exact() {
+        assert!(glob_match("ta status", "ta status"));
+        assert!(!glob_match("ta status", "ta plan list"));
+    }
+
+    #[test]
+    fn glob_match_wildcard_suffix() {
+        assert!(glob_match("ta draft *", "ta draft list"));
+        assert!(glob_match("ta draft *", "ta draft approve abc123"));
+        assert!(!glob_match("ta draft *", "ta goal list"));
+    }
+
+    #[test]
+    fn glob_match_star_matches_all() {
+        assert!(glob_match("*", "anything"));
+    }
+
+    #[test]
+    fn command_allowlist() {
+        let allow = vec!["ta draft *".to_string(), "ta status".to_string()];
+        assert!(is_command_allowed("ta draft list", &allow));
+        assert!(is_command_allowed("ta status", &allow));
+        assert!(!is_command_allowed("ta goal start foo", &allow));
+    }
+
+    #[test]
+    fn empty_allowlist_allows_all() {
+        assert!(is_command_allowed("anything", &[]));
+    }
+
+    #[test]
+    fn write_command_detection() {
+        let write = vec![
+            "ta draft approve *".to_string(),
+            "ta draft deny *".to_string(),
+        ];
+        assert!(is_write_command("ta draft approve abc", &write));
+        assert!(!is_write_command("ta draft list", &write));
+    }
+}

--- a/crates/ta-daemon/src/api/events.rs
+++ b/crates/ta-daemon/src/api/events.rs
@@ -1,0 +1,84 @@
+// api/events.rs — Server-Sent Events (SSE) stream for real-time TA events.
+//
+// Subscribes to the FsEventStore and streams events to connected clients.
+// Supports `?since=<ISO8601>` for replay from a cursor.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::{Query, State};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::IntoResponse;
+use serde::Deserialize;
+
+use ta_events::store::{EventQueryFilter, EventStore, FsEventStore};
+
+use crate::api::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct EventStreamQuery {
+    /// ISO 8601 timestamp — replay events after this cursor.
+    pub since: Option<String>,
+    /// Filter by event types (comma-separated).
+    pub types: Option<String>,
+}
+
+/// `GET /api/events` — SSE event stream.
+pub async fn event_stream(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<EventStreamQuery>,
+) -> impl IntoResponse {
+    let events_dir = state.events_dir.clone();
+
+    // Parse the initial cursor.
+    let initial_cursor = params
+        .since
+        .as_deref()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&chrono::Utc));
+
+    let type_filter: Vec<String> = params
+        .types
+        .map(|t| t.split(',').map(|s| s.trim().to_string()).collect())
+        .unwrap_or_default();
+
+    // Use an async_stream to poll for new events.
+    let stream = async_stream::stream! {
+        let mut cursor = initial_cursor;
+
+        loop {
+            let store = FsEventStore::new(&events_dir);
+            let filter = EventQueryFilter {
+                since: cursor,
+                event_types: type_filter.clone(),
+                limit: Some(50),
+                ..Default::default()
+            };
+
+            match store.query(&filter) {
+                Ok(envelopes) => {
+                    for envelope in envelopes {
+                        cursor = Some(envelope.timestamp);
+                        let data = serde_json::to_string(&envelope)
+                            .unwrap_or_else(|_| "{}".to_string());
+
+                        yield Ok::<_, Infallible>(
+                            Event::default()
+                                .event(envelope.event_type.clone())
+                                .id(envelope.id.to_string())
+                                .data(data)
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("Event store query error: {}", e);
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    };
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}

--- a/crates/ta-daemon/src/api/input.rs
+++ b/crates/ta-daemon/src/api/input.rs
@@ -1,0 +1,231 @@
+// api/input.rs — Unified `/api/input` endpoint with routing dispatch.
+//
+// Clients send raw text; the daemon checks the routing table (shell.toml)
+// and dispatches to /api/cmd or /api/agent/ask accordingly.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Extension;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::api::auth::CallerIdentity;
+use crate::api::AppState;
+use crate::config::{ShellConfig, ShortcutEntry};
+
+#[derive(Debug, Deserialize)]
+pub struct InputRequest {
+    pub text: String,
+    /// Agent session ID for agent-routed input.
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InputResponse {
+    /// How the input was routed.
+    pub routed_to: String,
+    /// The result payload.
+    pub result: serde_json::Value,
+}
+
+/// Routing decision for an input string.
+#[derive(Debug)]
+pub enum RouteDecision {
+    /// Route to command execution.
+    Command(String),
+    /// Route to agent.
+    Agent(String),
+}
+
+/// `POST /api/input` — Unified input endpoint.
+pub async fn handle_input(
+    State(state): State<Arc<AppState>>,
+    Extension(identity): Extension<CallerIdentity>,
+    Json(body): Json<InputRequest>,
+) -> impl IntoResponse {
+    let text = body.text.trim().to_string();
+    if text.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "text is required"})),
+        )
+            .into_response();
+    }
+
+    let shell_config = &state.shell_config;
+
+    match route_input(&text, shell_config) {
+        RouteDecision::Command(cmd) => {
+            // Dispatch to command execution.
+            let cmd_req = super::cmd::CmdRequest {
+                command: cmd.clone(),
+            };
+            let cmd_state = State(state.clone());
+            let cmd_identity = Extension(identity);
+
+            // Re-use the cmd handler logic inline.
+            let response =
+                super::cmd::execute_command(cmd_state, cmd_identity, Json(cmd_req)).await;
+            response.into_response()
+        }
+        RouteDecision::Agent(prompt) => {
+            // Route to agent session.
+            let session_id = body.session_id.unwrap_or_default();
+            if session_id.is_empty() {
+                return Json(InputResponse {
+                    routed_to: "agent".to_string(),
+                    result: serde_json::json!({
+                        "error": "No active agent session. Start one with POST /api/agent/start"
+                    }),
+                })
+                .into_response();
+            }
+
+            let ask_req = super::agent::AskRequest {
+                session_id: session_id.clone(),
+                prompt,
+            };
+            let response = super::agent::ask_agent(
+                State(state.clone()),
+                Extension(identity.clone()),
+                Json(ask_req),
+            )
+            .await;
+            response.into_response()
+        }
+    }
+}
+
+/// `GET /api/routes` — Return available routes and shortcuts for tab completion.
+pub async fn list_routes(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let config = &state.shell_config;
+    Json(serde_json::json!({
+        "routes": config.routes.iter().map(|r| serde_json::json!({
+            "prefix": r.prefix,
+            "command": r.command,
+        })).collect::<Vec<_>>(),
+        "shortcuts": config.shortcuts.iter().map(|s| serde_json::json!({
+            "match": s.r#match,
+            "expand": s.expand,
+        })).collect::<Vec<_>>(),
+    }))
+}
+
+/// Route input text using the shell config's routes and shortcuts.
+pub fn route_input(text: &str, config: &ShellConfig) -> RouteDecision {
+    // First, check shortcuts: if the first word matches a shortcut, expand it.
+    let expanded = expand_shortcut(text, &config.shortcuts);
+    let text = expanded.as_deref().unwrap_or(text);
+
+    // Check routes: if input matches a route prefix, it's a command.
+    for route in &config.routes {
+        if text.starts_with(&route.prefix) {
+            let cmd = if route.strip_prefix {
+                let rest = &text[route.prefix.len()..];
+                if route.args.is_empty() {
+                    format!("{} {}", route.command, rest)
+                } else {
+                    format!("{} {} {}", route.command, route.args.join(" "), rest)
+                }
+            } else {
+                format!("{} {}", route.command, text)
+            };
+            return RouteDecision::Command(cmd.trim().to_string());
+        }
+    }
+
+    // No route matched — send to agent.
+    RouteDecision::Agent(text.to_string())
+}
+
+fn expand_shortcut(text: &str, shortcuts: &[ShortcutEntry]) -> Option<String> {
+    let first_word = text.split_whitespace().next()?;
+    for shortcut in shortcuts {
+        if first_word == shortcut.r#match {
+            let rest = text[first_word.len()..].trim_start();
+            if rest.is_empty() {
+                return Some(shortcut.expand.clone());
+            } else {
+                return Some(format!("{} {}", shortcut.expand, rest));
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> ShellConfig {
+        ShellConfig::default()
+    }
+
+    #[test]
+    fn route_ta_command() {
+        let config = default_config();
+        match route_input("ta draft list", &config) {
+            RouteDecision::Command(cmd) => assert_eq!(cmd, "ta draft list"),
+            _ => panic!("expected Command"),
+        }
+    }
+
+    #[test]
+    fn route_git_command() {
+        let config = default_config();
+        match route_input("git status", &config) {
+            RouteDecision::Command(cmd) => assert_eq!(cmd, "git status"),
+            _ => panic!("expected Command"),
+        }
+    }
+
+    #[test]
+    fn route_shell_escape() {
+        let config = default_config();
+        match route_input("!ls -la", &config) {
+            RouteDecision::Command(cmd) => assert_eq!(cmd, "sh -c ls -la"),
+            _ => panic!("expected Command"),
+        }
+    }
+
+    #[test]
+    fn route_to_agent() {
+        let config = default_config();
+        match route_input("What should we work on next?", &config) {
+            RouteDecision::Agent(prompt) => {
+                assert_eq!(prompt, "What should we work on next?");
+            }
+            _ => panic!("expected Agent"),
+        }
+    }
+
+    #[test]
+    fn shortcut_expansion() {
+        let config = default_config();
+        match route_input("approve abc123", &config) {
+            RouteDecision::Command(cmd) => assert_eq!(cmd, "ta draft approve abc123"),
+            _ => panic!("expected Command from shortcut"),
+        }
+    }
+
+    #[test]
+    fn shortcut_no_args() {
+        let config = default_config();
+        match route_input("status", &config) {
+            RouteDecision::Command(cmd) => assert_eq!(cmd, "ta status"),
+            _ => panic!("expected Command from shortcut"),
+        }
+    }
+
+    #[test]
+    fn shortcut_drafts() {
+        let config = default_config();
+        match route_input("drafts", &config) {
+            RouteDecision::Command(cmd) => assert_eq!(cmd, "ta draft list"),
+            _ => panic!("expected Command from shortcut"),
+        }
+    }
+}

--- a/crates/ta-daemon/src/api/mod.rs
+++ b/crates/ta-daemon/src/api/mod.rs
@@ -1,0 +1,82 @@
+// api/mod.rs — Daemon HTTP API module organization (v0.9.7).
+//
+// Provides the full API surface for any interface to connect:
+//   /api/cmd      — command execution
+//   /api/agent    — agent session management
+//   /api/events   — SSE event stream
+//   /api/status   — project dashboard
+//   /api/input    — unified input with routing
+//   /api/routes   — routing table for tab completion
+//   /api/drafts   — draft review (existing, from web.rs)
+//   /api/memory   — memory store (existing, from web.rs)
+
+pub mod agent;
+pub mod auth;
+pub mod cmd;
+pub mod events;
+pub mod input;
+pub mod status;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::middleware;
+use axum::routing::{delete, get, post};
+use axum::Router;
+
+use crate::config::{DaemonConfig, ShellConfig, TokenStore};
+
+/// Shared application state for all API handlers.
+pub struct AppState {
+    pub project_root: PathBuf,
+    pub pr_packages_dir: PathBuf,
+    pub memory_dir: PathBuf,
+    pub events_dir: PathBuf,
+    pub goals_dir: PathBuf,
+    pub daemon_config: DaemonConfig,
+    pub shell_config: ShellConfig,
+    pub token_store: TokenStore,
+    pub agent_sessions: agent::AgentSessionManager,
+}
+
+impl AppState {
+    pub fn new(project_root: PathBuf, daemon_config: DaemonConfig) -> Self {
+        let ta_dir = project_root.join(".ta");
+        let shell_config = ShellConfig::load(&project_root);
+        let max_sessions = daemon_config.agent.max_sessions;
+
+        Self {
+            pr_packages_dir: ta_dir.join("pr_packages"),
+            memory_dir: ta_dir.join("memory"),
+            events_dir: ta_dir.join("events"),
+            goals_dir: ta_dir.join("goals"),
+            token_store: TokenStore::new(&project_root),
+            shell_config,
+            agent_sessions: agent::AgentSessionManager::new(max_sessions),
+            project_root,
+            daemon_config,
+        }
+    }
+}
+
+/// Build the full API router with auth middleware.
+pub fn build_api_router(state: Arc<AppState>) -> Router {
+    Router::new()
+        // New v0.9.7 API routes.
+        .route("/api/cmd", post(cmd::execute_command))
+        .route("/api/status", get(status::project_status))
+        .route("/api/events", get(events::event_stream))
+        .route("/api/input", post(input::handle_input))
+        .route("/api/routes", get(input::list_routes))
+        // Agent session routes.
+        .route("/api/agent/start", post(agent::start_session))
+        .route("/api/agent/ask", post(agent::ask_agent))
+        .route("/api/agent/sessions", get(agent::list_sessions))
+        .route("/api/agent/{id}", delete(agent::stop_session))
+        // Auth middleware on all API routes.
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::auth_middleware,
+        ))
+        .with_state(state)
+}

--- a/crates/ta-daemon/src/api/status.rs
+++ b/crates/ta-daemon/src/api/status.rs
@@ -1,0 +1,205 @@
+// api/status.rs — Project status endpoint (`GET /api/status`).
+//
+// Returns the same data as `ta status` but as JSON — project name, version,
+// current phase, active agents, pending drafts, and recent events.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::Serialize;
+
+use ta_events::store::{EventQueryFilter, EventStore, FsEventStore};
+use ta_goal::{GoalRunState, GoalRunStore};
+
+use crate::api::AppState;
+
+#[derive(Debug, Serialize)]
+pub struct ProjectStatus {
+    pub project: String,
+    pub version: String,
+    pub current_phase: Option<PhaseInfo>,
+    pub active_agents: Vec<AgentInfo>,
+    pub pending_drafts: usize,
+    pub active_goals: usize,
+    pub total_goals: usize,
+    pub recent_events: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PhaseInfo {
+    pub id: String,
+    pub title: String,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AgentInfo {
+    pub agent_id: String,
+    pub goal_id: String,
+    pub title: String,
+    pub state: String,
+    pub running_secs: i64,
+}
+
+/// `GET /api/status` — Project dashboard as JSON.
+pub async fn project_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let project_name = state
+        .project_root
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let version = env!("CARGO_PKG_VERSION").to_string();
+
+    // Current plan phase.
+    let current_phase = {
+        let plan_path = state.project_root.join("PLAN.md");
+        if plan_path.exists() {
+            std::fs::read_to_string(&plan_path)
+                .ok()
+                .and_then(|content| find_next_pending_phase(&content))
+        } else {
+            None
+        }
+    };
+
+    // Goals and agents.
+    let (active_agents, active_goals, total_goals) = {
+        let goal_store = GoalRunStore::new(&state.goals_dir);
+        match goal_store {
+            Ok(store) => {
+                let all = store.list().unwrap_or_default();
+                let active: Vec<AgentInfo> = all
+                    .iter()
+                    .filter(|g| {
+                        matches!(
+                            g.state,
+                            GoalRunState::Running
+                                | GoalRunState::Configured
+                                | GoalRunState::PrReady
+                        )
+                    })
+                    .map(|g| {
+                        let elapsed = chrono::Utc::now()
+                            .signed_duration_since(g.created_at)
+                            .num_seconds();
+                        AgentInfo {
+                            agent_id: g.agent_id.clone(),
+                            goal_id: g.goal_run_id.to_string(),
+                            title: g.title.clone(),
+                            state: g.state.to_string(),
+                            running_secs: elapsed,
+                        }
+                    })
+                    .collect();
+                let active_count = active.len();
+                let total = all.len();
+                (active, active_count, total)
+            }
+            Err(_) => (vec![], 0, 0),
+        }
+    };
+
+    // Pending drafts.
+    let pending_drafts = count_pending_drafts(&state.pr_packages_dir);
+
+    // Recent events (last 10).
+    let recent_events = {
+        let store = FsEventStore::new(&state.events_dir);
+        store
+            .query(&EventQueryFilter {
+                limit: Some(10),
+                ..Default::default()
+            })
+            .unwrap_or_default()
+            .into_iter()
+            .rev() // Most recent first.
+            .map(|e| serde_json::to_value(&e).unwrap_or_default())
+            .collect()
+    };
+
+    Json(ProjectStatus {
+        project: project_name,
+        version,
+        current_phase,
+        active_agents,
+        pending_drafts,
+        active_goals,
+        total_goals,
+        recent_events,
+    })
+}
+
+fn find_next_pending_phase(plan_content: &str) -> Option<PhaseInfo> {
+    let lines: Vec<&str> = plan_content.lines().collect();
+    for i in 0..lines.len().saturating_sub(1) {
+        if lines[i].starts_with("### ") && lines[i + 1].contains("<!-- status: pending -->") {
+            let raw = lines[i].trim_start_matches('#').trim();
+            // Parse "vX.Y.Z — Title" format.
+            let (id, title) = if let Some(sep_idx) = raw.find(" — ") {
+                (
+                    raw[..sep_idx].trim().to_string(),
+                    raw[sep_idx + " — ".len()..].trim().to_string(),
+                )
+            } else {
+                (raw.to_string(), raw.to_string())
+            };
+            return Some(PhaseInfo {
+                id,
+                title,
+                status: "pending".to_string(),
+            });
+        }
+    }
+    None
+}
+
+fn count_pending_drafts(pr_packages_dir: &std::path::Path) -> usize {
+    if !pr_packages_dir.exists() {
+        return 0;
+    }
+    std::fs::read_dir(pr_packages_dir)
+        .map(|entries| {
+            entries
+                .flatten()
+                .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+                .filter(|e| {
+                    std::fs::read_to_string(e.path())
+                        .map(|content| content.contains("PendingReview"))
+                        .unwrap_or(false)
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_phase_from_plan() {
+        let plan = r#"
+### v0.9.6 — Orchestrator API
+<!-- status: done -->
+
+### v0.9.7 — Daemon API Expansion
+<!-- status: pending -->
+
+### v0.9.8 — Interactive Shell
+<!-- status: pending -->
+"#;
+        let phase = find_next_pending_phase(plan).unwrap();
+        assert_eq!(phase.id, "v0.9.7");
+        assert_eq!(phase.title, "Daemon API Expansion");
+        assert_eq!(phase.status, "pending");
+    }
+
+    #[test]
+    fn no_pending_phase() {
+        let plan = "### Done\n<!-- status: done -->";
+        assert!(find_next_pending_phase(plan).is_none());
+    }
+}

--- a/crates/ta-daemon/src/config.rs
+++ b/crates/ta-daemon/src/config.rs
@@ -1,0 +1,428 @@
+// config.rs — Daemon configuration from `.ta/daemon.toml`.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Top-level daemon configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DaemonConfig {
+    pub server: ServerConfig,
+    pub auth: AuthConfig,
+    pub commands: CommandConfig,
+    pub agent: AgentConfig,
+    pub routing: RoutingConfig,
+}
+
+impl DaemonConfig {
+    /// Load config from `.ta/daemon.toml`, falling back to defaults.
+    pub fn load(project_root: &Path) -> Self {
+        let config_path = project_root.join(".ta").join("daemon.toml");
+        if config_path.exists() {
+            match std::fs::read_to_string(&config_path) {
+                Ok(content) => match toml::from_str(&content) {
+                    Ok(config) => return config,
+                    Err(e) => {
+                        tracing::warn!("Invalid daemon.toml, using defaults: {}", e);
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!("Cannot read daemon.toml, using defaults: {}", e);
+                }
+            }
+        }
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ServerConfig {
+    pub bind: String,
+    pub port: u16,
+    pub cors_origins: Vec<String>,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            bind: "127.0.0.1".to_string(),
+            port: 7700,
+            cors_origins: vec!["*".to_string()],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AuthConfig {
+    pub require_token: bool,
+    pub local_bypass: bool,
+}
+
+impl Default for AuthConfig {
+    fn default() -> Self {
+        Self {
+            require_token: false,
+            local_bypass: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CommandConfig {
+    pub allowed: Vec<String>,
+    pub write_commands: Vec<String>,
+    pub timeout_secs: u64,
+}
+
+impl Default for CommandConfig {
+    fn default() -> Self {
+        Self {
+            allowed: vec![
+                "ta draft *".to_string(),
+                "ta goal *".to_string(),
+                "ta plan *".to_string(),
+                "ta status".to_string(),
+                "ta context *".to_string(),
+            ],
+            write_commands: vec![
+                "ta draft approve *".to_string(),
+                "ta draft deny *".to_string(),
+                "ta draft apply *".to_string(),
+                "ta goal start *".to_string(),
+            ],
+            timeout_secs: 30,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AgentConfig {
+    pub max_sessions: usize,
+    pub idle_timeout_secs: u64,
+    pub default_agent: String,
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            max_sessions: 3,
+            idle_timeout_secs: 3600,
+            default_agent: "claude-code".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RoutingConfig {
+    pub use_shell_config: bool,
+}
+
+impl Default for RoutingConfig {
+    fn default() -> Self {
+        Self {
+            use_shell_config: true,
+        }
+    }
+}
+
+/// Routing configuration from `.ta/shell.toml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ShellConfig {
+    #[serde(default)]
+    pub routes: Vec<RouteEntry>,
+    #[serde(default)]
+    pub shortcuts: Vec<ShortcutEntry>,
+}
+
+impl Default for ShellConfig {
+    fn default() -> Self {
+        Self {
+            routes: vec![
+                RouteEntry {
+                    prefix: "ta ".to_string(),
+                    command: "ta".to_string(),
+                    args: vec![],
+                    strip_prefix: true,
+                },
+                RouteEntry {
+                    prefix: "git ".to_string(),
+                    command: "git".to_string(),
+                    args: vec![],
+                    strip_prefix: true,
+                },
+                RouteEntry {
+                    prefix: "!".to_string(),
+                    command: "sh".to_string(),
+                    args: vec!["-c".to_string()],
+                    strip_prefix: true,
+                },
+            ],
+            shortcuts: vec![
+                ShortcutEntry {
+                    r#match: "approve".to_string(),
+                    expand: "ta draft approve".to_string(),
+                },
+                ShortcutEntry {
+                    r#match: "deny".to_string(),
+                    expand: "ta draft deny".to_string(),
+                },
+                ShortcutEntry {
+                    r#match: "view".to_string(),
+                    expand: "ta draft view".to_string(),
+                },
+                ShortcutEntry {
+                    r#match: "apply".to_string(),
+                    expand: "ta draft apply".to_string(),
+                },
+                ShortcutEntry {
+                    r#match: "status".to_string(),
+                    expand: "ta status".to_string(),
+                },
+                ShortcutEntry {
+                    r#match: "plan".to_string(),
+                    expand: "ta plan list".to_string(),
+                },
+                ShortcutEntry {
+                    r#match: "goals".to_string(),
+                    expand: "ta goal list".to_string(),
+                },
+                ShortcutEntry {
+                    r#match: "drafts".to_string(),
+                    expand: "ta draft list".to_string(),
+                },
+            ],
+        }
+    }
+}
+
+impl ShellConfig {
+    /// Load from `.ta/shell.toml`, falling back to defaults.
+    pub fn load(project_root: &Path) -> Self {
+        let config_path = project_root.join(".ta").join("shell.toml");
+        if config_path.exists() {
+            match std::fs::read_to_string(&config_path) {
+                Ok(content) => match toml::from_str(&content) {
+                    Ok(config) => return config,
+                    Err(e) => {
+                        tracing::warn!("Invalid shell.toml, using defaults: {}", e);
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!("Cannot read shell.toml, using defaults: {}", e);
+                }
+            }
+        }
+        Self::default()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RouteEntry {
+    pub prefix: String,
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub strip_prefix: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShortcutEntry {
+    pub r#match: String,
+    pub expand: String,
+}
+
+/// Token record stored in `.ta/daemon-tokens.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenRecord {
+    pub token: String,
+    pub scope: TokenScope,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub label: Option<String>,
+}
+
+/// Token permission scopes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TokenScope {
+    Read,
+    Write,
+    Admin,
+}
+
+impl TokenScope {
+    pub fn allows_write(&self) -> bool {
+        matches!(self, Self::Write | Self::Admin)
+    }
+
+    #[allow(dead_code)]
+    pub fn allows_admin(&self) -> bool {
+        matches!(self, Self::Admin)
+    }
+}
+
+/// Manages bearer tokens stored in `.ta/daemon-tokens.json`.
+pub struct TokenStore {
+    tokens_path: PathBuf,
+}
+
+impl TokenStore {
+    pub fn new(project_root: &Path) -> Self {
+        Self {
+            tokens_path: project_root.join(".ta").join("daemon-tokens.json"),
+        }
+    }
+
+    /// Load all tokens from disk.
+    pub fn load(&self) -> Vec<TokenRecord> {
+        if !self.tokens_path.exists() {
+            return vec![];
+        }
+        match std::fs::read_to_string(&self.tokens_path) {
+            Ok(content) => serde_json::from_str(&content).unwrap_or_default(),
+            Err(_) => vec![],
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn save(&self, tokens: &[TokenRecord]) -> std::io::Result<()> {
+        if let Some(parent) = self.tokens_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(tokens)
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        std::fs::write(&self.tokens_path, json)
+    }
+
+    #[allow(dead_code)]
+    pub fn create(&self, scope: TokenScope, label: Option<String>) -> std::io::Result<TokenRecord> {
+        use rand::Rng;
+        let mut rng = rand::thread_rng();
+        let bytes: [u8; 32] = rng.gen();
+        let token = format!("ta_{}", hex_encode(&bytes));
+
+        let record = TokenRecord {
+            token,
+            scope,
+            created_at: chrono::Utc::now(),
+            label,
+        };
+
+        let mut tokens = self.load();
+        tokens.push(record.clone());
+        self.save(&tokens)?;
+
+        Ok(record)
+    }
+
+    /// Validate a token string and return its record if valid.
+    pub fn validate(&self, token: &str) -> Option<TokenRecord> {
+        self.load().into_iter().find(|t| t.token == token)
+    }
+
+    #[allow(dead_code)]
+    pub fn revoke(&self, token: &str) -> std::io::Result<bool> {
+        let mut tokens = self.load();
+        let len_before = tokens.len();
+        tokens.retain(|t| t.token != token);
+        if tokens.len() < len_before {
+            self.save(&tokens)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_daemon_config() {
+        let config = DaemonConfig::default();
+        assert_eq!(config.server.port, 7700);
+        assert_eq!(config.server.bind, "127.0.0.1");
+        assert!(!config.auth.require_token);
+        assert!(config.auth.local_bypass);
+        assert_eq!(config.commands.timeout_secs, 30);
+        assert_eq!(config.agent.max_sessions, 3);
+    }
+
+    #[test]
+    fn default_shell_config() {
+        let config = ShellConfig::default();
+        assert!(!config.routes.is_empty());
+        assert!(!config.shortcuts.is_empty());
+        assert_eq!(config.routes[0].prefix, "ta ");
+        assert_eq!(config.shortcuts[0].r#match, "approve");
+    }
+
+    #[test]
+    fn daemon_config_roundtrip() {
+        let config = DaemonConfig::default();
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let parsed: DaemonConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.server.port, config.server.port);
+    }
+
+    #[test]
+    fn shell_config_roundtrip() {
+        let config = ShellConfig::default();
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let parsed: ShellConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.routes.len(), config.routes.len());
+    }
+
+    #[test]
+    fn token_scope_permissions() {
+        assert!(!TokenScope::Read.allows_write());
+        assert!(TokenScope::Write.allows_write());
+        assert!(TokenScope::Admin.allows_write());
+        assert!(!TokenScope::Read.allows_admin());
+        assert!(!TokenScope::Write.allows_admin());
+        assert!(TokenScope::Admin.allows_admin());
+    }
+
+    #[test]
+    fn token_store_create_validate_revoke() {
+        let dir = tempfile::tempdir().unwrap();
+        let ta_dir = dir.path().join(".ta");
+        std::fs::create_dir_all(&ta_dir).unwrap();
+
+        let store = TokenStore::new(dir.path());
+
+        // Create a token.
+        let record = store.create(TokenScope::Read, Some("test".into())).unwrap();
+        assert!(record.token.starts_with("ta_"));
+
+        // Validate it.
+        let found = store.validate(&record.token);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().scope, TokenScope::Read);
+
+        // Validate unknown token.
+        assert!(store.validate("bogus").is_none());
+
+        // Revoke it.
+        assert!(store.revoke(&record.token).unwrap());
+        assert!(store.validate(&record.token).is_none());
+    }
+
+    #[test]
+    fn load_nonexistent_config() {
+        let config = DaemonConfig::load(Path::new("/nonexistent"));
+        assert_eq!(config.server.port, 7700);
+    }
+}

--- a/crates/ta-daemon/src/main.rs
+++ b/crates/ta-daemon/src/main.rs
@@ -1,17 +1,18 @@
 //! # ta-daemon
 //!
-//! Trusted Autonomy MCP server daemon.
+//! Trusted Autonomy MCP server daemon and HTTP API.
 //!
 //! Starts an MCP server on stdio that Claude Code (or any MCP client)
 //! connects to. All agent tool calls flow through the gateway's policy
 //! engine, staging workspace, and audit log.
 //!
-//! Optionally serves a web review UI at `--web-port <port>` for
-//! browser-based draft review.
+//! Additionally serves a full HTTP API (v0.9.7) that any interface
+//! (terminal, web, Discord, Slack, email) can connect to for commands,
+//! agent conversations, and event streams.
 //!
 //! ## Usage
 //!
-//! Typically started automatically by the MCP client via `.mcp.json`:
+//! MCP mode (default — started by MCP client via `.mcp.json`):
 //! ```json
 //! {
 //!   "mcpServers": {
@@ -23,7 +24,15 @@
 //!   }
 //! }
 //! ```
+//!
+//! API mode (`--api`):
+//! ```sh
+//! ta-daemon --api                    # Starts HTTP API on 127.0.0.1:7700
+//! ta-daemon --api --web-port 8080    # Also serves web UI on port 8080
+//! ```
 
+mod api;
+mod config;
 mod web;
 
 use anyhow::Result;
@@ -34,9 +43,12 @@ use tracing_subscriber::EnvFilter;
 
 use ta_mcp_gateway::{GatewayConfig, TaGatewayServer};
 
-/// Trusted Autonomy MCP server.
+/// Trusted Autonomy MCP server and HTTP API daemon.
 #[derive(Parser)]
-#[command(name = "ta-daemon", about = "Trusted Autonomy MCP server")]
+#[command(
+    name = "ta-daemon",
+    about = "Trusted Autonomy MCP server and HTTP API daemon"
+)]
 struct Cli {
     /// Project root directory (defaults to current directory).
     #[arg(long, default_value = ".")]
@@ -46,6 +58,11 @@ struct Cli {
     /// dashboard for reviewing draft packages.
     #[arg(long)]
     web_port: Option<u16>,
+
+    /// Run in API server mode instead of MCP stdio mode.
+    /// Starts the full HTTP API on the configured bind address and port.
+    #[arg(long)]
+    api: bool,
 }
 
 #[tokio::main]
@@ -64,34 +81,68 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     let project_root = cli.project_root.canonicalize()?;
 
-    tracing::info!("Starting Trusted Autonomy MCP server");
+    tracing::info!("Starting Trusted Autonomy daemon");
     tracing::info!("Project root: {}", project_root.display());
 
-    let config = GatewayConfig::for_project(&project_root);
-    let pr_packages_dir = config.pr_packages_dir.clone();
-    let web_port = cli.web_port.or(config.web_ui_port);
+    // Load daemon configuration.
+    let daemon_config = config::DaemonConfig::load(&project_root);
 
-    let server = TaGatewayServer::new(config)?;
+    if cli.api {
+        // API server mode: start the full HTTP API.
+        tracing::info!("Running in API server mode");
 
-    tracing::info!("MCP server ready, waiting for client connection");
+        // Optionally also serve the legacy web UI on a separate port.
+        if let Some(web_port) = cli.web_port {
+            let gateway_config = GatewayConfig::for_project(&project_root);
+            let dir = gateway_config.pr_packages_dir.clone();
+            tokio::spawn(async move {
+                if let Err(e) = web::serve_web_ui(dir, web_port).await {
+                    tracing::error!("Web UI server error: {}", e);
+                }
+            });
+        }
 
-    // Spawn optional web UI server.
-    if let Some(port) = web_port {
-        let dir = pr_packages_dir.clone();
-        tokio::spawn(async move {
-            if let Err(e) = web::serve_web_ui(dir, port).await {
-                tracing::error!("Web UI server error: {}", e);
-            }
-        });
+        web::serve_daemon_api(project_root, daemon_config).await?;
+    } else {
+        // MCP stdio mode (default): backward-compatible with existing setup.
+        let gateway_config = GatewayConfig::for_project(&project_root);
+        let pr_packages_dir = gateway_config.pr_packages_dir.clone();
+        let web_port = cli.web_port.or(gateway_config.web_ui_port);
+
+        let server = TaGatewayServer::new(gateway_config)?;
+
+        tracing::info!("MCP server ready, waiting for client connection");
+
+        // Spawn optional web UI server.
+        if let Some(port) = web_port {
+            let dir = pr_packages_dir.clone();
+            tokio::spawn(async move {
+                if let Err(e) = web::serve_web_ui(dir, port).await {
+                    tracing::error!("Web UI server error: {}", e);
+                }
+            });
+        }
+
+        // Spawn the daemon API alongside MCP if configured.
+        {
+            let root = project_root.clone();
+            let dc = daemon_config.clone();
+            tokio::spawn(async move {
+                if let Err(e) = web::serve_daemon_api(root, dc).await {
+                    tracing::error!("Daemon API error: {}", e);
+                }
+            });
+        }
+
+        let service = server
+            .serve(rmcp::transport::stdio())
+            .await
+            .inspect_err(|e| tracing::error!("serving error: {:?}", e))?;
+
+        service.waiting().await?;
+
+        tracing::info!("MCP server shutting down");
     }
 
-    let service = server
-        .serve(rmcp::transport::stdio())
-        .await
-        .inspect_err(|e| tracing::error!("serving error: {:?}", e))?;
-
-    service.waiting().await?;
-
-    tracing::info!("MCP server shutting down");
     Ok(())
 }

--- a/crates/ta-daemon/src/web.rs
+++ b/crates/ta-daemon/src/web.rs
@@ -372,7 +372,8 @@ fn update_draft_status(
 
 // ── Router and server ───────────────────────────────────────────
 
-/// Build the Axum router for the web review UI.
+/// Build the legacy web review UI router (draft/memory routes only).
+/// Used by tests that don't need the full daemon API.
 pub fn build_router(pr_packages_dir: PathBuf) -> Router {
     // Derive memory_dir from pr_packages_dir: sibling directory under .ta/
     let memory_dir = pr_packages_dir
@@ -385,6 +386,11 @@ pub fn build_router(pr_packages_dir: PathBuf) -> Router {
         memory_dir,
     });
 
+    build_web_routes(state)
+}
+
+/// Build web UI routes with the given state.
+fn build_web_routes(state: Arc<WebState>) -> Router {
     Router::new()
         .route("/", get(index))
         .route("/manifest.json", get(manifest))
@@ -402,11 +408,47 @@ pub fn build_router(pr_packages_dir: PathBuf) -> Router {
         .with_state(state)
 }
 
-/// Start the web review UI server.
+/// Build the combined router: web UI routes + full daemon API (v0.9.7).
+pub fn build_full_router(
+    project_root: std::path::PathBuf,
+    daemon_config: crate::config::DaemonConfig,
+) -> Router {
+    let app_state = Arc::new(crate::api::AppState::new(project_root, daemon_config));
+
+    // Web UI routes use their own state (legacy).
+    let web_state = Arc::new(WebState {
+        pr_packages_dir: app_state.pr_packages_dir.clone(),
+        memory_dir: app_state.memory_dir.clone(),
+    });
+
+    let web_routes = build_web_routes(web_state);
+    let api_routes = crate::api::build_api_router(app_state);
+
+    // Merge: API routes take precedence, web routes fill in the rest.
+    api_routes.merge(web_routes)
+}
+
+/// Start the web review UI server (legacy — draft/memory only).
 pub async fn serve_web_ui(pr_packages_dir: PathBuf, port: u16) -> anyhow::Result<()> {
     let app = build_router(pr_packages_dir);
     let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", port)).await?;
     tracing::info!("Web review UI listening on http://127.0.0.1:{}", port);
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// Start the full daemon API server (v0.9.7).
+pub async fn serve_daemon_api(
+    project_root: std::path::PathBuf,
+    daemon_config: crate::config::DaemonConfig,
+) -> anyhow::Result<()> {
+    let bind = format!(
+        "{}:{}",
+        daemon_config.server.bind, daemon_config.server.port
+    );
+    let app = build_full_router(project_root, daemon_config);
+    let listener = tokio::net::TcpListener::bind(&bind).await?;
+    tracing::info!("Daemon API listening on http://{}", bind);
     axum::serve(listener, app).await?;
     Ok(())
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: v0.9.4-alpha
+**Version**: v0.9.7-alpha
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 
@@ -46,6 +46,7 @@ Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent w
    - [Credential Management](#credential-management)
    - [Context Memory](#context-memory)
    - [Web Review UI](#web-review-ui)
+   - [Daemon API](#daemon-api)
    - [Webhook Review Channel](#webhook-review-channel)
    - [MCP Tool Call Interception](#mcp-tool-call-interception)
    - [Session Lifecycle](#session-lifecycle)
@@ -1377,6 +1378,133 @@ You can also set the port in your gateway config so it starts automatically:
 # .ta/workflow.toml or gateway config
 [gateway]
 web_ui_port = 7676
+```
+
+### Daemon API
+
+The TA daemon exposes a full HTTP API that any interface (terminal, web, Discord, Slack, email) can connect to for commands, agent conversations, and event streams.
+
+#### Starting the API
+
+```bash
+# API mode (standalone HTTP server)
+ta-daemon --api --project-root .
+
+# MCP mode also starts the API server on port 7700
+ta-daemon --project-root .
+```
+
+The API listens on `127.0.0.1:7700` by default. Configure via `.ta/daemon.toml`:
+
+```toml
+[server]
+bind = "127.0.0.1"
+port = 7700
+cors_origins = ["*"]
+```
+
+#### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/cmd` | Execute a `ta` CLI command |
+| `GET` | `/api/status` | Project dashboard (JSON) |
+| `GET` | `/api/events` | SSE event stream |
+| `POST` | `/api/input` | Unified input with routing |
+| `GET` | `/api/routes` | Route table (for tab completion) |
+| `POST` | `/api/agent/start` | Start an agent session |
+| `POST` | `/api/agent/ask` | Send a prompt to an agent |
+| `GET` | `/api/agent/sessions` | List agent sessions |
+| `DELETE` | `/api/agent/:id` | Stop an agent session |
+
+Plus the existing draft and memory endpoints (`/api/drafts/*`, `/api/memory/*`).
+
+#### Command Execution
+
+```bash
+curl -X POST http://127.0.0.1:7700/api/cmd \
+  -H "Content-Type: application/json" \
+  -d '{"command": "ta draft list"}'
+```
+
+Response:
+```json
+{"exit_code": 0, "stdout": "...", "stderr": ""}
+```
+
+Commands are validated against an allowlist in `.ta/daemon.toml`. Write commands (approve, deny, apply) require write scope.
+
+#### Event Stream
+
+Subscribe to real-time events via Server-Sent Events:
+
+```bash
+# Stream all events
+curl -N http://127.0.0.1:7700/api/events
+
+# Replay from a cursor
+curl -N "http://127.0.0.1:7700/api/events?since=2024-01-01T00:00:00Z"
+
+# Filter by event type
+curl -N "http://127.0.0.1:7700/api/events?types=draft_built,goal_completed"
+```
+
+#### Unified Input
+
+The `/api/input` endpoint routes text through the routing table (`.ta/shell.toml`). Input matching a route prefix runs as a command; everything else goes to the agent:
+
+```bash
+# This gets routed to /api/cmd (matches "ta " prefix)
+curl -X POST http://127.0.0.1:7700/api/input \
+  -H "Content-Type: application/json" \
+  -d '{"text": "ta draft list"}'
+
+# This gets routed to the agent (no prefix match)
+curl -X POST http://127.0.0.1:7700/api/input \
+  -H "Content-Type: application/json" \
+  -d '{"text": "What should we work on next?", "session_id": "sess-abc123"}'
+```
+
+Shortcuts expand automatically: `"approve abc123"` becomes `"ta draft approve abc123"`.
+
+#### Authentication
+
+For remote access, enable token authentication:
+
+```toml
+# .ta/daemon.toml
+[auth]
+require_token = true
+local_bypass = true   # 127.0.0.1 connections skip auth
+```
+
+Tokens are stored in `.ta/daemon-tokens.json`. Pass them via the `Authorization` header:
+
+```bash
+curl -H "Authorization: Bearer ta_..." http://your-server:7700/api/status
+```
+
+Token scopes: `read` (status, list, events), `write` (approve, deny, agent), `admin` (config, tokens).
+
+#### Input Routing
+
+Customize how input is routed in `.ta/shell.toml`:
+
+```toml
+[[routes]]
+prefix = "ta "
+command = "ta"
+strip_prefix = true
+
+[[routes]]
+prefix = "!"           # Shell escape
+command = "sh"
+args = ["-c"]
+strip_prefix = true
+
+[[shortcuts]]
+match = "approve"
+expand = "ta draft approve"
 ```
 
 ### Webhook Review Channel

--- a/templates/daemon.toml
+++ b/templates/daemon.toml
@@ -1,0 +1,26 @@
+# Trusted Autonomy Daemon Configuration
+# Place this file at .ta/daemon.toml in your project root.
+
+[server]
+bind = "127.0.0.1"       # Use "0.0.0.0" for remote access
+port = 7700
+cors_origins = ["*"]      # Restrict in production
+
+[auth]
+require_token = false      # Set true for remote access
+local_bypass = true        # Skip auth for 127.0.0.1 connections
+
+[commands]
+# Allowlist for /api/cmd (glob patterns — "ta draft *" matches any draft subcommand)
+allowed = ["ta draft *", "ta goal *", "ta plan *", "ta status", "ta context *"]
+# Commands that require write scope
+write_commands = ["ta draft approve *", "ta draft deny *", "ta draft apply *", "ta goal start *"]
+timeout_secs = 30
+
+[agent]
+max_sessions = 3           # Concurrent agent sessions
+idle_timeout_secs = 3600   # Kill idle sessions after 1 hour
+default_agent = "claude-code"
+
+[routing]
+use_shell_config = true    # Use .ta/shell.toml for command vs agent routing

--- a/templates/shell.toml
+++ b/templates/shell.toml
@@ -1,0 +1,59 @@
+# Trusted Autonomy Shell Routing Configuration
+# Place this file at .ta/shell.toml in your project root.
+#
+# Routes: prefix -> command execution
+# Anything not matching a route goes to the agent.
+
+[[routes]]
+prefix = "ta "
+command = "ta"
+strip_prefix = true
+
+[[routes]]
+prefix = "git "
+command = "git"
+strip_prefix = true
+
+[[routes]]
+prefix = "cargo "
+command = "./dev cargo"    # Project's nix wrapper
+strip_prefix = true
+
+[[routes]]
+prefix = "!"               # Shell escape: "!ls -la" -> runs "ls -la"
+command = "sh"
+args = ["-c"]
+strip_prefix = true
+
+# Shortcuts: keyword -> expanded command
+[[shortcuts]]
+match = "approve"
+expand = "ta draft approve"
+
+[[shortcuts]]
+match = "deny"
+expand = "ta draft deny"
+
+[[shortcuts]]
+match = "view"
+expand = "ta draft view"
+
+[[shortcuts]]
+match = "apply"
+expand = "ta draft apply"
+
+[[shortcuts]]
+match = "status"
+expand = "ta status"
+
+[[shortcuts]]
+match = "plan"
+expand = "ta plan list"
+
+[[shortcuts]]
+match = "goals"
+expand = "ta goal list"
+
+[[shortcuts]]
+match = "drafts"
+expand = "ta draft list"


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.9.7 — Daemon API Expansion

**Why**: Promote the TA daemon from a draft-review web UI to a full API server that any interface (terminal, web, Discord, Slack, email) can connect to for commands, agent conversations, and event streams.

**Impact**: 18 file(s) changed

## Changes (18 file(s))

- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/Cargo.toml` — Added workspace dependencies: toml 0.8, rand 0.8, tokio-stream 0.1 (with sync feature), async-stream 0.3.
  - Workspace-level dependency declarations for the new daemon crate requirements.
- `~` `fs://workspace/PLAN.md` — Added Completed section to v0.9.7 phase listing 15 implemented items. Added Remaining (deferred) section noting Unix socket, full agent subprocess wiring, and bridge templates.
  - Plan progress tracking must reflect what was actually implemented vs deferred.
- `~` `fs://workspace/apps/ta-cli/Cargo.toml` — Bumped version from 0.9.6-alpha to 0.9.7-alpha.
  - Version bump for the v0.9.7 release.
- `~` `fs://workspace/crates/ta-daemon/Cargo.toml` — Bumped version to 0.9.7-alpha. Added dependencies: tokio-stream, toml, rand, async-stream, ta-events, ta-goal.
  - New dependencies for SSE streaming (tokio-stream, async-stream), config parsing (toml), token generation (rand), and event/goal data access (ta-events, ta-goal).
- `+` `fs://workspace/crates/ta-daemon/src/api/agent.rs` — Agent session management API: AgentSessionManager with create/get/list/stop/touch operations, max session enforcement (stopped sessions don't count toward limit). Endpoints: POST /api/agent/start, POST /api/agent/ask, GET /api/agent/sessions, DELETE /api/agent/:id. 3 async tests for session lifecycle, limit enforcement, and stopped session handling.
  - v0.9.7 requires daemon-owned agent lifecycle management. Full headless subprocess wiring deferred to v0.9.8 when ta shell provides client rendering.
- `+` `fs://workspace/crates/ta-daemon/src/api/auth.rs` — Bearer token authentication middleware: extracts Authorization header, validates against TokenStore, attaches CallerIdentity to request extensions. Supports local bypass (127.0.0.1 gets admin scope without token), optional auth (when require_token=false). require_write() helper for write-scope enforcement. 3 tests.
  - v0.9.7 auth requirement: remote interfaces need token-based access control while local use stays frictionless.
- `+` `fs://workspace/crates/ta-daemon/src/api/cmd.rs` — POST /api/cmd endpoint: executes ta CLI commands by forking the ta binary, captures stdout/stderr as JSON. Validates commands against configurable allowlist with glob matching. Write commands require write scope. Configurable timeout (default 30s). 6 tests for glob matching, allowlist, and write detection.
  - Core v0.9.7 requirement: any interface can execute ta CLI commands via HTTP instead of requiring terminal access.
- `+` `fs://workspace/crates/ta-daemon/src/api/events.rs` — GET /api/events SSE endpoint: polls FsEventStore every 2 seconds, streams new events with cursor tracking. Supports ?since=<ISO8601> for replay and ?types=<comma-separated> for filtering. Uses async_stream for clean SSE generation.
  - Real-time event streaming is essential for any interface to show live notifications (draft ready, goal completed, etc.) without polling individual endpoints.
- `+` `fs://workspace/crates/ta-daemon/src/api/input.rs` — POST /api/input unified endpoint: routes raw text through shell.toml routing table. Shortcut expansion (e.g., 'approve abc123' -> 'ta draft approve abc123'), prefix-based routing to commands, fallback to agent. GET /api/routes returns the routing table for tab completion. 7 tests for routing logic.
  - Clients don't need to know routing rules — they send raw text and the daemon dispatches appropriately. This is the key abstraction enabling ta shell and all bridges.
- `+` `fs://workspace/crates/ta-daemon/src/api/mod.rs` — API module root: AppState shared state struct (project_root, config, sessions, token store), build_api_router() wiring all new endpoints with auth middleware.
  - Central organization for the new daemon API surface — all new endpoints register here.
- `+` `fs://workspace/crates/ta-daemon/src/api/status.rs` — GET /api/status endpoint: returns ProjectStatus JSON with project name, version, current pending plan phase (parsed from PLAN.md), active agents, pending drafts count, total goals, and 10 most recent events. 2 tests for phase parsing.
  - Single endpoint for any interface to render a project dashboard — same data as `ta status` CLI but as structured JSON.
- `+` `fs://workspace/crates/ta-daemon/src/config.rs` — DaemonConfig (daemon.toml parsing: server, auth, commands, agent, routing sections), ShellConfig (shell.toml parsing: routes with prefix/command/args/strip_prefix, shortcuts with match/expand), TokenStore (CRUD for bearer tokens in daemon-tokens.json with hex-encoded random generation), TokenScope enum (read/write/admin). 7 tests: config roundtrip, token CRUD, scope permissions, nonexistent config fallback.
  - All daemon behavior is driven by configuration — the config module is the foundation for every API endpoint.
- `~` `fs://workspace/crates/ta-daemon/src/main.rs` — Added --api flag for standalone API server mode. In MCP mode, also spawns daemon API alongside MCP on stdio. Loads DaemonConfig from .ta/daemon.toml. Updated module declarations (api, config).
  - The daemon now serves dual roles: MCP server for agent tool calls AND HTTP API for any interface. Both modes needed.
- `~` `fs://workspace/crates/ta-daemon/src/web.rs` — Refactored build_router into build_web_routes (internal) + build_full_router (merges API routes with existing draft/memory routes). Added serve_daemon_api() for standalone API server mode. Existing draft/memory routes preserved unchanged.
  - New API routes need to coexist with existing web UI routes. The merge approach avoids duplicating draft/memory handlers.
- `~` `fs://workspace/docs/USAGE.md` — Updated version to v0.9.7-alpha. Added Daemon API section covering: starting the API, all endpoints table, command execution examples, SSE event stream usage, unified input routing, authentication setup, and shell.toml customization. Added TOC entry.
  - User-facing documentation must cover the new HTTP API for remote access and multi-interface connectivity.
- `+` `fs://workspace/templates/daemon.toml` — Default daemon configuration template with all sections (server, auth, commands, agent, routing) and inline comments explaining each option.
  - Users need a reference template to customize daemon behavior. Copied to .ta/daemon.toml during project setup.
- `+` `fs://workspace/templates/shell.toml` — Default input routing config with routes (ta, git, cargo, shell escape) and shortcuts (approve, deny, view, apply, status, plan, goals, drafts).
  - Customizable routing for the unified /api/input endpoint. Shared by ta shell, web UI, and all bridge interfaces.

## Goal Context

- **Title**: Implement v0.9.7 — Daemon API Expansion
- **Objective**: Implement v0.9.7 — Daemon API Expansion
- **Goal ID**: `78d14e86-a114-40ea-a30d-97474f9d6f41`
- **PR ID**: `80184b86-6877-4bf3-9ffe-f2de69c5a5ce`
- **Plan Phase**: `0.9.7`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
