### PR TITLE
Implement v0.9.8.1.1 — Unified Allow/Deny List Pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "serde",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "glob",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "serde",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "serde",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2741,6 +2741,7 @@ dependencies = [
  "ta-goal",
  "ta-mcp-gateway",
  "ta-memory",
+ "ta-policy",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2754,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "serde",
@@ -2769,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "serde",
@@ -2782,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "rmcp",
@@ -2807,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "serde",
@@ -2822,7 +2823,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "glob",
@@ -2837,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "glob",
@@ -2852,11 +2853,12 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "ta-policy",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -2864,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "serde",
@@ -2879,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "serde",
@@ -2895,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.9.8-alpha.1"
+version = "0.9.8-alpha.1.1"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2959,7 +2959,7 @@ agents:
 ---
 
 ### v0.9.8.1.1 — Unified Allow/Deny List Pattern
-<!-- status: pending -->
+<!-- status: done -->
 **Goal**: Standardize all allowlist/blocklist patterns across TA to support both allow and deny lists with consistent semantics: deny takes precedence over allow, empty allow = allow all, empty deny = deny nothing.
 
 #### Problem
@@ -3008,6 +3008,19 @@ impl AccessFilter {
 - `crates/ta-sandbox/src/lib.rs` — use `AccessFilter` for command lists
 - Backward-compatible: existing configs with only `allowed` still work (empty `denied` = deny nothing)
 - Tests: deny-wins-over-allow, empty-allow-means-all, glob matching, backward compat
+
+#### Completed
+
+- [x] `AccessFilter` struct in `ta-policy/src/access_filter.rs` with `permits()`, `tighten()`, `from_allowed()`, `allow_all()`, `is_unrestricted()`, `Display` impl, serde support, and 18 tests
+- [x] Daemon `CommandConfig`: added `denied` field alongside `allowed`, `access_filter()` method returning `AccessFilter`, updated `cmd.rs` to use `filter.permits()` instead of `is_command_allowed()` (2 new tests)
+- [x] Auto-approval paths: refactored `should_auto_approve_draft()` to use `AccessFilter` for path matching, `merge_conditions()` to use `AccessFilter::tighten()` (backward compatible — existing YAML field names preserved)
+- [x] Sandbox: added `denied_commands` field to `SandboxConfig`, deny check in `execute()` and `is_allowed()` (2 new tests)
+- [x] Documentation: unified access control pattern in USAGE.md
+
+#### Remaining (deferred)
+
+- [ ] Channel access control: `denied_roles` / `denied_users` fields (requires channel registry changes)
+- [ ] Agent tool access: configurable tool allow/deny per agent config (requires alignment profile changes)
 
 #### Version: `0.9.8-alpha.1.1`
 

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -29,6 +29,7 @@ ta-changeset = { path = "../ta-changeset" }
 ta-memory = { path = "../ta-memory" }
 ta-events = { path = "../ta-events" }
 ta-goal = { path = "../ta-goal" }
+ta-policy = { path = "../ta-policy" }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/ta-daemon/src/api/cmd.rs
+++ b/crates/ta-daemon/src/api/cmd.rs
@@ -42,11 +42,12 @@ pub async fn execute_command(
             .into_response();
     }
 
-    // Check if command is allowed.
-    if !is_command_allowed(command_str, &state.daemon_config.commands.allowed) {
+    // Check if command is allowed (deny takes precedence over allow).
+    let filter = state.daemon_config.commands.access_filter();
+    if !filter.permits(command_str) {
         return (
             StatusCode::FORBIDDEN,
-            Json(serde_json::json!({"error": "command not in allowlist"})),
+            Json(serde_json::json!({"error": "command not permitted (check allowed/denied in daemon.toml)"})),
         )
             .into_response();
     }
@@ -257,6 +258,8 @@ fn find_ta_binary() -> String {
 }
 
 /// Check if a command matches the allowlist using simple glob patterns.
+/// Used in tests only; production code uses `AccessFilter::permits()`.
+#[cfg(test)]
 fn is_command_allowed(command: &str, allowlist: &[String]) -> bool {
     if allowlist.is_empty() {
         return true; // No allowlist = allow everything.
@@ -351,5 +354,27 @@ mod tests {
         ];
         assert!(is_write_command("ta draft approve abc", &write));
         assert!(!is_write_command("ta draft list", &write));
+    }
+
+    #[test]
+    fn access_filter_deny_takes_precedence() {
+        use crate::config::CommandConfig;
+        let config = CommandConfig {
+            allowed: vec!["ta draft *".to_string()],
+            denied: vec!["ta draft apply *".to_string()],
+            ..Default::default()
+        };
+        let filter = config.access_filter();
+        assert!(filter.permits("ta draft list"));
+        assert!(!filter.permits("ta draft apply abc123"));
+    }
+
+    #[test]
+    fn default_command_config_allows_all() {
+        use crate::config::CommandConfig;
+        let config = CommandConfig::default();
+        let filter = config.access_filter();
+        assert!(filter.permits("ta status"));
+        assert!(filter.permits("anything"));
     }
 }

--- a/crates/ta-daemon/src/config.rs
+++ b/crates/ta-daemon/src/config.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use ta_policy::AccessFilter;
 
 /// Top-level daemon configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -72,7 +73,12 @@ impl Default for AuthConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct CommandConfig {
+    /// Allowed command patterns. Empty = allow all.
+    /// Use `denied` to explicitly block specific commands (deny takes precedence).
     pub allowed: Vec<String>,
+    /// Denied command patterns. Deny always takes precedence over allowed.
+    #[serde(default)]
+    pub denied: Vec<String>,
     pub write_commands: Vec<String>,
     pub timeout_secs: u64,
     /// Commands that launch long-running processes (agents, dev loops).
@@ -82,12 +88,20 @@ pub struct CommandConfig {
     pub long_timeout_secs: u64,
 }
 
+impl CommandConfig {
+    /// Get the unified AccessFilter for this command config.
+    pub fn access_filter(&self) -> AccessFilter {
+        AccessFilter::new(self.allowed.clone(), self.denied.clone())
+    }
+}
+
 impl Default for CommandConfig {
     fn default() -> Self {
         Self {
             allowed: vec![
                 "*".to_string(), // All commands allowed by default for local human operator.
             ],
+            denied: vec![],
             write_commands: vec![
                 "ta draft approve *".to_string(),
                 "ta draft deny *".to_string(),

--- a/crates/ta-policy/src/access_filter.rs
+++ b/crates/ta-policy/src/access_filter.rs
@@ -1,0 +1,314 @@
+// access_filter.rs — Unified allow/deny list pattern (v0.9.8.1.1).
+//
+// Reusable access filter with consistent semantics across all TA subsystems:
+//   - Deny always takes precedence over allow.
+//   - Empty `allowed` = allow all.
+//   - Empty `denied` = deny nothing.
+//
+// Used by: daemon command routing, auto-approval paths, sandbox commands,
+// network policy, and channel access control.
+
+use glob::Pattern;
+use serde::{Deserialize, Serialize};
+
+/// Reusable allow/deny filter. Deny always takes precedence.
+///
+/// Supports glob patterns (via the `glob` crate) for flexible matching.
+/// The evaluation logic:
+///   1. If any `denied` pattern matches → **false** (deny always wins)
+///   2. If `allowed` is empty → **true** (empty allow = allow all)
+///   3. If any `allowed` pattern matches → **true**
+///   4. Otherwise → **false**
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AccessFilter {
+    /// Glob patterns for permitted inputs. Empty = allow all.
+    #[serde(default)]
+    pub allowed: Vec<String>,
+    /// Glob patterns for denied inputs. Empty = deny nothing.
+    /// Deny always takes precedence over allow.
+    #[serde(default)]
+    pub denied: Vec<String>,
+}
+
+impl AccessFilter {
+    /// Create a filter that allows everything (default).
+    pub fn allow_all() -> Self {
+        Self {
+            allowed: Vec::new(),
+            denied: Vec::new(),
+        }
+    }
+
+    /// Create a filter from only an allow list (backward compat).
+    pub fn from_allowed(allowed: Vec<String>) -> Self {
+        Self {
+            allowed,
+            denied: Vec::new(),
+        }
+    }
+
+    /// Create a filter from separate allow and deny lists.
+    pub fn new(allowed: Vec<String>, denied: Vec<String>) -> Self {
+        Self { allowed, denied }
+    }
+
+    /// Returns true if the input is permitted.
+    ///
+    /// Logic:
+    ///   1. If any `denied` pattern matches → false (deny always wins)
+    ///   2. If `allowed` is empty → true (allow all)
+    ///   3. If any `allowed` pattern matches → true
+    ///   4. Otherwise → false
+    pub fn permits(&self, input: &str) -> bool {
+        // Deny takes precedence.
+        for pattern in &self.denied {
+            if matches_pattern(pattern, input) {
+                return false;
+            }
+        }
+
+        // Empty allowed = allow all.
+        if self.allowed.is_empty() {
+            return true;
+        }
+
+        // Check allow list.
+        self.allowed
+            .iter()
+            .any(|pattern| matches_pattern(pattern, input))
+    }
+
+    /// Returns true if both allowed and denied are empty (permits everything).
+    pub fn is_unrestricted(&self) -> bool {
+        self.allowed.is_empty() && self.denied.is_empty()
+    }
+
+    /// Merge two filters with tighten-only semantics:
+    /// - denied lists are unioned (more restrictions)
+    /// - allowed lists are intersected (if both non-empty), or the non-empty one wins
+    pub fn tighten(&self, other: &AccessFilter) -> AccessFilter {
+        // Union of denied (more restrictions).
+        let mut denied = self.denied.clone();
+        for p in &other.denied {
+            if !denied.contains(p) {
+                denied.push(p.clone());
+            }
+        }
+
+        // Intersection of allowed (more restrictive).
+        let allowed = if self.allowed.is_empty() {
+            other.allowed.clone()
+        } else if other.allowed.is_empty() {
+            self.allowed.clone()
+        } else {
+            self.allowed
+                .iter()
+                .filter(|p| other.allowed.contains(p))
+                .cloned()
+                .collect()
+        };
+
+        AccessFilter { allowed, denied }
+    }
+}
+
+/// Match a pattern against input. Supports glob patterns via the `glob` crate,
+/// with a fast path for simple cases (exact match, `*`, prefix `*`, suffix `*`).
+fn matches_pattern(pattern: &str, input: &str) -> bool {
+    // Fast paths for common simple patterns.
+    if pattern == "*" {
+        return true;
+    }
+    if pattern == input {
+        return true;
+    }
+
+    // Use glob::Pattern for full glob support.
+    Pattern::new(pattern)
+        .map(|p| p.matches(input))
+        .unwrap_or(false)
+}
+
+impl std::fmt::Display for AccessFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_unrestricted() {
+            write!(f, "allow all")
+        } else if self.allowed.is_empty() {
+            write!(f, "deny: [{}]", self.denied.join(", "))
+        } else if self.denied.is_empty() {
+            write!(f, "allow: [{}]", self.allowed.join(", "))
+        } else {
+            write!(
+                f,
+                "allow: [{}], deny: [{}]",
+                self.allowed.join(", "),
+                self.denied.join(", ")
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_filter_allows_all() {
+        let filter = AccessFilter::allow_all();
+        assert!(filter.permits("anything"));
+        assert!(filter.permits(""));
+        assert!(filter.is_unrestricted());
+    }
+
+    #[test]
+    fn deny_takes_precedence_over_allow() {
+        let filter = AccessFilter::new(
+            vec!["**".to_string()],    // allow everything
+            vec!["*.exe".to_string()], // deny .exe
+        );
+        assert!(filter.permits("script.sh"));
+        assert!(!filter.permits("malware.exe"));
+    }
+
+    #[test]
+    fn empty_allowed_means_allow_all() {
+        let filter = AccessFilter::new(
+            vec![],                         // empty = allow all
+            vec!["secret.key".to_string()], // deny specific file
+        );
+        assert!(filter.permits("normal.txt"));
+        assert!(!filter.permits("secret.key"));
+    }
+
+    #[test]
+    fn non_empty_allowed_restricts() {
+        let filter =
+            AccessFilter::from_allowed(vec!["tests/**".to_string(), "docs/**".to_string()]);
+        assert!(filter.permits("tests/foo.rs"));
+        assert!(filter.permits("docs/readme.md"));
+        assert!(!filter.permits("src/main.rs"));
+    }
+
+    #[test]
+    fn glob_patterns_work() {
+        let filter = AccessFilter::new(
+            vec!["src/**/*.rs".to_string()],
+            vec!["**/secret*".to_string()],
+        );
+        assert!(filter.permits("src/lib.rs"));
+        assert!(filter.permits("src/commands/run.rs"));
+        assert!(!filter.permits("src/secret_key.rs"));
+        assert!(!filter.permits("build/output.js"));
+    }
+
+    #[test]
+    fn exact_match() {
+        let filter = AccessFilter::from_allowed(vec!["ta status".to_string()]);
+        assert!(filter.permits("ta status"));
+        assert!(!filter.permits("ta goal list"));
+    }
+
+    #[test]
+    fn wildcard_star_matches_all() {
+        let filter = AccessFilter::from_allowed(vec!["*".to_string()]);
+        assert!(filter.permits("anything"));
+    }
+
+    #[test]
+    fn command_style_glob() {
+        // Matches the pattern used by daemon command routing.
+        let filter = AccessFilter::new(
+            vec!["ta draft *".to_string(), "ta status".to_string()],
+            vec!["ta draft apply *".to_string()],
+        );
+        assert!(filter.permits("ta draft list"));
+        assert!(filter.permits("ta status"));
+        assert!(!filter.permits("ta draft apply abc123")); // denied
+        assert!(!filter.permits("ta goal start foo")); // not in allowed
+    }
+
+    #[test]
+    fn backward_compat_from_allowed() {
+        let filter = AccessFilter::from_allowed(vec!["*".to_string()]);
+        assert!(filter.permits("anything"));
+        assert!(filter.denied.is_empty());
+    }
+
+    #[test]
+    fn tighten_unions_denied() {
+        let a = AccessFilter::new(vec![], vec!["a".to_string()]);
+        let b = AccessFilter::new(vec![], vec!["b".to_string()]);
+        let merged = a.tighten(&b);
+        assert_eq!(merged.denied, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn tighten_intersects_allowed() {
+        let a = AccessFilter::from_allowed(vec!["x".to_string(), "y".to_string()]);
+        let b = AccessFilter::from_allowed(vec!["y".to_string(), "z".to_string()]);
+        let merged = a.tighten(&b);
+        assert_eq!(merged.allowed, vec!["y".to_string()]);
+    }
+
+    #[test]
+    fn tighten_empty_allowed_uses_other() {
+        let a = AccessFilter::allow_all();
+        let b = AccessFilter::from_allowed(vec!["only-this".to_string()]);
+        let merged = a.tighten(&b);
+        assert_eq!(merged.allowed, vec!["only-this".to_string()]);
+    }
+
+    #[test]
+    fn tighten_deduplicates_denied() {
+        let a = AccessFilter::new(vec![], vec!["x".to_string()]);
+        let b = AccessFilter::new(vec![], vec!["x".to_string()]);
+        let merged = a.tighten(&b);
+        assert_eq!(merged.denied, vec!["x".to_string()]);
+    }
+
+    #[test]
+    fn display_unrestricted() {
+        assert_eq!(format!("{}", AccessFilter::allow_all()), "allow all");
+    }
+
+    #[test]
+    fn display_with_lists() {
+        let filter = AccessFilter::new(vec!["a".to_string()], vec!["b".to_string()]);
+        assert_eq!(format!("{}", filter), "allow: [a], deny: [b]");
+    }
+
+    #[test]
+    fn serde_round_trip() {
+        let filter =
+            AccessFilter::new(vec!["tests/**".to_string()], vec!["**/secret*".to_string()]);
+        let json = serde_json::to_string(&filter).unwrap();
+        let restored: AccessFilter = serde_json::from_str(&json).unwrap();
+        assert_eq!(filter, restored);
+    }
+
+    #[test]
+    fn serde_yaml_round_trip() {
+        let filter = AccessFilter::new(vec!["src/**".to_string()], vec!["*.key".to_string()]);
+        let yaml = serde_yaml::to_string(&filter).unwrap();
+        let restored: AccessFilter = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(filter, restored);
+    }
+
+    #[test]
+    fn empty_denied_denies_nothing() {
+        let filter = AccessFilter::from_allowed(vec!["*".to_string()]);
+        assert!(filter.permits("anything"));
+        // No denied patterns means nothing is denied.
+    }
+
+    #[test]
+    fn permits_with_path_globs() {
+        let filter = AccessFilter::new(
+            vec!["**".to_string()],
+            vec![".ta/**".to_string(), "**/main.rs".to_string()],
+        );
+        assert!(filter.permits("tests/foo.rs"));
+        assert!(!filter.permits(".ta/config.yaml"));
+        assert!(!filter.permits("src/main.rs"));
+    }
+}

--- a/crates/ta-policy/src/auto_approve.rs
+++ b/crates/ta-policy/src/auto_approve.rs
@@ -11,9 +11,9 @@
 //   4. phase limits
 //   5. agent security level
 
-use glob::Pattern;
 use serde::{Deserialize, Serialize};
 
+use crate::access_filter::AccessFilter;
 use crate::document::{AutoApproveDraftConfig, PolicyDocument, SecurityLevel};
 
 /// Minimal draft info needed for auto-approval evaluation.
@@ -116,41 +116,31 @@ pub fn should_auto_approve_draft(draft: &DraftInfo, doc: &PolicyDocument) -> Aut
         ));
     }
 
-    // 4. Path rules — blocked_paths first (deny takes precedence).
-    if !conditions.blocked_paths.is_empty() {
+    // 4. Path rules — use AccessFilter (deny takes precedence over allow).
+    let path_filter = AccessFilter::new(
+        conditions.allowed_paths.clone(),
+        conditions.blocked_paths.clone(),
+    );
+    if !path_filter.is_unrestricted() {
         for path in &draft.changed_paths {
             let bare = strip_uri_prefix(path);
-            for pattern in &conditions.blocked_paths {
-                if matches_glob(pattern, bare) {
-                    return AutoApproveDecision::Denied {
-                        blockers: vec![format!(
-                            "path '{}' matches blocked_paths pattern '{}'",
-                            bare, pattern
-                        )],
-                    };
-                }
-            }
-        }
-        reasons.push("no blocked paths matched".to_string());
-    }
-
-    if !conditions.allowed_paths.is_empty() {
-        for path in &draft.changed_paths {
-            let bare = strip_uri_prefix(path);
-            let matched = conditions
-                .allowed_paths
-                .iter()
-                .any(|pattern| matches_glob(pattern, bare));
-            if !matched {
+            if !path_filter.permits(bare) {
+                // Determine whether it was denied or just not allowed.
+                let reason = if conditions
+                    .blocked_paths
+                    .iter()
+                    .any(|p| AccessFilter::from_allowed(vec![p.clone()]).permits(bare))
+                {
+                    format!("path '{}' matches blocked_paths", bare)
+                } else {
+                    format!("path '{}' does not match any allowed_paths pattern", bare)
+                };
                 return AutoApproveDecision::Denied {
-                    blockers: vec![format!(
-                        "path '{}' does not match any allowed_paths pattern",
-                        bare
-                    )],
+                    blockers: vec![reason],
                 };
             }
         }
-        reasons.push(format!("all {} paths match allowed_paths", file_count));
+        reasons.push(format!("all {} paths pass access filter", file_count));
     }
 
     // 5. Phase limits.
@@ -245,29 +235,20 @@ fn merge_conditions(
             (Some(a), Some(b)) => Some(a.min(b)),
             (a, b) => a.or(b),
         },
-        // Union of blocked paths (more restrictions).
+        // Use AccessFilter::tighten for path merge (union denied, intersect allowed).
         blocked_paths: {
-            let mut merged = base.blocked_paths.clone();
-            for p in &overlay.blocked_paths {
-                if !merged.contains(p) {
-                    merged.push(p.clone());
-                }
-            }
-            merged
+            let base_filter =
+                AccessFilter::new(base.allowed_paths.clone(), base.blocked_paths.clone());
+            let overlay_filter =
+                AccessFilter::new(overlay.allowed_paths.clone(), overlay.blocked_paths.clone());
+            base_filter.tighten(&overlay_filter).denied
         },
-        // Intersection of allowed paths (more restrictive).
-        // If either is empty (allow all), use the other.
-        allowed_paths: if base.allowed_paths.is_empty() {
-            overlay.allowed_paths.clone()
-        } else if overlay.allowed_paths.is_empty() {
-            base.allowed_paths.clone()
-        } else {
-            // Keep only patterns present in both.
-            base.allowed_paths
-                .iter()
-                .filter(|p| overlay.allowed_paths.contains(p))
-                .cloned()
-                .collect()
+        allowed_paths: {
+            let base_filter =
+                AccessFilter::new(base.allowed_paths.clone(), base.blocked_paths.clone());
+            let overlay_filter =
+                AccessFilter::new(overlay.allowed_paths.clone(), overlay.blocked_paths.clone());
+            base_filter.tighten(&overlay_filter).allowed
         },
         // Tighten: if either requires, require.
         require_tests_pass: base.require_tests_pass || overlay.require_tests_pass,
@@ -295,13 +276,6 @@ fn merge_conditions(
 /// Strip the `fs://workspace/` URI prefix to get a bare path.
 fn strip_uri_prefix(uri: &str) -> &str {
     uri.strip_prefix("fs://workspace/").unwrap_or(uri)
-}
-
-/// Match a glob pattern against a path.
-fn matches_glob(pattern: &str, path: &str) -> bool {
-    Pattern::new(pattern)
-        .map(|p| p.matches(path))
-        .unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/crates/ta-policy/src/lib.rs
+++ b/crates/ta-policy/src/lib.rs
@@ -46,8 +46,10 @@ pub use constitution::{
     ConstitutionValidation, EnforcementMode,
 };
 pub use context::PolicyContext;
+pub mod access_filter;
 pub mod auto_approve;
 
+pub use access_filter::AccessFilter;
 pub use auto_approve::{AutoApproveDecision, DraftInfo};
 pub use document::{
     AgentPolicyOverride, AutoApproveConditions, AutoApproveConfig, AutoApproveDraftConfig,

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }
+ta-policy = { path = "../ta-policy" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-sandbox/src/lib.rs
+++ b/crates/ta-sandbox/src/lib.rs
@@ -31,12 +31,17 @@ use std::process::{Command, Output};
 use std::time::{Duration, SystemTime};
 
 use serde::{Deserialize, Serialize};
+use ta_policy::AccessFilter;
 
 /// Sandbox configuration defining what commands are permitted.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SandboxConfig {
     /// Allowed commands and their policies.
     pub commands: HashMap<String, CommandPolicy>,
+    /// Explicitly denied commands. Deny takes precedence over `commands` allowlist.
+    /// Supports glob patterns (e.g., "rm", "curl*").
+    #[serde(default)]
+    pub denied_commands: Vec<String>,
     /// Network access policy.
     pub network: NetworkPolicy,
     /// Maximum execution time per command (seconds).
@@ -165,6 +170,17 @@ impl SandboxRunner {
     /// Checks the allowlist, validates arguments, enforces CWD, captures output,
     /// and hashes the transcript.
     pub fn execute(&mut self, command: &str, args: &[&str]) -> Result<SandboxResult, SandboxError> {
+        // 0. Check denied commands first (deny takes precedence over allowlist).
+        if !self.config.denied_commands.is_empty() {
+            let filter = AccessFilter::new(vec![], self.config.denied_commands.clone());
+            if !filter.permits(command) {
+                return Err(SandboxError::CommandNotAllowed(format!(
+                    "{} (explicitly denied)",
+                    command
+                )));
+            }
+        }
+
         // 1. Check allowlist.
         let policy = self
             .config
@@ -323,12 +339,23 @@ impl SandboxRunner {
         &self.workspace_root
     }
 
-    /// Check if a command is in the allowlist.
+    /// Check if a command is permitted (in allowlist and not denied).
     pub fn is_allowed(&self, command: &str) -> bool {
+        // Check denied first.
+        if !self.config.denied_commands.is_empty() {
+            let filter = AccessFilter::new(vec![], self.config.denied_commands.clone());
+            if !filter.permits(command) {
+                return false;
+            }
+        }
         self.config.commands.contains_key(command)
     }
 
     /// Check if a domain is allowed by the network policy.
+    ///
+    /// Uses domain-specific matching (supports `*.github.com` subdomain wildcards)
+    /// rather than generic glob patterns. The semantics follow AccessFilter's model:
+    /// deny takes precedence, then allow, then default action.
     pub fn is_domain_allowed(&self, domain: &str) -> bool {
         // Check deny list first (deny takes priority).
         for denied in &self.config.network.deny_domains {
@@ -448,6 +475,7 @@ impl Default for SandboxConfig {
 
         Self {
             commands,
+            denied_commands: vec![],
             network: NetworkPolicy {
                 default_action: NetworkAction::Deny,
                 allow_domains: vec![
@@ -677,5 +705,33 @@ mod tests {
         assert!(runner.is_allowed("cargo"));
         assert!(!runner.is_allowed("rm"));
         assert!(!runner.is_allowed("curl"));
+    }
+
+    #[test]
+    fn denied_commands_take_precedence() {
+        // cargo is in the allowlist by default, but deny it explicitly.
+        let config = SandboxConfig {
+            denied_commands: vec!["cargo".to_string()],
+            ..SandboxConfig::default()
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let runner = SandboxRunner::new(config, dir.path());
+
+        assert!(!runner.is_allowed("cargo"));
+        assert!(runner.is_allowed("rg")); // still allowed
+    }
+
+    #[test]
+    fn denied_command_execution_blocked() {
+        let config = SandboxConfig {
+            denied_commands: vec!["cat".to_string()],
+            ..SandboxConfig::default()
+        };
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("test.txt"), "hello").unwrap();
+        let mut runner = SandboxRunner::new(config, dir.path());
+
+        let result = runner.execute("cat", &["test.txt"]);
+        assert!(matches!(result, Err(SandboxError::CommandNotAllowed(_))));
     }
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -53,6 +53,7 @@ Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent w
    - [MCP Tool Call Interception](#mcp-tool-call-interception)
    - [Session Lifecycle](#session-lifecycle)
    - [Unified Policy Config](#unified-policy-config)
+   - [Unified Access Control Pattern](#unified-access-control-pattern)
    - [Resource Mediation](#resource-mediation)
    - [Channel Registry](#channel-registry)
    - [API Mediation](#api-mediation)
@@ -1900,6 +1901,9 @@ allowed = [                 # Command allowlist (glob patterns)
   "ta status",
   "ta context *",
 ]
+denied = [                  # Command denylist (deny takes precedence)
+  "ta draft apply --force *",
+]
 write_commands = [           # Commands requiring write scope
   "ta draft approve *",
   "ta draft deny *",
@@ -2155,6 +2159,46 @@ budget:
 - **Checkpoint** (default): Review at draft submission
 - **Supervised**: Approve each state-changing action
 - **Strict**: Constitutions required for all goals
+
+### Unified Access Control Pattern
+
+All allow/deny lists in TA follow the same `AccessFilter` pattern:
+
+- **Deny always takes precedence** over allow
+- **Empty `allowed`** = allow all
+- **Empty `denied`** = deny nothing
+
+This pattern is used across daemon command routing, auto-approval path matching, and sandbox command policies.
+
+```yaml
+# In .ta/daemon.toml — command access control
+[commands]
+allowed = ["ta draft *", "ta goal *", "ta status"]
+denied = ["ta draft apply --force *"]  # deny always wins
+
+# In .ta/policy.yaml — auto-approval path rules
+defaults:
+  auto_approve:
+    drafts:
+      conditions:
+        allowed_paths: ["tests/**", "docs/**"]
+        blocked_paths: [".ta/**", "**/main.rs"]
+```
+
+The `AccessFilter` struct in `ta-policy` provides this as a reusable building block:
+
+```rust
+use ta_policy::AccessFilter;
+
+let filter = AccessFilter::new(
+    vec!["src/**".to_string()],     // allowed patterns
+    vec!["**/secret*".to_string()], // denied patterns
+);
+assert!(filter.permits("src/lib.rs"));
+assert!(!filter.permits("src/secret_key.rs")); // denied wins
+```
+
+Sandbox commands also support a `denied_commands` list that takes precedence over the allowlist.
 
 ### Resource Mediation (v0.6.2)
 


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.9.8.1.1 — Unified Allow/Deny List Pattern

**Why**: Standardize all allowlist/blocklist patterns across TA to support both allow and deny lists with consistent semantics: deny takes precedence over allow, empty allow = allow all, empty deny = deny nothing.

**Impact**: 12 file(s) changed

## Changes (12 file(s))

- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/Cargo.toml` — Bumped workspace version from 0.9.8-alpha.1 to 0.9.8-alpha.1.1.
  - Version bump for v0.9.8.1.1 release.
- `~` `fs://workspace/PLAN.md` — Added Completed section to v0.9.8.1.1 phase listing all 5 implemented items. Added Remaining (deferred) section noting channel access control and agent tool access.
  - Plan progress tracking must reflect what was actually implemented vs deferred.
- `~` `fs://workspace/crates/ta-daemon/Cargo.toml` — Added ta-policy dependency.
  - Daemon config now imports AccessFilter from ta-policy.
- `~` `fs://workspace/crates/ta-daemon/src/api/cmd.rs` — Replaced is_command_allowed() call with AccessFilter::permits() via CommandConfig::access_filter(). Moved is_command_allowed() to #[cfg(test)] since it's only used by legacy tests. Added 2 new tests: access_filter_deny_takes_precedence, default_command_config_allows_all.
  - Production code path now uses the unified AccessFilter pattern; old function retained in tests only for backward compat validation.
- `~` `fs://workspace/crates/ta-daemon/src/config.rs` — Added `denied: Vec<String>` field to CommandConfig (serde default = empty). Added `access_filter()` method returning AccessFilter. Added ta_policy import.
  - Daemon command routing only had an allowlist — adding a deny list with AccessFilter gives operators the ability to selectively block commands even within a broad allowlist.
- `+` `fs://workspace/crates/ta-policy/src/access_filter.rs` — New AccessFilter struct with permits(), tighten(), from_allowed(), allow_all(), is_unrestricted(), Display impl, serde support (JSON + YAML). 18 tests covering deny-wins-over-allow, empty-allow-means-all, glob matching, backward compat, tighten semantics, serialization round-trips.
  - Central reusable building block for the unified allow/deny list pattern — all access control in TA should share one set of semantics.
- `~` `fs://workspace/crates/ta-policy/src/auto_approve.rs` — Refactored path checking in should_auto_approve_draft() to use AccessFilter instead of inline glob matching. Refactored merge_conditions() to use AccessFilter::tighten() for path merge. Removed unused matches_glob() function and glob::Pattern import.
  - Auto-approval path matching was the most complex existing allow/deny pattern — unifying it under AccessFilter ensures consistent semantics and eliminates duplicated logic.
- `~` `fs://workspace/crates/ta-policy/src/lib.rs` — Added access_filter module declaration and public re-export of AccessFilter.
  - New module needs to be exposed as part of the ta-policy public API.
- `~` `fs://workspace/crates/ta-sandbox/Cargo.toml` — Added ta-policy dependency.
  - Sandbox now imports AccessFilter from ta-policy for denied command checking.
- `~` `fs://workspace/crates/ta-sandbox/src/lib.rs` — Added denied_commands field to SandboxConfig. Added deny check in execute() (before allowlist check). Updated is_allowed() to check denied_commands. Added ta_policy::AccessFilter import. Added 2 new tests: denied_commands_take_precedence, denied_command_execution_blocked.
  - Sandbox only had a command allowlist — adding a deny list gives operators the ability to block specific commands even if they appear in the allowlist (e.g., deny 'cargo' in restricted environments).
- `~` `fs://workspace/docs/USAGE.md` — Added 'Unified Access Control Pattern' section explaining AccessFilter semantics with YAML and Rust examples. Added TOC entry. Updated daemon.toml example to show denied field.
  - User-facing documentation must cover the new unified access control pattern — one mental model for all allow/deny lists in TA.

## Goal Context

- **Title**: Implement v0.9.8.1.1 — Unified Allow/Deny List Pattern
- **Objective**: Implement v0.9.8.1.1 — Unified Allow/Deny List Pattern
- **Goal ID**: `0d0c8f47-ec46-4952-bf04-10c8c8b0bf8b`
- **PR ID**: `c5f1daa0-6d1b-4fb5-b3d2-6196873c4789`
- **Plan Phase**: `v0.9.8.1.1`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
