### PR TITLE
v0.9.8 release notes and v0.10.5/v0.10.6 plan

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -3942,6 +3942,111 @@ channels:
 
 ---
 
+### v0.10.5 — External Workflow & Agent Definitions
+<!-- status: pending -->
+**Goal**: Allow workflow definitions and agent configurations to be pulled from external sources (registries, git repos, URLs) so teams and third-party authors can publish reusable configurations. Include an automated release process with press-release generation.
+
+#### Problem
+Today, workflow YAML files and agent configs (`agents/*.yaml`) live only in the project's `.ta/` directory. There's no mechanism to:
+- Share a workflow across multiple projects
+- Publish an agent configuration for others to use (e.g., "security-reviewer" agent with specialized system prompt)
+- Pull in community-authored configurations
+- Generate release communications automatically as part of `ta release`
+
+#### Design
+
+##### 1. External workflow/agent sources
+```bash
+# Pull a workflow from a registry
+ta workflow add security-review --from registry:trustedautonomy/workflows
+ta workflow add deploy-pipeline --from gh:myorg/ta-workflows
+
+# Pull an agent config
+ta agent add security-reviewer --from registry:trustedautonomy/agents
+ta agent add code-auditor --from https://example.com/ta-agents/auditor.yaml
+
+# List installed external configs
+ta workflow list --source external
+ta agent list --source external
+```
+
+##### 2. Workflow/agent package format
+```yaml
+# workflow-package.yaml (published to registry)
+name: security-review
+version: 1.0.0
+author: trustedautonomy
+description: "Multi-step security review workflow with SAST, dependency audit, and manual sign-off"
+ta_version: ">=0.9.8"
+files:
+  - workflows/security-review.yaml
+  - agents/security-reviewer.yaml
+  - policies/security-baseline.yaml
+```
+
+##### 3. Release press-release generation
+The `ta release` process includes an optional press-release authoring step where an agent generates a release announcement from the changelog, guided by a user-provided sample:
+
+```bash
+# Configure a sample press release as the style template
+ta release config set press_release_template ./samples/sample-press-release.md
+
+# During release, the agent generates a press release matching the sample's style
+ta release run --press-release
+
+# The user can update the prompt to refine the output
+ta release run --press-release --prompt "Focus on the workflow engine and VCS adapter features"
+```
+
+The agent reads the changelog/release notes, follows the style and tone of the sample document, and produces a draft press release that goes through the normal TA review process (draft → approve → apply).
+
+##### 4. Workflow authoring and publishing
+```bash
+# Author a new workflow
+ta workflow new deploy-pipeline
+# Edit .ta/workflows/deploy-pipeline.yaml
+
+# Publish to registry
+ta workflow publish deploy-pipeline --registry trustedautonomy
+
+# Version management
+ta workflow publish deploy-pipeline --bump minor
+```
+
+#### Items
+1. [ ] External source resolver: registry, GitHub repo, and raw URL fetching for YAML configs
+2. [ ] `ta workflow add/remove/list` commands with `--from` source parameter
+3. [ ] `ta agent add/remove/list` commands with `--from` source parameter
+4. [ ] Workflow/agent package manifest format (`workflow-package.yaml`)
+5. [ ] Local cache for external configs (`~/.ta/cache/workflows/`, `~/.ta/cache/agents/`)
+6. [ ] Version pinning and update checking for external configs
+7. [ ] `ta release` press-release generation step with sample-based style matching
+8. [ ] Press release template configuration (`ta release config set press_release_template`)
+9. [ ] `ta workflow publish` command for authoring and publishing to registry
+10. [ ] Documentation: authoring guide for workflow/agent packages
+
+#### Version: `0.10.5-alpha`
+
+---
+
+### v0.10.6 — Release Process Hardening
+<!-- status: pending -->
+**Goal**: Fix release process issues and harden the `ta release run` pipeline.
+
+#### Known Bugs
+- **`ta_fs_write` forbidden in orchestrator mode**: The release notes agent tries to write `.release-draft.md` directly but is blocked by orchestrator policy. The agent should either use `ta_goal` to delegate the write, or the orchestrator policy should whitelist release artifact writes. Filed as bug — the process should just work without the agent needing workarounds.
+- **Release notes agent workaround**: Currently the agent works around the `ta_fs_write` restriction by using alternative write methods, but this is fragile and shouldn't be necessary.
+
+#### Items
+1. [ ] Fix `ta_fs_write` permission in orchestrator mode for release artifact files (`.release-draft.md`, `CHANGELOG.md`)
+2. [ ] Add orchestrator-mode write whitelist for release-specific file patterns
+3. [ ] End-to-end test for `ta release run` pipeline without manual intervention
+4. [ ] Release dry-run mode: `ta release run --dry-run` that validates all steps without publishing
+
+#### Version: `0.10.6-alpha`
+
+---
+
 ## Projects On Top (separate repos, built on TA)
 
 > These are NOT part of TA core. They are independent projects that consume TA's extension points.

