### PR TITLE
Add structured actions to event envelopes

### DIFF
--- a/apps/ta-cli/src/commands/shell.rs
+++ b/apps/ta-cli/src/commands/shell.rs
@@ -639,10 +639,7 @@ fn render_sse_event(frame: &str) -> Option<String> {
             } else {
                 format!("{}s", secs)
             };
-            format!(
-                "goal completed: \"{}\" ({}) [{}]\n  Next: ta draft list | ta draft view <id>",
-                title, duration, goal_id
-            )
+            format!("goal completed: \"{}\" ({}) [{}]", title, duration, goal_id)
         }
         "draft_built" => {
             let count = payload["artifact_count"].as_u64().unwrap_or(0);
@@ -650,11 +647,7 @@ fn render_sse_event(frame: &str) -> Option<String> {
                 .as_str()
                 .map(|s| &s[..8.min(s.len())])
                 .unwrap_or("?");
-            let full_id = payload["draft_id"].as_str().unwrap_or("?");
-            format!(
-                "draft ready: {} files ({})\n  View:    ta draft view {}\n  Approve: ta draft approve {}\n  Deny:    ta draft deny {}",
-                count, draft_id, full_id, full_id, full_id
-            )
+            format!("draft ready: {} files ({})", count, draft_id)
         }
         "draft_approved" | "draft_denied" => {
             let decision = if event_type == "draft_approved" {
@@ -678,7 +671,55 @@ fn render_sse_event(frame: &str) -> Option<String> {
         }
     };
 
-    Some(format!("\n[event] {}\n", detail))
+    // Render structured actions from the event envelope (if present).
+    // Falls back to hardcoded suggestions for backwards compatibility with
+    // events written before the actions field was added.
+    let actions_suffix = render_actions_suffix(event_type, &json);
+
+    Some(format!("\n[event] {}{}\n", detail, actions_suffix))
+}
+
+/// Render the actions section of an SSE event for terminal display.
+///
+/// Reads the `actions` array from the event envelope. If no actions are
+/// present (e.g., older events), falls back to hardcoded suggestions for
+/// the known lifecycle events that warrant them.
+fn render_actions_suffix(event_type: &str, json: &serde_json::Value) -> String {
+    // Prefer structured actions from the envelope.
+    if let Some(actions) = json["actions"].as_array() {
+        if !actions.is_empty() {
+            let mut lines = String::new();
+            for action in actions {
+                if let (Some(label), Some(command)) =
+                    (action["label"].as_str(), action["command"].as_str())
+                {
+                    lines.push_str(&format!("\n  {}: {}", label, command));
+                }
+            }
+            return lines;
+        }
+    }
+
+    // Backwards-compat fallback for events without the actions field.
+    match event_type {
+        "goal_completed" => "\n  Next: ta draft list | ta draft view <id>".to_string(),
+        "draft_built" => {
+            let full_id = json["payload"]["draft_id"].as_str().unwrap_or("?");
+            format!(
+                "\n  View:    ta draft view {}\n  Approve: ta draft approve {}\n  Deny:    ta draft deny {}",
+                full_id, full_id, full_id
+            )
+        }
+        "goal_started" => {
+            let goal_id = json["payload"]["goal_id"].as_str().unwrap_or("");
+            if goal_id.len() >= 8 {
+                format!("\n  Tail: ta shell :tail {}", &goal_id[..8])
+            } else {
+                String::new()
+            }
+        }
+        _ => String::new(),
+    }
 }
 
 // -- Rustyline helper --------------------------------------------------------
@@ -783,6 +824,60 @@ mod tests {
         assert!(rendered.contains("goal started"));
         assert!(rendered.contains("Fix auth"));
         assert!(rendered.contains("claude-code"));
+    }
+
+    #[test]
+    fn render_sse_event_uses_structured_actions_when_present() {
+        let frame = concat!(
+            "event: draft_built\n",
+            "data: {",
+            "\"event_type\":\"draft_built\",",
+            "\"payload\":{\"artifact_count\":3,\"draft_id\":\"abc12345-0000-0000-0000-000000000000\"},",
+            "\"actions\":[",
+            "{\"verb\":\"view\",\"command\":\"ta draft view abc12345\",\"label\":\"View draft abc12345\"},",
+            "{\"verb\":\"approve\",\"command\":\"ta draft approve abc12345\",\"label\":\"Approve draft abc12345\"}",
+            "]}"
+        );
+        let rendered = render_sse_event(frame).unwrap();
+        // Should use structured actions, not hardcoded fallback.
+        assert!(rendered.contains("View draft abc12345"));
+        assert!(rendered.contains("ta draft view abc12345"));
+        assert!(rendered.contains("Approve draft abc12345"));
+        assert!(rendered.contains("ta draft approve abc12345"));
+    }
+
+    #[test]
+    fn render_sse_event_falls_back_when_no_actions_field() {
+        // Old-format event without an actions field: should use hardcoded fallback.
+        let frame = concat!(
+            "event: goal_completed\n",
+            "data: {",
+            "\"event_type\":\"goal_completed\",",
+            "\"payload\":{\"title\":\"Fix auth\",\"goal_id\":\"abc12345-dead-beef-cafe-000000000000\",\"duration_secs\":120}",
+            "}"
+        );
+        let rendered = render_sse_event(frame).unwrap();
+        assert!(rendered.contains("goal completed"));
+        assert!(rendered.contains("Fix auth"));
+        // Backwards-compat fallback action should appear.
+        assert!(rendered.contains("ta draft list"));
+    }
+
+    #[test]
+    fn render_sse_event_empty_actions_array_uses_fallback() {
+        // Event with an empty actions array: should fall back to hardcoded suggestions.
+        let frame = concat!(
+            "event: draft_built\n",
+            "data: {",
+            "\"event_type\":\"draft_built\",",
+            "\"payload\":{\"artifact_count\":2,\"draft_id\":\"deadbeef-0000-0000-0000-000000000000\"},",
+            "\"actions\":[]",
+            "}"
+        );
+        let rendered = render_sse_event(frame).unwrap();
+        assert!(rendered.contains("draft ready"));
+        // Backwards-compat fallback should appear since actions list is empty.
+        assert!(rendered.contains("ta draft view"));
     }
 
     #[test]

--- a/crates/ta-events/src/lib.rs
+++ b/crates/ta-events/src/lib.rs
@@ -16,6 +16,6 @@ pub mod tokens;
 pub use bus::{EventBus, EventFilter};
 pub use error::EventError;
 pub use hooks::{HookConfig, HookRunner};
-pub use schema::{EventEnvelope, SessionEvent};
+pub use schema::{EventAction, EventEnvelope, SessionEvent};
 pub use store::{EventStore, FsEventStore};
 pub use tokens::{ApprovalToken, TokenStore};

--- a/crates/ta-events/src/schema.rs
+++ b/crates/ta-events/src/schema.rs
@@ -11,6 +11,36 @@ use uuid::Uuid;
 /// Current schema version. Bumped when backward-incompatible changes are made.
 pub const SCHEMA_VERSION: u32 = 1;
 
+/// A structured action that any interface can render as an actionable next step.
+///
+/// Actions are embedded in event envelopes so that non-CLI interfaces (Discord,
+/// Slack, webapp, email) can present the same actionable suggestions that the
+/// CLI shell currently hardcodes in its renderer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EventAction {
+    /// Machine-readable verb: "view", "approve", "deny", "tail", "list"
+    pub verb: String,
+    /// The CLI command to execute (interface-agnostic)
+    pub command: String,
+    /// Human-readable label for the action
+    pub label: String,
+}
+
+impl EventAction {
+    /// Create a new action.
+    pub fn new(
+        verb: impl Into<String>,
+        command: impl Into<String>,
+        label: impl Into<String>,
+    ) -> Self {
+        Self {
+            verb: verb.into(),
+            command: command.into(),
+            label: label.into(),
+        }
+    }
+}
+
 /// Wrapper around every event with metadata for persistence and routing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventEnvelope {
@@ -24,17 +54,24 @@ pub struct EventEnvelope {
     pub event_type: String,
     /// The event payload.
     pub payload: SessionEvent,
+    /// Structured actions that any interface can render as next steps.
+    /// Most events have an empty list; key lifecycle events populate this.
+    #[serde(default)]
+    pub actions: Vec<EventAction>,
 }
 
 impl EventEnvelope {
     /// Create a new envelope wrapping the given event.
+    /// Actions are automatically derived from the event payload.
     pub fn new(event: SessionEvent) -> Self {
+        let actions = event.suggested_actions();
         Self {
             id: Uuid::new_v4(),
             timestamp: Utc::now(),
             version: SCHEMA_VERSION,
             event_type: event.event_type().to_string(),
             payload: event,
+            actions,
         }
     }
 }
@@ -185,6 +222,50 @@ impl SessionEvent {
             _ => None,
         }
     }
+
+    /// Return structured actions appropriate for this event type.
+    ///
+    /// These are suggested next steps an operator or interface can present
+    /// to the user. Any interface (CLI, Discord, webapp) can render them
+    /// without hardcoding event-specific logic.
+    pub fn suggested_actions(&self) -> Vec<EventAction> {
+        match self {
+            Self::GoalStarted { goal_id, .. } => {
+                let short_id = &goal_id.to_string()[..8];
+                vec![EventAction::new(
+                    "tail",
+                    format!("ta shell :tail {}", short_id),
+                    format!("Tail live output for goal {}", short_id),
+                )]
+            }
+            Self::GoalCompleted { .. } => {
+                vec![EventAction::new("list", "ta draft list", "List all drafts")]
+            }
+            Self::DraftBuilt { draft_id, .. } => {
+                let full_id = draft_id.to_string();
+                let short_id = &full_id[..8];
+                vec![
+                    EventAction::new(
+                        "view",
+                        format!("ta draft view {}", full_id),
+                        format!("View draft {}", short_id),
+                    ),
+                    EventAction::new(
+                        "approve",
+                        format!("ta draft approve {}", full_id),
+                        format!("Approve draft {}", short_id),
+                    ),
+                    EventAction::new(
+                        "deny",
+                        format!("ta draft deny {}", full_id),
+                        format!("Deny draft {}", short_id),
+                    ),
+                ]
+            }
+            // All other events have no suggested actions.
+            _ => vec![],
+        }
+    }
 }
 
 #[cfg(test)]