--- a/docs/releases/v0.9.8-alpha.md
+++ b/docs/releases/v0.9.8-alpha.md
@@ -1,0 +1,185 @@
+# Trusted Autonomy v0.9.8-alpha — Release Notes
+
+**Released**: 2026-03-07
+
+v0.9.8 is a significant release that adds a pluggable workflow engine, an interactive shell for managing goals and agents, Windows build support, and moves all version control operations behind an adapter interface.
+
+---
+
+## What's New
+
+### Pluggable Workflow Engine (v0.9.8.2)
+
+TA now ships a configurable workflow engine that lets you define custom step-based processes for how goals move from creation through review to completion. Workflows are defined in YAML and can be customized per-project.
+
+The built-in `default` workflow covers the standard create → run → review → apply lifecycle. You can define custom workflows with approval gates, notification hooks, and conditional branching.
+
+```yaml
+# .ta/workflows/deploy.yaml
+name: deploy
+steps:
+  - name: build
+    action: ta draft build --latest
+  - name: test
+    action: ta draft verify
+    on_failure: notify
+  - name: review
+    action: ta draft approve
+    requires: [build, test]
+```
+
+### Interactive Shell (`ta shell`) (v0.9.8, v0.9.8.3)
+
+`ta shell` provides a persistent command interface for working with TA. It connects to the local daemon and provides:
+
+- **Unified input routing**: Type commands (`ta draft list`, `git status`) or natural language questions. Commands are routed to execution; free-text goes to an AI agent session for Q&A.
+- **Live event streaming**: Goal progress, draft builds, and completion events appear in real-time via SSE.
+- **Health monitoring**: Automatic reconnect when the daemon restarts. Connection status indicators.
+- **Goal output tailing**: `:tail` attaches to a running goal's stdout/stderr. Auto-attaches when a single goal is active.
+- **Actionable events**: When a draft is built, the shell displays the exact commands to view, approve, or deny it.
+- **TUI mode** (v0.9.8.3): Full terminal UI built on `ratatui` with split panes for events, command input, and goal output.
+
+```
+$ ta shell
+ta> status
+Project: MyApp (v0.3.0-alpha)
+Next phase: v0.3.1 — Add caching layer
+
+ta> run "Add Redis caching to the API" --phase 0.3.1
+[event] goal started: Add Redis caching to the API (agent: claude-code)
+[event] draft built: 3 files changed
+  → ta draft view a1b2c3d4
+  → ta draft approve a1b2c3d4
+  → ta draft deny a1b2c3d4
+
+ta> approve a1b2c3d4
+Approved. Applied 3 files.
+```
+
+### Windows Build Support
+
+TA now builds and passes CI on Windows (MSVC target). The GitHub Actions workflow includes a Windows build job alongside Linux and macOS. PTY-dependent features (interactive agent sessions) are Unix-only; all other functionality works cross-platform.
+
+### VCS Adapter Abstraction (v0.9.8.4)
+
+All version control operations now go through the `SubmitAdapter` trait. This release includes:
+
+- **Git adapter**: Full implementation (branch management, commit, push, PR creation).
+- **SVN adapter**: Stub implementation — `svn add`, `svn commit` mapping. Untested; needs validation by SVN users.
+- **Perforce adapter**: Stub implementation — changelist creation, `p4 reconcile`, `p4 shelve/submit`. Untested; needs validation by Perforce users.
+- **Adapter auto-detection**: TA detects your VCS by checking for `.git/`, `.svn/`, or `P4CONFIG`.
+- **Adapter-contributed excludes**: Each adapter declares which directories to exclude from staging (`.git/`, `.svn/`, etc.), replacing hardcoded patterns.
+
+Configure your adapter in `.ta/workflow.toml`:
+```toml
+[submit]
+adapter = "git"    # or "svn", "perforce", "none"
+auto_commit = true
+auto_push = false
+```
+
+### Structured Event Actions (v0.9.8.1.1)
+
+Event payloads now include machine-readable `actions` arrays so any interface (CLI, Discord, Slack, email, webapp) can render appropriate action buttons. Each action has a `verb`, `command`, and `label`:
+
+```json
+{
+  "event_type": "draft_built",
+  "actions": [
+    {"verb": "view", "command": "ta draft view a1b2c3d4", "label": "View draft"},
+    {"verb": "approve", "command": "ta draft approve a1b2c3d4", "label": "Approve"},
+    {"verb": "deny", "command": "ta draft deny a1b2c3d4", "label": "Deny"}
+  ]
+}
+```
+
+### Unified Allow/Deny Lists (v0.9.8.1.1)
+
+Policy rules, sandbox configurations, and access filters all use the same `AccessFilter` pattern: explicit allow lists, deny lists, and glob matching. This replaces the previous per-subsystem filter implementations.
+
+### Other Improvements
+
+- **Daemon agent sessions**: The daemon spawns real `claude --print` subprocesses for Q&A, with auto-session creation on first use.
+- **Goal state machine fix**: `ta draft apply` now validates state transitions before applying files, preventing silent state corruption.
+- **SSE event replay fix**: Timestamps use `Z` suffix instead of `+00:00` to avoid URL encoding issues that caused old events to replay on shell startup.
+- **Branch restore on apply**: `ta draft apply --git-commit` automatically returns to your original branch after creating the feature branch commit.
+- **Framework registry**: Detect and integrate with project frameworks (Next.js, Rails, Django, etc.) for framework-aware agent configurations.
+
+---
+
+## Quick Start
+
+### Add TA to any project
+
+```bash
+# Install
+curl -fsSL https://raw.githubusercontent.com/trustedautonomy/ta/main/install.sh | bash
+
+# Initialize TA in your project
+cd your-project
+ta init
+ta setup
+```
+
+### Create a development plan
+
+```bash
+# Generate a plan from your project structure
+ta plan init
+
+# Or write one manually — see docs/USAGE.md for the PLAN.md format
+```
+
+### Run your first goal
+
+```bash
+# Start a goal linked to a plan phase
+ta run "Implement user authentication" --phase 1 --source .
+
+# The agent works in an isolated staging copy
+# When it finishes, TA builds a draft of the changes
+
+# Review what the agent produced
+ta draft view --latest
+
+# Apply the changes to your project
+ta draft apply --latest --git-commit
+```
+
+### Use the interactive shell
+
+```bash
+# Start the daemon + shell
+ta daemon start
+ta shell
+
+# Inside the shell, everything is streamlined:
+ta> run "Add input validation" --phase 2
+ta> drafts            # shortcut for 'ta draft list'
+ta> approve abc123    # shortcut for 'ta draft approve'
+ta> status            # project overview
+```
+
+---
+
+## Breaking Changes
+
+None. This release is backwards-compatible with v0.7.x configurations.
+
+---
+
+## Build Targets
+
+| Platform | Status |
+|---|---|
+| Linux (x86_64, aarch64) | Supported |
+| macOS (Intel, Apple Silicon) | Supported |
+| Windows (MSVC) | Supported (new) |
+
+---
+
+## Links
+
+- [User Guide](../USAGE.md)
+- [Development Plan](../../PLAN.md)
+- [GitHub Repository](https://github.com/trustedautonomy/ta)


### PR DESCRIPTION
## Summary
- Release notes for v0.9.8-alpha at `docs/releases/v0.9.8-alpha.md`
- Covers: workflow engine, ta shell, Windows build, VCS adapters, structured actions
- Includes quick start guide for adding TA to any project
- v0.10.5 plan: External workflow/agent definitions, registry support, press-release generation
- v0.10.6 plan: Release process hardening (ta_fs_write orchestrator mode bug)

## Test plan
- [x] Content review

Co-Authored-By: claude-flow <ruv@ruv.net>