@@ -202,6 +283,95 @@ mod tests {
         let envelope = EventEnvelope::new(event);
         assert_eq!(envelope.version, SCHEMA_VERSION);
         assert_eq!(envelope.event_type, "goal_started");
+    }
+
+    #[test]
+    fn goal_started_envelope_has_tail_action() {
+        let goal_id = Uuid::new_v4();
+        let event = SessionEvent::GoalStarted {
+            goal_id,
+            title: "Fix auth".into(),
+            agent_id: "claude-code".into(),
+            phase: None,
+        };
+        let envelope = EventEnvelope::new(event);
+        assert_eq!(envelope.actions.len(), 1);
+        assert_eq!(envelope.actions[0].verb, "tail");
+        let short_id = &goal_id.to_string()[..8];
+        assert!(envelope.actions[0].command.contains(short_id));
+    }
+
+    #[test]
+    fn draft_built_envelope_has_view_approve_deny_actions() {
+        let draft_id = Uuid::new_v4();
+        let event = SessionEvent::DraftBuilt {
+            goal_id: Uuid::new_v4(),
+            draft_id,
+            artifact_count: 5,
+        };
+        let envelope = EventEnvelope::new(event);
+        assert_eq!(envelope.actions.len(), 3);
+        let verbs: Vec<&str> = envelope.actions.iter().map(|a| a.verb.as_str()).collect();
+        assert!(verbs.contains(&"view"));
+        assert!(verbs.contains(&"approve"));
+        assert!(verbs.contains(&"deny"));
+        let full_id = draft_id.to_string();
+        for action in &envelope.actions {
+            assert!(action.command.contains(&full_id));
+        }
+    }
+
+    #[test]
+    fn goal_completed_envelope_has_list_action() {
+        let event = SessionEvent::GoalCompleted {
+            goal_id: Uuid::new_v4(),
+            title: "Done".into(),
+            duration_secs: Some(90),
+        };
+        let envelope = EventEnvelope::new(event);
+        assert_eq!(envelope.actions.len(), 1);
+        assert_eq!(envelope.actions[0].verb, "list");
+        assert!(envelope.actions[0].command.contains("ta draft list"));
+    }
+
+    #[test]
+    fn other_events_have_no_actions() {
+        let event = SessionEvent::MemoryStored {
+            key: "k".into(),
+            category: None,
+            source: "cli".into(),
+        };
+        let envelope = EventEnvelope::new(event);
+        assert!(envelope.actions.is_empty());
+    }
+
+    #[test]
+    fn envelope_serialization_includes_actions() {
+        let event = SessionEvent::DraftBuilt {
+            goal_id: Uuid::new_v4(),
+            draft_id: Uuid::new_v4(),
+            artifact_count: 2,
+        };
+        let envelope = EventEnvelope::new(event);
+        let json = serde_json::to_string(&envelope).unwrap();
+        assert!(json.contains("\"actions\""));
+        assert!(json.contains("\"verb\""));
+        assert!(json.contains("\"command\""));
+        assert!(json.contains("\"label\""));
+    }
+
+    #[test]
+    fn envelope_deserialization_backwards_compat_no_actions_field() {
+        // Old events without an `actions` field should deserialize with empty actions.
+        let json = r#"{
+            "id": "00000000-0000-0000-0000-000000000001",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "version": 1,
+            "event_type": "memory_stored",
+            "payload": {"type": "memory_stored", "key": "k", "category": null, "source": "cli"}
+        }"#;
+        let envelope: EventEnvelope = serde_json::from_str(json).unwrap();
+        assert!(envelope.actions.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `EventAction` struct (verb, command, label) to `ta-events` crate
- `EventEnvelope` now includes an `actions` field auto-populated via `SessionEvent::suggested_actions()`
- `goal_started` → tail action, `draft_built` → view/approve/deny actions, `goal_completed` → list drafts action
- Shell's `render_sse_event()` reads actions from payload with fallback to hardcoded strings for backward compat
- Enables Discord, Slack, email, webapp to render interface-appropriate action buttons/links

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes
- [x] `cargo clippy` clean
- [x] Backward compat: old events without `actions` field still render correctly

Co-Authored-By: claude-flow <ruv@ruv.net>