### PR TITLE
implement v0.9.9.5 — Workflow & Agent Authoring Tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "chrono",
  "serde",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "chrono",
  "glob",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "chrono",
  "serde",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "chrono",
  "serde",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "chrono",
  "rmcp",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "chrono",
  "serde",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "chrono",
  "glob",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "chrono",
  "glob",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "chrono",
  "serde",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "chrono",
  "serde",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "chrono",
  "serde",
@@ -3153,7 +3153,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.9.9-alpha.4"
+version = "0.9.9-alpha.5"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -3821,7 +3821,7 @@ Human sees question in ta shell / Slack / web UI
 ---
 
 ### v0.9.9.5 — Workflow & Agent Authoring Tooling
-<!-- status: pending -->
+<!-- status: done -->
 **Goal**: Make it easy for users to create, validate, and iterate on custom workflow definitions and agent profiles without reading Rust source code or guessing YAML schema.
 
 #### Problem
@@ -3872,6 +3872,22 @@ Today, creating a custom workflow or agent config requires copying an existing f
    - `ta plan create --version-schema semver` selects a template
    - Schema defines: version format regex, bump rules, phase-to-version mapping
    - Users can write custom schemas in `.ta/version-schema.yaml`
+
+#### Completed
+- [x] `ta workflow new <name>` with annotated scaffold and `--from` template selection
+- [x] `ta workflow validate <path>` with schema, reference, dependency, and agent config validation
+- [x] `ta agent new <name>` with `--type` (developer, auditor, orchestrator, planner) and alignment defaults
+- [x] `ta agent validate <path>` with schema validation and PATH checking
+- [x] Example library: 5 workflow templates, 6 role templates, 4 agent templates
+- [x] `ta workflow list --templates` and `ta agent list --templates` browsing commands
+- [x] Planner workflow role with `plan-implement-review.yaml` template
+- [x] Versioning schema templates: semver, calver, sprint, milestone
+- [x] Validation module in ta-workflow crate with 12 tests
+- [x] Agent CLI command module with 10 tests
+- [x] Workflow CLI new/validate commands with 7 tests
+
+#### Remaining (deferred)
+- [ ] `ta plan create --version-schema` command integration (requires plan create refactor)
 
 #### Version: `0.9.9-alpha.5`
 

--- a/apps/ta-cli/src/commands/agent.rs
+++ b/apps/ta-cli/src/commands/agent.rs
@@ -1,0 +1,475 @@
+// agent.rs — CLI commands for agent config authoring (v0.9.9.5).
+//
+// Commands:
+//   ta agent new <name>             — scaffold a new agent config
+//   ta agent validate <path>        — validate an agent config YAML
+//   ta agent list [--templates]     — list configured agents or browse templates
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+use ta_mcp_gateway::GatewayConfig;
+
+#[derive(Subcommand)]
+pub enum AgentCommands {
+    /// Scaffold a new agent configuration YAML file.
+    New {
+        /// Agent name (used as the file name).
+        name: String,
+        /// Agent type: developer, auditor, orchestrator, planner.
+        #[arg(long, default_value = "developer")]
+        r#type: String,
+    },
+    /// Validate an agent configuration YAML file.
+    Validate {
+        /// Path to the agent config YAML file.
+        path: PathBuf,
+    },
+    /// List configured agents or browse templates.
+    List {
+        /// Show available agent templates instead of configured agents.
+        #[arg(long)]
+        templates: bool,
+    },
+}
+
+pub fn execute(command: &AgentCommands, config: &GatewayConfig) -> anyhow::Result<()> {
+    match command {
+        AgentCommands::New { name, r#type } => new_agent(name, r#type, config),
+        AgentCommands::Validate { path } => validate_agent(path),
+        AgentCommands::List { templates } => {
+            if *templates {
+                list_templates()
+            } else {
+                list_agents(config)
+            }
+        }
+    }
+}
+
+fn new_agent(name: &str, agent_type: &str, config: &GatewayConfig) -> anyhow::Result<()> {
+    let agents_dir = config.workspace_root.join(".ta").join("agents");
+    std::fs::create_dir_all(&agents_dir)?;
+
+    let file_path = agents_dir.join(format!("{}.yaml", name));
+    if file_path.exists() {
+        anyhow::bail!(
+            "Agent config already exists: {}\n\
+             Edit the existing file or choose a different name.",
+            file_path.display()
+        );
+    }
+
+    let content = match agent_type {
+        "developer" => generate_developer_config(name),
+        "auditor" => generate_auditor_config(name),
+        "orchestrator" => generate_orchestrator_config(name),
+        "planner" => generate_planner_config(name),
+        _ => {
+            anyhow::bail!(
+                "Unknown agent type: '{}'\n\
+                 Available types: developer, auditor, orchestrator, planner",
+                agent_type
+            );
+        }
+    };
+
+    std::fs::write(&file_path, &content)?;
+
+    println!("Created agent config: {}", file_path.display());
+    println!("  Type: {}", agent_type);
+    println!();
+    println!("Next steps:");
+    println!("  1. Edit the config to customize for your project");
+    println!("  2. Validate: ta agent validate {}", file_path.display());
+    println!("  3. Use in a workflow role: agent: {}", name);
+
+    Ok(())
+}
+
+fn validate_agent(path: &std::path::Path) -> anyhow::Result<()> {
+    if !path.exists() {
+        anyhow::bail!(
+            "File not found: {}\n\
+             Provide a path to an agent config YAML file.",
+            path.display()
+        );
+    }
+
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", path.display(), e))?;
+
+    let result = ta_workflow::validate::validate_agent_config(&content);
+
+    if result.findings.is_empty() {
+        println!("Agent config is valid: {}", path.display());
+
+        // Show a summary of what was parsed.
+        if let Ok(doc) =
+            serde_yaml::from_str::<std::collections::HashMap<String, serde_yaml::Value>>(&content)
+        {
+            if let Some(serde_yaml::Value::String(name)) = doc.get("name") {
+                println!("  Name: {}", name);
+            }
+            if let Some(serde_yaml::Value::String(cmd)) = doc.get("command") {
+                // Check if command exists on PATH.
+                let on_path = std::process::Command::new("which")
+                    .arg(cmd)
+                    .output()
+                    .map(|o| o.status.success())
+                    .unwrap_or(false);
+                println!(
+                    "  Command: {} {}",
+                    cmd,
+                    if on_path {
+                        "(found on PATH)"
+                    } else {
+                        "(not found on PATH)"
+                    }
+                );
+            }
+        }
+        return Ok(());
+    }
+
+    println!("Validation results for {}:", path.display());
+    println!();
+
+    for finding in &result.findings {
+        let icon = match finding.severity {
+            ta_workflow::validate::ValidationSeverity::Error => "ERROR",
+            ta_workflow::validate::ValidationSeverity::Warning => "WARN ",
+        };
+        println!("  [{}] {}: {}", icon, finding.location, finding.message);
+        if let Some(suggestion) = &finding.suggestion {
+            println!("         -> {}", suggestion);
+        }
+    }
+
+    println!();
+    println!(
+        "  {} error(s), {} warning(s)",
+        result.error_count(),
+        result.warning_count()
+    );
+
+    Ok(())
+}
+
+fn list_agents(config: &GatewayConfig) -> anyhow::Result<()> {
+    let agents_dir = config.workspace_root.join(".ta").join("agents");
+
+    println!("Configured agents:");
+    if agents_dir.exists() {
+        let mut found = false;
+        let mut entries: Vec<_> = std::fs::read_dir(&agents_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .map(|ext| ext == "yaml" || ext == "yml")
+                    .unwrap_or(false)
+            })
+            .collect();
+        entries.sort_by_key(|e| e.file_name());
+
+        for entry in entries {
+            found = true;
+            let name = entry
+                .path()
+                .file_stem()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+
+            // Try to read the command field.
+            let cmd = std::fs::read_to_string(entry.path())
+                .ok()
+                .and_then(|c| {
+                    serde_yaml::from_str::<std::collections::HashMap<String, serde_yaml::Value>>(&c)
+                        .ok()
+                })
+                .and_then(|doc| {
+                    doc.get("command")
+                        .and_then(|v| v.as_str().map(|s| s.to_string()))
+                })
+                .unwrap_or_else(|| "?".to_string());
+
+            println!("  {} (command: {})", name, cmd);
+        }
+
+        if !found {
+            println!("  (none configured)");
+        }
+    } else {
+        println!("  (none configured)");
+    }
+
+    println!();
+    println!("Scaffold a new agent:");
+    println!("  ta agent new my-agent --type developer");
+    println!();
+    println!("Browse templates:");
+    println!("  ta agent list --templates");
+
+    Ok(())
+}
+
+fn list_templates() -> anyhow::Result<()> {
+    println!("Agent templates:");
+    println!();
+    println!("  developer     Full read/write developer agent with test permissions");
+    println!("  auditor       Read-only auditor agent for security/code review");
+    println!("  orchestrator  Multi-agent orchestrator with elevated permissions");
+    println!("  planner       Technical planner focused on decomposition and design");
+    println!();
+    println!("Create from template:");
+    println!("  ta agent new my-agent --type developer");
+    println!("  ta agent new security-bot --type auditor");
+    println!();
+    println!("Template files: templates/agents/");
+
+    Ok(())
+}
+
+fn generate_developer_config(name: &str) -> String {
+    format!(
+        r#"# Agent Configuration: {name}
+# Type: developer — Full read/write access for building features and fixes.
+#
+# Validate: ta agent validate .ta/agents/{name}.yaml
+
+name: {name}
+command: claude
+args_template:
+  - "{{prompt}}"
+
+# Context injection settings.
+injects_context_file: true
+injects_settings: true
+
+# Alignment profile — controls what this agent is allowed to do.
+# alignment:
+#   security_level: checkpoint
+#   allowed_actions:
+#     - read
+#     - write
+#     - execute
+#   forbidden_patterns:
+#     - "rm -rf /"
+#     - "DROP TABLE"
+"#,
+        name = name
+    )
+}
+
+fn generate_auditor_config(name: &str) -> String {
+    format!(
+        r#"# Agent Configuration: {name}
+# Type: auditor — Read-only access for security and code review.
+#
+# Validate: ta agent validate .ta/agents/{name}.yaml
+
+name: {name}
+command: claude
+args_template:
+  - "{{prompt}}"
+
+# Context injection settings.
+injects_context_file: true
+injects_settings: false
+
+# Alignment profile — auditors are read-only by default.
+alignment:
+  security_level: supervised
+  allowed_actions:
+    - read
+    - list
+    - search
+  forbidden_patterns:
+    - "write"
+    - "delete"
+    - "execute"
+"#,
+        name = name
+    )
+}
+
+fn generate_orchestrator_config(name: &str) -> String {
+    format!(
+        r#"# Agent Configuration: {name}
+# Type: orchestrator — Coordinates multiple agents and workflows.
+#
+# Validate: ta agent validate .ta/agents/{name}.yaml
+
+name: {name}
+command: claude
+args_template:
+  - "{{prompt}}"
+
+# Context injection settings.
+injects_context_file: true
+injects_settings: true
+
+# Alignment profile — orchestrators can read, plan, and delegate.
+alignment:
+  security_level: checkpoint
+  allowed_actions:
+    - read
+    - list
+    - search
+    - plan
+    - delegate
+"#,
+        name = name
+    )
+}
+
+fn generate_planner_config(name: &str) -> String {
+    format!(
+        r#"# Agent Configuration: {name}
+# Type: planner — Technical planning, decomposition, and design.
+#
+# Validate: ta agent validate .ta/agents/{name}.yaml
+
+name: {name}
+command: claude
+args_template:
+  - "{{prompt}}"
+
+# Context injection settings.
+injects_context_file: true
+injects_settings: true
+
+# Alignment profile — planners focus on analysis and design.
+alignment:
+  security_level: checkpoint
+  allowed_actions:
+    - read
+    - list
+    - search
+    - plan
+"#,
+        name = name
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_config(dir: &TempDir) -> GatewayConfig {
+        GatewayConfig::for_project(dir.path())
+    }
+
+    #[test]
+    fn new_agent_developer() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        new_agent("test-dev", "developer", &config).unwrap();
+
+        let path = dir.path().join(".ta/agents/test-dev.yaml");
+        assert!(path.exists());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("name: test-dev"));
+        assert!(content.contains("command: claude"));
+        assert!(content.contains("developer"));
+    }
+
+    #[test]
+    fn new_agent_auditor() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        new_agent("test-audit", "auditor", &config).unwrap();
+
+        let path = dir.path().join(".ta/agents/test-audit.yaml");
+        assert!(path.exists());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("auditor"));
+        assert!(content.contains("supervised"));
+    }
+
+    #[test]
+    fn new_agent_planner() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        new_agent("test-plan", "planner", &config).unwrap();
+
+        let path = dir.path().join(".ta/agents/test-plan.yaml");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn new_agent_orchestrator() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        new_agent("test-orch", "orchestrator", &config).unwrap();
+
+        let path = dir.path().join(".ta/agents/test-orch.yaml");
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn new_agent_unknown_type_error() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        let result = new_agent("test", "unknown", &config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn new_agent_already_exists_error() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        new_agent("dup", "developer", &config).unwrap();
+        let result = new_agent("dup", "developer", &config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_valid_agent() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("agent.yaml");
+        std::fs::write(
+            &path,
+            "name: test\ncommand: claude\nargs_template:\n  - \"{prompt}\"\n",
+        )
+        .unwrap();
+        let result = validate_agent(&path);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_invalid_agent() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bad.yaml");
+        std::fs::write(&path, "command: claude\n").unwrap();
+        // Should not error (prints findings instead).
+        let result = validate_agent(&path);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_nonexistent_error() {
+        let result = validate_agent(&PathBuf::from("/no/such/file.yaml"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn list_agents_empty() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        let result = list_agents(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn list_agents_with_configs() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        new_agent("my-agent", "developer", &config).unwrap();
+        let result = list_agents(&config);
+        assert!(result.is_ok());
+    }
+}

--- a/apps/ta-cli/src/commands/mod.rs
+++ b/apps/ta-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod adapter;
+pub mod agent;
 pub mod audit;
 pub mod context;
 pub mod conversation;

--- a/apps/ta-cli/src/commands/workflow.rs
+++ b/apps/ta-cli/src/commands/workflow.rs
@@ -1,11 +1,13 @@
-// workflow.rs — CLI commands for workflow management (v0.9.8.2).
+// workflow.rs — CLI commands for workflow management (v0.9.9.5).
 //
 // Commands:
 //   ta workflow start <definition.yaml>  — start a workflow
 //   ta workflow status [workflow_id]      — show status
-//   ta workflow list                      — list workflows
+//   ta workflow list [--templates]        — list workflows or browse templates
 //   ta workflow cancel <workflow_id>      — cancel a workflow
 //   ta workflow history <workflow_id>     — show stage transitions
+//   ta workflow new <name>               — scaffold a new workflow definition
+//   ta workflow validate <path>          — validate a workflow definition
 
 use std::path::PathBuf;
 
@@ -26,7 +28,11 @@ pub enum WorkflowCommands {
         workflow_id: Option<String>,
     },
     /// List all workflows (active and completed).
-    List,
+    List {
+        /// Show available workflow templates instead of active workflows.
+        #[arg(long)]
+        templates: bool,
+    },
     /// Cancel a running workflow.
     Cancel {
         /// Workflow ID to cancel.
@@ -37,15 +43,36 @@ pub enum WorkflowCommands {
         /// Workflow ID.
         workflow_id: String,
     },
+    /// Scaffold a new workflow definition YAML file.
+    New {
+        /// Workflow name (used as the file name and workflow name field).
+        name: String,
+        /// Start from a built-in template instead of the default scaffold.
+        #[arg(long)]
+        from: Option<String>,
+    },
+    /// Validate a workflow definition YAML file.
+    Validate {
+        /// Path to the workflow definition YAML file.
+        path: PathBuf,
+    },
 }
 
-pub fn execute(command: &WorkflowCommands, _config: &GatewayConfig) -> anyhow::Result<()> {
+pub fn execute(command: &WorkflowCommands, config: &GatewayConfig) -> anyhow::Result<()> {
     match command {
         WorkflowCommands::Start { definition } => start_workflow(definition),
         WorkflowCommands::Status { workflow_id } => show_status(workflow_id.as_deref()),
-        WorkflowCommands::List => list_workflows(),
+        WorkflowCommands::List { templates } => {
+            if *templates {
+                list_templates()
+            } else {
+                list_workflows()
+            }
+        }
         WorkflowCommands::Cancel { workflow_id } => cancel_workflow(workflow_id),
         WorkflowCommands::History { workflow_id } => show_history(workflow_id),
+        WorkflowCommands::New { name, from } => new_workflow(name, from.as_deref(), config),
+        WorkflowCommands::Validate { path } => validate_workflow_cmd(path, config),
     }
 }
 
@@ -54,7 +81,8 @@ fn start_workflow(definition_path: &std::path::Path) -> anyhow::Result<()> {
         anyhow::bail!(
             "Workflow definition not found: {}\n\
              Create a workflow YAML file or use a built-in template:\n  \
-             ls templates/workflows/",
+             ta workflow new my-workflow\n  \
+             ta workflow list --templates",
             definition_path.display()
         );
     }
@@ -62,9 +90,11 @@ fn start_workflow(definition_path: &std::path::Path) -> anyhow::Result<()> {
     let def = WorkflowDefinition::from_file(definition_path).map_err(|e| {
         anyhow::anyhow!(
             "Failed to parse {}: {}\n\
-             Check the YAML syntax and ensure all required fields are present.",
+             Check the YAML syntax and ensure all required fields are present.\n\
+             Run: ta workflow validate {}",
             definition_path.display(),
-            e
+            e,
+            definition_path.display()
         )
     })?;
 
@@ -129,10 +159,37 @@ fn list_workflows() -> anyhow::Result<()> {
     println!("Active workflows:");
     println!("  (No workflows running. Start one with: ta workflow start <definition.yaml>)");
     println!();
-    println!("Built-in templates:");
-    println!("  templates/workflows/simple-review.yaml     — 2-stage build + review");
-    println!("  templates/workflows/milestone-review.yaml  — full plan/build/review cycle");
-    println!("  templates/workflows/security-audit.yaml    — security-focused audit");
+    println!("Scaffold a new workflow:");
+    println!("  ta workflow new my-workflow");
+    println!();
+    println!("Browse built-in templates:");
+    println!("  ta workflow list --templates");
+    Ok(())
+}
+
+fn list_templates() -> anyhow::Result<()> {
+    println!("Workflow templates:");
+    println!();
+    println!("  simple-review        2-stage build + review");
+    println!("  security-audit       3-stage scan, review, remediate");
+    println!("  milestone-review     4-stage plan, build, review, approval");
+    println!("  deploy-pipeline      3-stage build, test, deploy with gates");
+    println!("  plan-implement-review  Planner-driven loop with iterative review");
+    println!();
+    println!("Use a template:");
+    println!("  ta workflow new my-workflow --from simple-review");
+    println!();
+    println!("Template files: templates/workflows/");
+    println!();
+    println!("Role templates:");
+    println!("  engineer          Software engineer role");
+    println!("  reviewer          Code reviewer role");
+    println!("  security-reviewer Security-focused reviewer");
+    println!("  planner           Technical planner role");
+    println!("  pm                Project manager role");
+    println!("  orchestrator      Multi-agent orchestrator role");
+    println!();
+    println!("Role files: templates/workflows/roles/");
     Ok(())
 }
 
@@ -150,6 +207,583 @@ fn show_history(workflow_id: &str) -> anyhow::Result<()> {
     println!("  (Workflow history requires daemon connection. Start with: ta-daemon --api --project-root .)");
     Ok(())
 }
+
+/// Scaffold a new workflow definition.
+fn new_workflow(
+    name: &str,
+    from_template: Option<&str>,
+    config: &GatewayConfig,
+) -> anyhow::Result<()> {
+    let workflows_dir = config.workspace_root.join(".ta").join("workflows");
+    std::fs::create_dir_all(&workflows_dir)?;
+
+    let file_path = workflows_dir.join(format!("{}.yaml", name));
+    if file_path.exists() {
+        anyhow::bail!(
+            "Workflow already exists: {}\n\
+             Edit the existing file or choose a different name.",
+            file_path.display()
+        );
+    }
+
+    let content = if let Some(template_name) = from_template {
+        // Try to find the template.
+        let template_path = config
+            .workspace_root
+            .join("templates")
+            .join("workflows")
+            .join(format!("{}.yaml", template_name));
+        if template_path.exists() {
+            std::fs::read_to_string(&template_path).map_err(|e| {
+                anyhow::anyhow!("Failed to read template {}: {}", template_path.display(), e)
+            })?
+        } else {
+            // Fall back to built-in templates.
+            match template_name {
+                "simple-review" => TEMPLATE_SIMPLE_REVIEW.to_string(),
+                "security-audit" => TEMPLATE_SECURITY_AUDIT.to_string(),
+                "milestone-review" => TEMPLATE_MILESTONE_REVIEW.to_string(),
+                "deploy-pipeline" => TEMPLATE_DEPLOY_PIPELINE.to_string(),
+                "plan-implement-review" => TEMPLATE_PLAN_IMPLEMENT_REVIEW.to_string(),
+                _ => {
+                    anyhow::bail!(
+                        "Unknown template: '{}'\n\
+                         Available templates: simple-review, security-audit, milestone-review, deploy-pipeline, plan-implement-review\n\
+                         List all: ta workflow list --templates",
+                        template_name
+                    );
+                }
+            }
+        }
+    } else {
+        generate_scaffold(name)
+    };
+
+    std::fs::write(&file_path, &content)?;
+
+    println!("Created workflow: {}", file_path.display());
+
+    // Parse the generated workflow and check for missing agent configs.
+    if let Ok(def) = WorkflowDefinition::from_file(&file_path) {
+        let agents_dir = config.workspace_root.join(".ta").join("agents");
+        let missing_agents = find_missing_agents(&def, &agents_dir);
+        if !missing_agents.is_empty() {
+            println!();
+            println!("Missing agent configs (create them to complete setup):");
+            for (agent_name, agent_type) in &missing_agents {
+                println!("  ta agent new {} --type {}", agent_name, agent_type);
+            }
+        }
+    }
+
+    println!();
+    println!("Next steps:");
+    println!("  1. Edit the workflow definition to match your needs");
+    println!(
+        "  2. Validate: ta workflow validate {}",
+        file_path.display()
+    );
+    println!("  3. Start:    ta workflow start {}", file_path.display());
+
+    Ok(())
+}
+
+/// Find agent names referenced in workflow roles that have no .ta/agents/<name>.yaml.
+/// Returns (agent_name, suggested_type) pairs.
+fn find_missing_agents(
+    def: &WorkflowDefinition,
+    agents_dir: &std::path::Path,
+) -> Vec<(String, String)> {
+    let mut seen = std::collections::HashSet::new();
+    let mut missing = Vec::new();
+
+    for (role_name, role_def) in &def.roles {
+        if seen.contains(&role_def.agent) {
+            continue;
+        }
+        seen.insert(role_def.agent.clone());
+
+        let agent_path = agents_dir.join(format!("{}.yaml", role_def.agent));
+        if !agent_path.exists() {
+            // Guess agent type from role name / prompt content.
+            let agent_type = guess_agent_type(role_name, &role_def.prompt);
+            missing.push((role_def.agent.clone(), agent_type));
+        }
+    }
+
+    missing
+}
+
+/// Guess an agent type from the role name and prompt.
+fn guess_agent_type(role_name: &str, prompt: &str) -> String {
+    let lower_name = role_name.to_lowercase();
+    let lower_prompt = prompt.to_lowercase();
+
+    if lower_name.contains("review")
+        || lower_name.contains("audit")
+        || lower_name.contains("security")
+        || lower_name.contains("scanner")
+    {
+        "auditor".to_string()
+    } else if lower_name.contains("plan") || lower_prompt.contains("planner") {
+        "planner".to_string()
+    } else if lower_name.contains("orchestrat") || lower_prompt.contains("coordinate") {
+        "orchestrator".to_string()
+    } else {
+        "developer".to_string()
+    }
+}
+
+/// Generate a scaffold workflow YAML with annotated comments.
+fn generate_scaffold(name: &str) -> String {
+    format!(
+        r#"# {name} — Custom workflow definition.
+#
+# Usage:
+#   ta workflow start .ta/workflows/{name}.yaml
+#
+# Validate before running:
+#   ta workflow validate .ta/workflows/{name}.yaml
+
+name: {name}
+
+# Stages execute in dependency order. Each stage runs its assigned roles
+# in parallel, then runs 'then' roles sequentially.
+stages:
+  - name: build
+    # Roles that execute in parallel within this stage.
+    roles: [engineer]
+    # When to pause for human input: never | always | on_fail
+    await_human: never
+
+  - name: review
+    # This stage waits for 'build' to complete first.
+    depends_on: [build]
+    roles: [reviewer]
+    await_human: on_fail
+    # Where to route if this stage fails review.
+    on_fail:
+      route_to: build
+      max_retries: 2
+
+# Role definitions — each role maps to an agent with a system prompt.
+# The agent field references a config in .ta/agents/<agent>.yaml.
+roles:
+  engineer:
+    agent: claude-code
+    prompt: |
+      You are a software engineer. Implement the requested changes
+      following the project's coding standards. Write tests for your changes.
+
+  reviewer:
+    agent: claude-code
+    prompt: |
+      You are a code reviewer. Review the implementation for:
+      - Correctness and completeness
+      - Test coverage
+      - Security issues
+      - Code style consistency
+      Provide a verdict with specific findings.
+
+# Verdict scoring (optional). Controls when stages pass or fail.
+verdict:
+  # Minimum aggregate score (0.0-1.0) to pass.
+  pass_threshold: 0.7
+  # Roles whose pass is required regardless of aggregate score.
+  # required_pass: [security-reviewer]
+"#,
+        name = name
+    )
+}
+
+/// Validate a workflow definition and print results.
+fn validate_workflow_cmd(path: &std::path::Path, config: &GatewayConfig) -> anyhow::Result<()> {
+    if !path.exists() {
+        anyhow::bail!(
+            "File not found: {}\n\
+             Provide a path to a workflow YAML file.",
+            path.display()
+        );
+    }
+
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", path.display(), e))?;
+
+    let def = match WorkflowDefinition::from_yaml(&content) {
+        Ok(d) => d,
+        Err(e) => {
+            println!("YAML parse error in {}:", path.display());
+            println!("  {}", e);
+            println!();
+            println!("Fix the YAML syntax and try again.");
+            return Ok(());
+        }
+    };
+
+    let result = ta_workflow::validate::validate_workflow(&def, Some(&config.workspace_root));
+
+    if result.findings.is_empty() {
+        println!("Workflow '{}' is valid.", def.name);
+        if let Ok(order) = def.stage_order() {
+            println!("  Stages: {}", order.join(" -> "));
+        }
+        println!("  Roles:  {}", def.roles.len());
+
+        // Even when valid, check for missing agent configs.
+        let agents_dir = config.workspace_root.join(".ta").join("agents");
+        let missing = find_missing_agents(&def, &agents_dir);
+        if !missing.is_empty() {
+            println!();
+            println!("Create missing agent configs:");
+            for (agent_name, agent_type) in &missing {
+                println!("  ta agent new {} --type {}", agent_name, agent_type);
+            }
+        }
+
+        return Ok(());
+    }
+
+    println!(
+        "Validation results for '{}' ({}):",
+        def.name,
+        path.display()
+    );
+    println!();
+
+    for finding in &result.findings {
+        let icon = match finding.severity {
+            ta_workflow::validate::ValidationSeverity::Error => "ERROR",
+            ta_workflow::validate::ValidationSeverity::Warning => "WARN ",
+        };
+        println!("  [{}] {}: {}", icon, finding.location, finding.message);
+        if let Some(suggestion) = &finding.suggestion {
+            println!("         -> {}", suggestion);
+        }
+    }
+
+    println!();
+    println!(
+        "  {} error(s), {} warning(s)",
+        result.error_count(),
+        result.warning_count()
+    );
+
+    if result.has_errors() {
+        println!();
+        println!("Fix errors before starting this workflow.");
+    }
+
+    // Show consolidated missing-agents summary with ready-to-run commands.
+    let agents_dir = config.workspace_root.join(".ta").join("agents");
+    let missing = find_missing_agents(&def, &agents_dir);
+    if !missing.is_empty() {
+        println!();
+        println!("Create missing agent configs:");
+        for (agent_name, agent_type) in &missing {
+            println!("  ta agent new {} --type {}", agent_name, agent_type);
+        }
+    }
+
+    Ok(())
+}
+
+// Built-in template strings for when template files aren't on disk.
+const TEMPLATE_SIMPLE_REVIEW: &str = r#"# simple-review — Minimal 2-stage workflow: build + review.
+#
+# Usage:
+#   ta workflow start .ta/workflows/simple-review.yaml
+
+name: simple-review
+
+stages:
+  - name: build
+    roles: [engineer]
+    await_human: never
+
+  - name: review
+    depends_on: [build]
+    roles: [reviewer]
+    await_human: on_fail
+    on_fail:
+      route_to: build
+      max_retries: 2
+
+roles:
+  engineer:
+    agent: claude-code
+    prompt: |
+      You are a software engineer. Implement the requested feature or fix
+      following the project's coding standards. Write tests for your changes.
+
+  reviewer:
+    agent: claude-code
+    prompt: |
+      You are a code reviewer. Review the implementation for:
+      - Correctness and completeness
+      - Test coverage
+      - Security issues
+      - Code style consistency
+      Provide a verdict with specific findings.
+
+verdict:
+  pass_threshold: 0.7
+"#;
+
+const TEMPLATE_SECURITY_AUDIT: &str = r#"# security-audit — Security-focused workflow with OWASP reviewer.
+#
+# Usage:
+#   ta workflow start .ta/workflows/security-audit.yaml
+
+name: security-audit
+
+stages:
+  - name: scan
+    roles: [scanner]
+    await_human: never
+
+  - name: review
+    depends_on: [scan]
+    roles: [owasp-reviewer, dependency-scanner]
+    await_human: on_fail
+    on_fail:
+      route_to: remediate
+      max_retries: 3
+
+  - name: remediate
+    depends_on: [review]
+    roles: [engineer]
+    await_human: never
+    on_fail:
+      route_to: review
+      max_retries: 2
+
+roles:
+  scanner:
+    agent: claude-code
+    prompt: |
+      You are a security scanner. Analyze the codebase for:
+      - OWASP Top 10 vulnerabilities
+      - Hardcoded credentials or secrets
+      - Insecure configurations
+      - Known CVEs in dependencies
+      Output structured findings with severity ratings.
+
+  owasp-reviewer:
+    agent: claude-code
+    prompt: |
+      You are an OWASP security expert. Review the scan results and
+      verify each finding. Classify by OWASP category (A01-A10).
+      Identify false positives and prioritize remediation.
+
+  dependency-scanner:
+    agent: claude-code
+    prompt: |
+      You are a dependency security analyst. Check all dependencies
+      for known vulnerabilities. Recommend version updates or
+      alternative packages where needed.
+
+  engineer:
+    agent: claude-code
+    prompt: |
+      You are a security engineer. Fix the identified vulnerabilities.
+      Prioritize critical findings first. Ensure fixes don't introduce
+      regressions. Add tests for security-sensitive code paths.
+
+verdict:
+  pass_threshold: 0.8
+  required_pass: [owasp-reviewer]
+"#;
+
+const TEMPLATE_MILESTONE_REVIEW: &str = r#"# milestone-review — Full plan/build/review workflow.
+#
+# Usage:
+#   ta workflow start .ta/workflows/milestone-review.yaml
+
+name: milestone-review
+
+stages:
+  - name: planning
+    roles: [planner]
+    await_human: always
+
+  - name: build
+    depends_on: [planning]
+    roles: [engineer]
+    await_human: never
+
+  - name: review
+    depends_on: [build]
+    roles: [reviewer, security-reviewer]
+    await_human: on_fail
+    on_fail:
+      route_to: build
+      max_retries: 3
+
+  - name: approval
+    depends_on: [review]
+    roles: [pm]
+    await_human: always
+
+roles:
+  planner:
+    agent: claude-code
+    prompt: |
+      You are a technical planner. Break down the milestone into
+      concrete implementation tasks. Identify risks and dependencies.
+      Output a structured plan with task descriptions and ordering.
+
+  engineer:
+    agent: claude-code
+    prompt: |
+      You are a software engineer. Implement the tasks from the plan.
+      Follow the project's coding standards. Write tests for all changes.
+
+  reviewer:
+    agent: claude-code
+    prompt: |
+      You are a code reviewer. Review the implementation for correctness,
+      test coverage, and code quality.
+
+  security-reviewer:
+    agent: claude-code
+    prompt: |
+      You are a security reviewer. Focus on input validation, auth,
+      data exposure, and dependency vulnerabilities.
+
+  pm:
+    agent: claude-code
+    prompt: |
+      You are a project manager. Review the completed work against
+      the original milestone goals. Approve or request revisions.
+
+verdict:
+  pass_threshold: 0.7
+  required_pass: [security-reviewer]
+"#;
+
+const TEMPLATE_DEPLOY_PIPELINE: &str = r#"# deploy-pipeline — Build, test, and deploy with human gates.
+#
+# Usage:
+#   ta workflow start .ta/workflows/deploy-pipeline.yaml
+
+name: deploy-pipeline
+
+stages:
+  - name: build
+    roles: [engineer]
+    await_human: never
+
+  - name: test
+    depends_on: [build]
+    roles: [tester, security-reviewer]
+    await_human: on_fail
+    on_fail:
+      route_to: build
+      max_retries: 2
+
+  - name: deploy
+    depends_on: [test]
+    roles: [deployer]
+    await_human: always
+
+roles:
+  engineer:
+    agent: claude-code
+    prompt: |
+      You are a software engineer. Build and prepare the release.
+      Ensure all compilation, linting, and formatting checks pass.
+
+  tester:
+    agent: claude-code
+    prompt: |
+      You are a QA engineer. Run the full test suite and verify:
+      - All existing tests pass
+      - New code has adequate test coverage
+      - Integration tests cover critical paths
+      Report any failures with reproduction steps.
+
+  security-reviewer:
+    agent: claude-code
+    prompt: |
+      You are a security reviewer. Audit the changes for security
+      implications before deployment. Check for leaked secrets,
+      insecure defaults, and OWASP Top 10 issues.
+
+  deployer:
+    agent: claude-code
+    prompt: |
+      You are a deployment engineer. Prepare the deployment:
+      - Generate release notes
+      - Verify version bumps
+      - Check deployment prerequisites
+      - Document rollback procedures
+
+verdict:
+  pass_threshold: 0.8
+  required_pass: [security-reviewer]
+"#;
+
+const TEMPLATE_PLAN_IMPLEMENT_REVIEW: &str = r#"# plan-implement-review — Planner-driven workflow with iterative review.
+#
+# Uses the planner role to decompose objectives, then routes through
+# implementation and review stages. On review failure, routes back to
+# the planner to revise the approach.
+#
+# Usage:
+#   ta workflow start .ta/workflows/plan-implement-review.yaml
+
+name: plan-implement-review
+
+stages:
+  - name: plan
+    roles: [planner]
+    await_human: always
+
+  - name: implement
+    depends_on: [plan]
+    roles: [engineer]
+    await_human: never
+
+  - name: review
+    depends_on: [implement]
+    roles: [reviewer]
+    await_human: on_fail
+    on_fail:
+      route_to: plan
+      max_retries: 3
+
+roles:
+  planner:
+    agent: claude-code
+    prompt: |
+      You are a technical planner. Given an objective or document:
+      1. Break it down into concrete implementation tasks
+      2. Identify risks, dependencies, and acceptance criteria
+      3. Order tasks by dependency and priority
+      4. Output a structured plan
+
+      If this is a re-plan after review failure, incorporate the feedback
+      and adjust the approach. Focus on the specific issues raised.
+
+  engineer:
+    agent: claude-code
+    prompt: |
+      You are a software engineer. Follow the plan from the planning stage.
+      Implement each task in order. Write tests for all changes.
+      Commit in logical working units.
+
+  reviewer:
+    agent: claude-code
+    prompt: |
+      You are a code reviewer. Review the implementation against the plan:
+      - Were all planned tasks completed?
+      - Is the code correct and well-tested?
+      - Are there security or quality issues?
+      Provide specific, actionable findings.
+
+verdict:
+  pass_threshold: 0.7
+"#;
 
 #[cfg(test)]
 mod tests {
@@ -189,5 +823,90 @@ roles:
         .unwrap();
         let result = start_workflow(&path);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn new_workflow_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = GatewayConfig::for_project(dir.path());
+        new_workflow("test-wf", None, &config).unwrap();
+
+        let path = dir.path().join(".ta/workflows/test-wf.yaml");
+        assert!(path.exists());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("name: test-wf"));
+        assert!(content.contains("stages:"));
+        assert!(content.contains("roles:"));
+    }
+
+    #[test]
+    fn new_workflow_from_template() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = GatewayConfig::for_project(dir.path());
+        new_workflow("my-review", Some("simple-review"), &config).unwrap();
+
+        let path = dir.path().join(".ta/workflows/my-review.yaml");
+        assert!(path.exists());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("simple-review"));
+    }
+
+    #[test]
+    fn new_workflow_unknown_template_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = GatewayConfig::for_project(dir.path());
+        let result = new_workflow("test", Some("nonexistent"), &config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn new_workflow_already_exists_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = GatewayConfig::for_project(dir.path());
+        new_workflow("dup", None, &config).unwrap();
+        let result = new_workflow("dup", None, &config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_valid_workflow() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("valid.yaml");
+        std::fs::write(
+            &path,
+            r#"
+name: valid
+stages:
+  - name: build
+    roles: [engineer]
+roles:
+  engineer:
+    agent: claude-code
+    prompt: Build it
+"#,
+        )
+        .unwrap();
+        let config = GatewayConfig::for_project(dir.path());
+        let result = validate_workflow_cmd(&path, &config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_nonexistent_file_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = GatewayConfig::for_project(dir.path());
+        let result = validate_workflow_cmd(&PathBuf::from("/no/such/file.yaml"), &config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn scaffold_contains_annotations() {
+        let content = generate_scaffold("my-workflow");
+        assert!(content.contains("# my-workflow"));
+        assert!(content.contains("ta workflow validate"));
+        assert!(content.contains("depends_on:"));
+        assert!(content.contains("await_human:"));
+        assert!(content.contains("on_fail:"));
+        assert!(content.contains("verdict:"));
     }
 }

--- a/apps/ta-cli/src/main.rs
+++ b/apps/ta-cli/src/main.rs
@@ -162,6 +162,11 @@ enum Commands {
         #[command(subcommand)]
         command: commands::init::InitCommands,
     },
+    /// Author, validate, and manage agent configurations.
+    Agent {
+        #[command(subcommand)]
+        command: commands::agent::AgentCommands,
+    },
     /// Manage agent adapter integrations.
     Adapter {
         #[command(subcommand)]
@@ -394,6 +399,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Plan { command } => commands::plan::execute(command, &config),
         Commands::Context { command } => commands::context::execute(command, &config),
         Commands::Credentials { command } => commands::credentials::execute(command, &config),
+        Commands::Agent { command } => commands::agent::execute(command, &config),
         Commands::Adapter { command } => commands::adapter::execute(command, &project_root),
         Commands::Setup { command } => commands::setup::execute(command, &config),
         Commands::Init { command } => commands::init::execute(command, &config),

--- a/crates/ta-workflow/src/lib.rs
+++ b/crates/ta-workflow/src/lib.rs
@@ -11,6 +11,7 @@ pub mod error;
 pub mod interaction;
 pub mod process_engine;
 pub mod scorer;
+pub mod validate;
 pub mod verdict;
 pub mod yaml_engine;
 

--- a/crates/ta-workflow/src/validate.rs
+++ b/crates/ta-workflow/src/validate.rs
@@ -1,0 +1,628 @@
+// validate.rs — Workflow definition validation (v0.9.9.5).
+//
+// Provides structural, reference, and dependency validation for workflow
+// YAML definitions and agent config YAML files.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use crate::definition::WorkflowDefinition;
+
+/// A single validation finding.
+#[derive(Debug, Clone)]
+pub struct ValidationFinding {
+    /// Severity: error, warning.
+    pub severity: ValidationSeverity,
+    /// Which field or element triggered this finding.
+    pub location: String,
+    /// Human-readable description.
+    pub message: String,
+    /// Suggested fix.
+    pub suggestion: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidationSeverity {
+    Error,
+    Warning,
+}
+
+impl std::fmt::Display for ValidationSeverity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValidationSeverity::Error => write!(f, "error"),
+            ValidationSeverity::Warning => write!(f, "warning"),
+        }
+    }
+}
+
+/// Result of validating a workflow definition.
+#[derive(Debug)]
+pub struct ValidationResult {
+    pub findings: Vec<ValidationFinding>,
+}
+
+impl ValidationResult {
+    pub fn has_errors(&self) -> bool {
+        self.findings
+            .iter()
+            .any(|f| f.severity == ValidationSeverity::Error)
+    }
+
+    pub fn error_count(&self) -> usize {
+        self.findings
+            .iter()
+            .filter(|f| f.severity == ValidationSeverity::Error)
+            .count()
+    }
+
+    pub fn warning_count(&self) -> usize {
+        self.findings
+            .iter()
+            .filter(|f| f.severity == ValidationSeverity::Warning)
+            .count()
+    }
+}
+
+/// Validate a workflow definition comprehensively.
+///
+/// Checks:
+/// 1. Schema: required fields, non-empty name, at least one stage
+/// 2. References: every role in a stage exists in `roles:`
+/// 3. Dependencies: no cycles, no references to undefined stages
+/// 4. Agent configs: every `roles.*.agent` has a matching config file (optional)
+pub fn validate_workflow(
+    def: &WorkflowDefinition,
+    project_root: Option<&Path>,
+) -> ValidationResult {
+    let mut findings = Vec::new();
+
+    // 1. Schema validation
+    if def.name.trim().is_empty() {
+        findings.push(ValidationFinding {
+            severity: ValidationSeverity::Error,
+            location: "name".to_string(),
+            message: "Workflow name is empty.".to_string(),
+            suggestion: Some("Add a descriptive name for this workflow.".to_string()),
+        });
+    }
+
+    if def.stages.is_empty() {
+        findings.push(ValidationFinding {
+            severity: ValidationSeverity::Error,
+            location: "stages".to_string(),
+            message: "Workflow has no stages defined.".to_string(),
+            suggestion: Some("Add at least one stage to the workflow.".to_string()),
+        });
+    }
+
+    // Check for duplicate stage names.
+    let mut seen_stages: HashSet<&str> = HashSet::new();
+    for stage in &def.stages {
+        if !seen_stages.insert(stage.name.as_str()) {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Error,
+                location: format!("stages.{}", stage.name),
+                message: format!("Duplicate stage name: '{}'.", stage.name),
+                suggestion: Some("Each stage must have a unique name.".to_string()),
+            });
+        }
+    }
+
+    // Check for stages with empty names.
+    for (i, stage) in def.stages.iter().enumerate() {
+        if stage.name.trim().is_empty() {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Error,
+                location: format!("stages[{}].name", i),
+                message: "Stage has an empty name.".to_string(),
+                suggestion: Some("Give this stage a descriptive name.".to_string()),
+            });
+        }
+
+        // Stages should reference at least one role.
+        if stage.roles.is_empty() && stage.then.is_empty() {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Warning,
+                location: format!("stages.{}", stage.name),
+                message: format!("Stage '{}' has no roles assigned.", stage.name),
+                suggestion: Some(
+                    "Add roles to execute in this stage, or use 'then' for sequential roles."
+                        .to_string(),
+                ),
+            });
+        }
+    }
+
+    // 2. Reference validation: every role used in a stage must be defined.
+    let defined_roles: HashSet<&str> = def.roles.keys().map(|k| k.as_str()).collect();
+    let stage_names: HashSet<&str> = def.stages.iter().map(|s| s.name.as_str()).collect();
+
+    for stage in &def.stages {
+        for role in stage.roles.iter().chain(stage.then.iter()) {
+            if !defined_roles.contains(role.as_str()) {
+                findings.push(ValidationFinding {
+                    severity: ValidationSeverity::Error,
+                    location: format!("stages.{}.roles", stage.name),
+                    message: format!(
+                        "Stage '{}' references undefined role '{}'.",
+                        stage.name, role
+                    ),
+                    suggestion: Some(format!(
+                        "Add '{}' to the 'roles:' section or remove it from this stage.",
+                        role
+                    )),
+                });
+            }
+        }
+
+        // Check review.reviewers references.
+        if let Some(review) = &stage.review {
+            for reviewer in &review.reviewers {
+                if !defined_roles.contains(reviewer.as_str()) {
+                    findings.push(ValidationFinding {
+                        severity: ValidationSeverity::Error,
+                        location: format!("stages.{}.review.reviewers", stage.name),
+                        message: format!(
+                            "Stage '{}' review references undefined role '{}'.",
+                            stage.name, reviewer
+                        ),
+                        suggestion: Some(format!("Add '{}' to the 'roles:' section.", reviewer)),
+                    });
+                }
+            }
+        }
+
+        // Check on_fail.route_to references a valid stage.
+        if let Some(on_fail) = &stage.on_fail {
+            if !stage_names.contains(on_fail.route_to.as_str()) {
+                findings.push(ValidationFinding {
+                    severity: ValidationSeverity::Error,
+                    location: format!("stages.{}.on_fail.route_to", stage.name),
+                    message: format!(
+                        "Stage '{}' routes failures to undefined stage '{}'.",
+                        stage.name, on_fail.route_to
+                    ),
+                    suggestion: Some(format!(
+                        "Change route_to to one of: {}",
+                        stage_names.iter().copied().collect::<Vec<_>>().join(", ")
+                    )),
+                });
+            }
+        }
+
+        // Check depends_on references.
+        for dep in &stage.depends_on {
+            if !stage_names.contains(dep.as_str()) {
+                findings.push(ValidationFinding {
+                    severity: ValidationSeverity::Error,
+                    location: format!("stages.{}.depends_on", stage.name),
+                    message: format!(
+                        "Stage '{}' depends on undefined stage '{}'.",
+                        stage.name, dep
+                    ),
+                    suggestion: Some(format!(
+                        "Available stages: {}",
+                        stage_names.iter().copied().collect::<Vec<_>>().join(", ")
+                    )),
+                });
+            }
+        }
+    }
+
+    // Check for unused roles (warning only).
+    let mut used_roles: HashSet<&str> = HashSet::new();
+    for stage in &def.stages {
+        for role in stage.roles.iter().chain(stage.then.iter()) {
+            used_roles.insert(role.as_str());
+        }
+        if let Some(review) = &stage.review {
+            for reviewer in &review.reviewers {
+                used_roles.insert(reviewer.as_str());
+            }
+        }
+    }
+    if let Some(verdict) = &def.verdict {
+        for rp in &verdict.required_pass {
+            used_roles.insert(rp.as_str());
+        }
+    }
+    for role_name in defined_roles.difference(&used_roles) {
+        findings.push(ValidationFinding {
+            severity: ValidationSeverity::Warning,
+            location: format!("roles.{}", role_name),
+            message: format!(
+                "Role '{}' is defined but never used in any stage.",
+                role_name
+            ),
+            suggestion: Some("Remove unused roles or add them to a stage.".to_string()),
+        });
+    }
+
+    // 3. Dependency validation: check for cycles.
+    match def.stage_order() {
+        Ok(_) => {}
+        Err(crate::WorkflowError::CycleDetected { stage, .. }) => {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Error,
+                location: "stages".to_string(),
+                message: format!("Dependency cycle detected involving stage '{}'.", stage),
+                suggestion: Some(
+                    "Remove circular depends_on references between stages.".to_string(),
+                ),
+            });
+        }
+        Err(e) => {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Error,
+                location: "stages".to_string(),
+                message: format!("Stage ordering error: {}", e),
+                suggestion: None,
+            });
+        }
+    }
+
+    // 4. Agent config validation (when project_root is available).
+    if let Some(root) = project_root {
+        let agents_dir = root.join(".ta").join("agents");
+        for (role_name, role_def) in &def.roles {
+            let agent_config = agents_dir.join(format!("{}.yaml", role_def.agent));
+            if agents_dir.exists() && !agent_config.exists() {
+                findings.push(ValidationFinding {
+                    severity: ValidationSeverity::Warning,
+                    location: format!("roles.{}.agent", role_name),
+                    message: format!(
+                        "Role '{}' uses agent '{}' but no config found at {}.",
+                        role_name,
+                        role_def.agent,
+                        agent_config.display()
+                    ),
+                    suggestion: Some(format!(
+                        "Create an agent config with: ta agent new {}",
+                        role_def.agent
+                    )),
+                });
+            }
+
+            // Warn on empty prompts.
+            if role_def.prompt.trim().is_empty() {
+                findings.push(ValidationFinding {
+                    severity: ValidationSeverity::Warning,
+                    location: format!("roles.{}.prompt", role_name),
+                    message: format!("Role '{}' has an empty prompt.", role_name),
+                    suggestion: Some(
+                        "Add a system prompt describing this role's responsibilities.".to_string(),
+                    ),
+                });
+            }
+        }
+    }
+
+    // Verdict config checks.
+    if let Some(verdict) = &def.verdict {
+        if verdict.pass_threshold < 0.0 || verdict.pass_threshold > 1.0 {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Error,
+                location: "verdict.pass_threshold".to_string(),
+                message: format!(
+                    "pass_threshold must be between 0.0 and 1.0 (got {}).",
+                    verdict.pass_threshold
+                ),
+                suggestion: Some("Use a value like 0.7 (70% pass rate).".to_string()),
+            });
+        }
+
+        for rp in &verdict.required_pass {
+            if !defined_roles.contains(rp.as_str()) {
+                findings.push(ValidationFinding {
+                    severity: ValidationSeverity::Error,
+                    location: "verdict.required_pass".to_string(),
+                    message: format!("required_pass references undefined role '{}'.", rp),
+                    suggestion: Some(format!("Add '{}' to the 'roles:' section.", rp)),
+                });
+            }
+        }
+    }
+
+    ValidationResult { findings }
+}
+
+/// Validate an agent config YAML file.
+///
+/// Checks:
+/// - Required fields: name, command
+/// - Warning if injects_settings without injects_context_file
+pub fn validate_agent_config(content: &str) -> ValidationResult {
+    let mut findings = Vec::new();
+
+    let doc: HashMap<String, serde_yaml::Value> = match serde_yaml::from_str(content) {
+        Ok(d) => d,
+        Err(e) => {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Error,
+                location: "file".to_string(),
+                message: format!("Invalid YAML: {}", e),
+                suggestion: Some("Fix the YAML syntax errors.".to_string()),
+            });
+            return ValidationResult { findings };
+        }
+    };
+
+    // Required: name
+    match doc.get("name") {
+        Some(serde_yaml::Value::String(s)) if !s.trim().is_empty() => {}
+        Some(_) => {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Error,
+                location: "name".to_string(),
+                message: "Agent name must be a non-empty string.".to_string(),
+                suggestion: Some("Add: name: my-agent".to_string()),
+            });
+        }
+        None => {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Error,
+                location: "name".to_string(),
+                message: "Missing required field 'name'.".to_string(),
+                suggestion: Some("Add: name: my-agent".to_string()),
+            });
+        }
+    }
+
+    // Required: command
+    match doc.get("command") {
+        Some(serde_yaml::Value::String(s)) if !s.trim().is_empty() => {}
+        Some(_) => {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Error,
+                location: "command".to_string(),
+                message: "Agent command must be a non-empty string.".to_string(),
+                suggestion: Some("Add: command: claude".to_string()),
+            });
+        }
+        None => {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Error,
+                location: "command".to_string(),
+                message: "Missing required field 'command'.".to_string(),
+                suggestion: Some("Add: command: claude".to_string()),
+            });
+        }
+    }
+
+    // Warning: injects_settings without injects_context_file
+    let injects_settings = doc
+        .get("injects_settings")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let injects_context = doc
+        .get("injects_context_file")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if injects_settings && !injects_context {
+        findings.push(ValidationFinding {
+            severity: ValidationSeverity::Warning,
+            location: "injects_settings".to_string(),
+            message: "injects_settings is true but injects_context_file is false.".to_string(),
+            suggestion: Some(
+                "Settings injection usually requires context file injection. Set injects_context_file: true."
+                    .to_string(),
+            ),
+        });
+    }
+
+    // Check args_template is a list.
+    if let Some(args) = doc.get("args_template") {
+        if !args.is_sequence() {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Error,
+                location: "args_template".to_string(),
+                message: "args_template must be a list of strings.".to_string(),
+                suggestion: Some("Use:\nargs_template:\n  - \"{prompt}\"".to_string()),
+            });
+        }
+    }
+
+    // Check alignment section if present.
+    if let Some(alignment) = doc.get("alignment") {
+        if !alignment.is_mapping() {
+            findings.push(ValidationFinding {
+                severity: ValidationSeverity::Warning,
+                location: "alignment".to_string(),
+                message: "alignment should be a mapping with fields like security_level, allowed_actions."
+                    .to_string(),
+                suggestion: None,
+            });
+        }
+    }
+
+    ValidationResult { findings }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::definition::{RoleDefinition, StageDefinition, WorkflowDefinition};
+
+    fn minimal_workflow() -> WorkflowDefinition {
+        WorkflowDefinition {
+            name: "test".to_string(),
+            stages: vec![StageDefinition {
+                name: "build".to_string(),
+                depends_on: vec![],
+                roles: vec!["engineer".to_string()],
+                then: vec![],
+                review: None,
+                on_fail: None,
+                await_human: Default::default(),
+            }],
+            roles: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "engineer".to_string(),
+                    RoleDefinition {
+                        agent: "claude-code".to_string(),
+                        constitution: None,
+                        prompt: "Build it".to_string(),
+                        framework: None,
+                    },
+                );
+                m
+            },
+            verdict: None,
+        }
+    }
+
+    #[test]
+    fn valid_workflow_no_errors() {
+        let result = validate_workflow(&minimal_workflow(), None);
+        assert!(!result.has_errors(), "findings: {:?}", result.findings);
+    }
+
+    #[test]
+    fn empty_name_is_error() {
+        let mut wf = minimal_workflow();
+        wf.name = "".to_string();
+        let result = validate_workflow(&wf, None);
+        assert!(result.has_errors());
+        assert!(result.findings.iter().any(|f| f.location == "name"));
+    }
+
+    #[test]
+    fn no_stages_is_error() {
+        let mut wf = minimal_workflow();
+        wf.stages.clear();
+        let result = validate_workflow(&wf, None);
+        assert!(result.has_errors());
+    }
+
+    #[test]
+    fn undefined_role_reference() {
+        let mut wf = minimal_workflow();
+        wf.stages[0].roles.push("nonexistent".to_string());
+        let result = validate_workflow(&wf, None);
+        assert!(result.has_errors());
+        assert!(result
+            .findings
+            .iter()
+            .any(|f| f.message.contains("nonexistent")));
+    }
+
+    #[test]
+    fn undefined_stage_dependency() {
+        let mut wf = minimal_workflow();
+        wf.stages[0].depends_on.push("phantom".to_string());
+        let result = validate_workflow(&wf, None);
+        assert!(result.has_errors());
+        assert!(result
+            .findings
+            .iter()
+            .any(|f| f.message.contains("phantom")));
+    }
+
+    #[test]
+    fn cycle_detected() {
+        let wf = WorkflowDefinition {
+            name: "cycle".to_string(),
+            stages: vec![
+                StageDefinition {
+                    name: "a".to_string(),
+                    depends_on: vec!["b".to_string()],
+                    roles: vec![],
+                    then: vec![],
+                    review: None,
+                    on_fail: None,
+                    await_human: Default::default(),
+                },
+                StageDefinition {
+                    name: "b".to_string(),
+                    depends_on: vec!["a".to_string()],
+                    roles: vec![],
+                    then: vec![],
+                    review: None,
+                    on_fail: None,
+                    await_human: Default::default(),
+                },
+            ],
+            roles: HashMap::new(),
+            verdict: None,
+        };
+        let result = validate_workflow(&wf, None);
+        assert!(result.has_errors());
+        assert!(result.findings.iter().any(|f| f.message.contains("cycle")));
+    }
+
+    #[test]
+    fn unused_role_warning() {
+        let mut wf = minimal_workflow();
+        wf.roles.insert(
+            "unused".to_string(),
+            RoleDefinition {
+                agent: "claude-code".to_string(),
+                constitution: None,
+                prompt: "Never used".to_string(),
+                framework: None,
+            },
+        );
+        let result = validate_workflow(&wf, None);
+        assert!(!result.has_errors());
+        assert!(result.warning_count() > 0);
+        assert!(result.findings.iter().any(|f| f.message.contains("unused")));
+    }
+
+    #[test]
+    fn duplicate_stage_name() {
+        let mut wf = minimal_workflow();
+        wf.stages.push(StageDefinition {
+            name: "build".to_string(),
+            depends_on: vec![],
+            roles: vec![],
+            then: vec![],
+            review: None,
+            on_fail: None,
+            await_human: Default::default(),
+        });
+        let result = validate_workflow(&wf, None);
+        assert!(result.has_errors());
+    }
+
+    #[test]
+    fn valid_agent_config() {
+        let yaml = "name: test-agent\ncommand: claude\nargs_template:\n  - \"{prompt}\"\n";
+        let result = validate_agent_config(yaml);
+        assert!(!result.has_errors());
+    }
+
+    #[test]
+    fn agent_missing_name() {
+        let yaml = "command: claude\n";
+        let result = validate_agent_config(yaml);
+        assert!(result.has_errors());
+        assert!(result.findings.iter().any(|f| f.location == "name"));
+    }
+
+    #[test]
+    fn agent_missing_command() {
+        let yaml = "name: test\n";
+        let result = validate_agent_config(yaml);
+        assert!(result.has_errors());
+        assert!(result.findings.iter().any(|f| f.location == "command"));
+    }
+
+    #[test]
+    fn agent_injects_settings_warning() {
+        let yaml =
+            "name: test\ncommand: claude\ninjects_settings: true\ninjects_context_file: false\n";
+        let result = validate_agent_config(yaml);
+        assert!(!result.has_errors());
+        assert!(result.warning_count() > 0);
+    }
+
+    #[test]
+    fn agent_invalid_yaml() {
+        let yaml = "name: [invalid\n";
+        let result = validate_agent_config(yaml);
+        assert!(result.has_errors());
+    }
+}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -2511,8 +2511,17 @@ TA includes a pluggable workflow engine for orchestrating multi-stage, multi-rol
 #### Quick start
 
 ```bash
+# Scaffold a new workflow
+ta workflow new my-workflow
+
+# Scaffold from a built-in template
+ta workflow new my-pipeline --from deploy-pipeline
+
+# Validate before running
+ta workflow validate .ta/workflows/my-workflow.yaml
+
 # Start a workflow from a YAML definition
-ta workflow start templates/workflows/simple-review.yaml
+ta workflow start .ta/workflows/my-workflow.yaml
 
 # Check status
 ta workflow status <workflow-id>
@@ -2520,12 +2529,118 @@ ta workflow status <workflow-id>
 # List active workflows
 ta workflow list
 
+# Browse available templates
+ta workflow list --templates
+
 # Cancel a workflow
 ta workflow cancel <workflow-id>
 
 # Show stage transitions and routing history
 ta workflow history <workflow-id>
 ```
+
+#### Authoring a workflow end-to-end
+
+Creating a custom workflow is a three-step process: scaffold the workflow, create any missing agent configs, then validate and run.
+
+**Step 1: Scaffold a workflow.**
+
+```bash
+ta workflow new my-pipeline
+```
+
+This creates `.ta/workflows/my-pipeline.yaml` with annotated comments explaining every field. The default scaffold is a 2-stage build→review workflow. To start from a richer template:
+
+```bash
+ta workflow new my-pipeline --from deploy-pipeline
+```
+
+Available templates: `simple-review`, `security-audit`, `milestone-review`, `deploy-pipeline`, `plan-implement-review`. Browse them with `ta workflow list --templates`.
+
+**Step 2: Create missing agent configs.**
+
+After scaffolding, TA checks which agents the workflow references and tells you which ones are missing:
+
+```
+Created workflow: .ta/workflows/my-pipeline.yaml
+
+Missing agent configs (create them to complete setup):
+  ta agent new claude-code --type developer
+```
+
+Each workflow role has an `agent:` field that points to a config file in `.ta/agents/`. TA guesses the right agent type from the role name (reviewer → auditor, planner → planner, etc.). Run the suggested commands:
+
+```bash
+ta agent new claude-code --type developer
+```
+
+This creates `.ta/agents/claude-code.yaml` with appropriate defaults for the agent type:
+
+| Type | Security level | Permissions |
+|------|---------------|-------------|
+| `developer` | `checkpoint` | read, write, execute |
+| `auditor` | `supervised` | read, list, search (read-only) |
+| `planner` | `checkpoint` | read, list, search, plan |
+| `orchestrator` | `checkpoint` | read, list, search, plan, delegate |
+
+Edit the generated config to customize the command, args, and alignment for your project. Validate it:
+
+```bash
+ta agent validate .ta/agents/claude-code.yaml
+```
+
+This checks required fields, verifies the command exists on PATH, and warns on common misconfigurations (e.g., `injects_settings: true` without `injects_context_file: true`).
+
+**Step 3: Validate and run.**
+
+```bash
+ta workflow validate .ta/workflows/my-pipeline.yaml
+```
+
+Validation checks:
+- **Schema**: required fields, non-empty name, at least one stage
+- **References**: every role used in a stage is defined in `roles:`
+- **Dependencies**: no cycles, no references to undefined stages
+- **Agents**: every `roles.*.agent` has a matching config in `.ta/agents/`
+- **Verdict config**: valid threshold range, referenced roles exist
+
+Even when the workflow is valid, the validator shows any remaining missing agent configs with ready-to-run commands. Once everything passes:
+
+```bash
+ta workflow start .ta/workflows/my-pipeline.yaml
+```
+
+#### Managing agents and workflows
+
+```bash
+# List configured agents
+ta agent list
+
+# List active workflows
+ta workflow list
+
+# Browse agent templates
+ta agent list --templates
+
+# Browse workflow templates
+ta workflow list --templates
+```
+
+#### Version schema templates
+
+Pre-built version schemas in `templates/version-schemas/`:
+
+```bash
+# Copy a version schema to your project
+cp templates/version-schemas/semver.yaml .ta/version-schema.yaml
+```
+
+| Schema | Format | Use case |
+|--------|--------|----------|
+| `semver.yaml` | MAJOR.MINOR.PATCH-pre | Standard semantic versioning |
+| `calver.yaml` | YYYY.MM.PATCH | Calendar-based releases |
+| `sprint.yaml` | sprint-N.iteration | Agile sprint cycles |
+| `milestone.yaml` | vN.phase | Simple milestone tracking |
 
 #### Workflow YAML format
 

--- a/templates/agents/auditor.yaml
+++ b/templates/agents/auditor.yaml
@@ -1,0 +1,22 @@
+# Agent Template: Auditor
+# Read-only agent for security and code review.
+#
+# Copy to .ta/agents/ and customize:
+#   cp templates/agents/auditor.yaml .ta/agents/my-auditor.yaml
+# Or scaffold with:
+#   ta agent new my-auditor --type auditor
+
+name: auditor
+command: claude
+args_template:
+  - "{prompt}"
+
+injects_context_file: true
+injects_settings: false
+
+alignment:
+  security_level: supervised
+  allowed_actions:
+    - read
+    - list
+    - search

--- a/templates/agents/developer.yaml
+++ b/templates/agents/developer.yaml
@@ -1,0 +1,22 @@
+# Agent Template: Developer
+# Full read/write developer agent for building features and fixes.
+#
+# Copy to .ta/agents/ and customize:
+#   cp templates/agents/developer.yaml .ta/agents/my-dev.yaml
+# Or scaffold with:
+#   ta agent new my-dev --type developer
+
+name: developer
+command: claude
+args_template:
+  - "{prompt}"
+
+injects_context_file: true
+injects_settings: true
+
+alignment:
+  security_level: checkpoint
+  allowed_actions:
+    - read
+    - write
+    - execute

--- a/templates/agents/orchestrator.yaml
+++ b/templates/agents/orchestrator.yaml
@@ -1,0 +1,24 @@
+# Agent Template: Orchestrator
+# Multi-agent orchestrator with delegation permissions.
+#
+# Copy to .ta/agents/ and customize:
+#   cp templates/agents/orchestrator.yaml .ta/agents/my-orch.yaml
+# Or scaffold with:
+#   ta agent new my-orch --type orchestrator
+
+name: orchestrator
+command: claude
+args_template:
+  - "{prompt}"
+
+injects_context_file: true
+injects_settings: true
+
+alignment:
+  security_level: checkpoint
+  allowed_actions:
+    - read
+    - list
+    - search
+    - plan
+    - delegate

--- a/templates/agents/planner.yaml
+++ b/templates/agents/planner.yaml
@@ -1,0 +1,23 @@
+# Agent Template: Planner
+# Technical planning and decomposition agent.
+#
+# Copy to .ta/agents/ and customize:
+#   cp templates/agents/planner.yaml .ta/agents/my-planner.yaml
+# Or scaffold with:
+#   ta agent new my-planner --type planner
+
+name: planner
+command: claude
+args_template:
+  - "{prompt}"
+
+injects_context_file: true
+injects_settings: true
+
+alignment:
+  security_level: checkpoint
+  allowed_actions:
+    - read
+    - list
+    - search
+    - plan

--- a/templates/version-schemas/calver.yaml
+++ b/templates/version-schemas/calver.yaml
@@ -1,0 +1,26 @@
+# Version Schema: Calendar Versioning (calver)
+# Uses date-based version numbers: YYYY.MM.PATCH
+#
+# Usage:
+#   cp templates/version-schemas/calver.yaml .ta/version-schema.yaml
+# Or:
+#   ta plan create --version-schema calver
+
+name: calver
+description: Calendar-based versioning (YYYY.MM.PATCH)
+
+format:
+  pattern: "^(?P<year>\\d{4})\\.(?P<month>\\d{1,2})\\.(?P<patch>\\d+)$"
+  template: "{year}.{month}.{patch}"
+
+bump_rules:
+  year: "Automatically set to current year"
+  month: "Automatically set to current month"
+  patch: "Incremented for each release within the same month"
+
+phase_mapping:
+  strategy: auto_date
+  # Versions are derived from the release date, not plan phases.
+  # Patch is incremented for multiple releases in the same month.
+
+initial_version: "2026.1.0"

--- a/templates/version-schemas/milestone.yaml
+++ b/templates/version-schemas/milestone.yaml
@@ -1,0 +1,26 @@
+# Version Schema: Milestone-Based Versioning
+# Simple milestone versioning: v1, v2, v3 with sub-phases.
+#
+# Usage:
+#   cp templates/version-schemas/milestone.yaml .ta/version-schema.yaml
+# Or:
+#   ta plan create --version-schema milestone
+
+name: milestone
+description: Milestone-based versioning (vN with sub-phases)
+
+format:
+  pattern: "^v(?P<milestone>\\d+)(?:\\.(?P<phase>\\d+))?$"
+  template: "v{milestone}"
+  phase_template: "v{milestone}.{phase}"
+
+bump_rules:
+  milestone: "Major milestone reached (e.g., public release, feature complete)"
+  phase: "Sub-phase within a milestone"
+
+phase_mapping:
+  strategy: milestone_aligned
+  # Plan phases map directly to milestone.phase numbers.
+  # v1 = first public release, v1.1 = first follow-up, etc.
+
+initial_version: "v1"

--- a/templates/version-schemas/semver.yaml
+++ b/templates/version-schemas/semver.yaml
@@ -1,0 +1,32 @@
+# Version Schema: Semantic Versioning (semver)
+# Standard MAJOR.MINOR.PATCH with optional pre-release suffix.
+#
+# Usage:
+#   cp templates/version-schemas/semver.yaml .ta/version-schema.yaml
+# Or:
+#   ta plan create --version-schema semver
+
+name: semver
+description: Standard semantic versioning (MAJOR.MINOR.PATCH-prerelease)
+
+format:
+  # Regex pattern for valid version strings.
+  pattern: "^v?(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<pre>[a-zA-Z0-9.]+))?$"
+  # Display template.
+  template: "v{major}.{minor}.{patch}"
+  pre_release_template: "v{major}.{minor}.{patch}-{pre}"
+
+bump_rules:
+  # When to bump each component.
+  major: "Breaking changes to public API"
+  minor: "New features, backward-compatible"
+  patch: "Bug fixes, backward-compatible"
+
+phase_mapping:
+  # How plan phases map to versions.
+  # Each phase can specify which component to bump.
+  strategy: explicit
+  # Phases declare their target version in PLAN.md.
+  # Sub-phases use pre-release: v0.4.1-alpha.2
+
+initial_version: "0.1.0-alpha"

--- a/templates/version-schemas/sprint.yaml
+++ b/templates/version-schemas/sprint.yaml
@@ -1,0 +1,25 @@
+# Version Schema: Sprint-Based Versioning
+# Uses sprint numbers: sprint-N.iteration
+#
+# Usage:
+#   cp templates/version-schemas/sprint.yaml .ta/version-schema.yaml
+# Or:
+#   ta plan create --version-schema sprint
+
+name: sprint
+description: Sprint-based versioning (sprint-N.iteration)
+
+format:
+  pattern: "^sprint-(?P<sprint>\\d+)\\.(?P<iteration>\\d+)$"
+  template: "sprint-{sprint}.{iteration}"
+
+bump_rules:
+  sprint: "New sprint cycle begins"
+  iteration: "Iteration within a sprint (hotfix, follow-up)"
+
+phase_mapping:
+  strategy: sprint_aligned
+  # Each plan phase maps to a sprint number.
+  # Sub-phases increment the iteration counter.
+
+initial_version: "sprint-1.0"

--- a/templates/workflows/deploy-pipeline.yaml
+++ b/templates/workflows/deploy-pipeline.yaml
@@ -1,0 +1,63 @@
+# deploy-pipeline.yaml — Build, test, and deploy with human gates.
+#
+# A 3-stage workflow with security review at the test stage
+# and mandatory human approval before deployment.
+#
+# Usage:
+#   ta workflow start templates/workflows/deploy-pipeline.yaml
+
+name: deploy-pipeline
+
+stages:
+  - name: build
+    roles: [engineer]
+    await_human: never
+
+  - name: test
+    depends_on: [build]
+    roles: [tester, security-reviewer]
+    await_human: on_fail
+    on_fail:
+      route_to: build
+      max_retries: 2
+
+  - name: deploy
+    depends_on: [test]
+    roles: [deployer]
+    await_human: always
+
+roles:
+  engineer:
+    agent: claude-code
+    prompt: |
+      You are a software engineer. Build and prepare the release.
+      Ensure all compilation, linting, and formatting checks pass.
+
+  tester:
+    agent: claude-code
+    prompt: |
+      You are a QA engineer. Run the full test suite and verify:
+      - All existing tests pass
+      - New code has adequate test coverage
+      - Integration tests cover critical paths
+      Report any failures with reproduction steps.
+
+  security-reviewer:
+    agent: claude-code
+    prompt: |
+      You are a security reviewer. Audit the changes for security
+      implications before deployment. Check for leaked secrets,
+      insecure defaults, and OWASP Top 10 issues.
+
+  deployer:
+    agent: claude-code
+    prompt: |
+      You are a deployment engineer. Prepare the deployment:
+      - Generate release notes
+      - Verify version bumps
+      - Check deployment prerequisites
+      - Document rollback procedures
+
+verdict:
+  pass_threshold: 0.8
+  required_pass: [security-reviewer]

--- a/templates/workflows/plan-implement-review.yaml
+++ b/templates/workflows/plan-implement-review.yaml
@@ -1,0 +1,60 @@
+# plan-implement-review.yaml — Planner-driven workflow with iterative review.
+#
+# Uses the planner role to decompose objectives, then routes through
+# implementation and review stages. On review failure, routes back to
+# the planner to revise the approach.
+#
+# Usage:
+#   ta workflow start templates/workflows/plan-implement-review.yaml
+
+name: plan-implement-review
+
+stages:
+  - name: plan
+    roles: [planner]
+    await_human: always
+
+  - name: implement
+    depends_on: [plan]
+    roles: [engineer]
+    await_human: never
+
+  - name: review
+    depends_on: [implement]
+    roles: [reviewer]
+    await_human: on_fail
+    on_fail:
+      route_to: plan
+      max_retries: 3
+
+roles:
+  planner:
+    agent: claude-code
+    prompt: |
+      You are a technical planner. Given an objective or document:
+      1. Break it down into concrete implementation tasks
+      2. Identify risks, dependencies, and acceptance criteria
+      3. Order tasks by dependency and priority
+      4. Output a structured plan
+
+      If this is a re-plan after review failure, incorporate the feedback
+      and adjust the approach. Focus on the specific issues raised.
+
+  engineer:
+    agent: claude-code
+    prompt: |
+      You are a software engineer. Follow the plan from the planning stage.
+      Implement each task in order. Write tests for all changes.
+      Commit in logical working units.
+
+  reviewer:
+    agent: claude-code
+    prompt: |
+      You are a code reviewer. Review the implementation against the plan:
+      - Were all planned tasks completed?
+      - Is the code correct and well-tested?
+      - Are there security or quality issues?
+      Provide specific, actionable findings.
+
+verdict:
+  pass_threshold: 0.7

--- a/templates/workflows/roles/orchestrator.yaml
+++ b/templates/workflows/roles/orchestrator.yaml
@@ -1,0 +1,6 @@
+# Role: Orchestrator
+agent: claude-code
+prompt: |
+  You are a multi-agent orchestrator. Coordinate work across agents:
+  decompose complex tasks, delegate to specialists, aggregate results,
+  and resolve conflicts. Track overall progress and ensure quality.


### PR DESCRIPTION
## Summary

Changes from goal: implement v0.9.9.5 — Workflow & Agent Authoring Tooling

**Why**: Make it easy for users to create, validate, and iterate on custom workflow definitions and agent profiles without reading Rust source code or guessing YAML schema.

**Impact**: 22 file(s) changed

## Changes (22 file(s))

- `~` `fs://workspace/.git/index`
- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/Cargo.toml` — Bumped workspace version from 0.9.9-alpha.4 to 0.9.9-alpha.5.
  - Version bump for v0.9.9.5 release.
- `~` `fs://workspace/PLAN.md` — Added Completed section to v0.9.9.5 phase listing 11 implemented items. Added Remaining section noting deferred `ta plan create --version-schema` integration.
  - Plan progress tracking must reflect what was actually implemented.
- `+` `fs://workspace/apps/ta-cli/src/commands/agent.rs` — New CLI module with AgentCommands: New (--type developer|auditor|orchestrator|planner), Validate, List (--templates). Generates typed agent configs with appropriate alignment defaults. Validate checks PATH availability. 10 tests.
  - v0.9.9.5 requires `ta agent new` and `ta agent validate` as first-class CLI commands. Agent config authoring was previously only available through `ta setup wizard`.
- `~` `fs://workspace/apps/ta-cli/src/commands/mod.rs` — Added `pub mod agent;` declaration.
  - New agent command module needs to be registered.
- `~` `fs://workspace/apps/ta-cli/src/commands/workflow.rs` — Added New and Validate subcommands to WorkflowCommands. Changed List to accept --templates flag. Added new_workflow() with scaffold generation and --from template selection (5 built-in templates as const strings). Added validate_workflow_cmd() using ta_workflow::validate. Added generate_scaffold() producing annotated YAML. 7 new tests.
  - v0.9.9.5 requires `ta workflow new` for scaffolding and `ta workflow validate` for pre-flight validation. Users should not need to guess YAML schema or copy-paste from examples.
- `~` `fs://workspace/apps/ta-cli/src/main.rs` — Added Agent command variant to Commands enum and dispatch in match block.
  - Wire up the new `ta agent` top-level command.
- `~` `fs://workspace/crates/ta-workflow/src/lib.rs` — Added `pub mod validate;` declaration to expose the new validation module.
  - The validate module needs to be part of the ta-workflow public API for CLI commands to use it.
- `+` `fs://workspace/crates/ta-workflow/src/validate.rs` — New validation module with validate_workflow() (schema, reference, dependency, agent config checks) and validate_agent_config() (required fields, misconfiguration warnings). ValidationResult, ValidationFinding, ValidationSeverity types. 12 tests.
  - v0.9.9.5 requires comprehensive validation beyond serde parse errors — users need actionable feedback on undefined roles, cycles, missing agent configs, and common misconfigurations.
- `~` `fs://workspace/docs/USAGE.md` — Added workflow authoring section (ta workflow new, ta workflow validate, template list), agent authoring section (ta agent new/validate/list with type descriptions), and version schema templates section. Updated workflow quick-start with new commands.
  - User-facing documentation must cover the new authoring commands and templates.
- `+` `fs://workspace/templates/agents/auditor.yaml` — Auditor agent template with supervised security level and read-only permissions.
  - v0.9.9.5 agent template for security/code review agents.
- `+` `fs://workspace/templates/agents/developer.yaml` — Developer agent template with checkpoint security level and read/write/execute permissions.
  - v0.9.9.5 example library needs agent config templates users can copy and customize.
- `+` `fs://workspace/templates/agents/orchestrator.yaml` — Orchestrator agent template with checkpoint security level and delegation permissions.
  - v0.9.9.5 agent template for multi-agent orchestrator agents.
- `+` `fs://workspace/templates/agents/planner.yaml` — Planner agent template with checkpoint security level and read/plan permissions.
  - v0.9.9.5 agent template for planning-focused agents.
- `+` `fs://workspace/templates/version-schemas/calver.yaml` — Calendar versioning schema template with YYYY.MM.PATCH format.
  - v0.9.9.5 versioning schema templates — alternative to semver.
- `+` `fs://workspace/templates/version-schemas/milestone.yaml` — Milestone-based versioning schema template with vN.phase format.
  - v0.9.9.5 versioning schema templates — simple milestone numbering.
- `+` `fs://workspace/templates/version-schemas/semver.yaml` — Semantic versioning schema template with MAJOR.MINOR.PATCH format, bump rules, and phase mapping strategy.
  - v0.9.9.5 versioning schema templates — users can adopt standard version schemes.
- `+` `fs://workspace/templates/version-schemas/sprint.yaml` — Sprint-based versioning schema template with sprint-N.iteration format.
  - v0.9.9.5 versioning schema templates — for agile/sprint workflows.
- `+` `fs://workspace/templates/workflows/deploy-pipeline.yaml` — 3-stage deploy pipeline workflow template: build -> test (with security reviewer) -> deploy (with human gate).
  - v0.9.9.5 example library needs a deployment-focused workflow template.
- `+` `fs://workspace/templates/workflows/plan-implement-review.yaml` — 3-stage planner-driven workflow: plan -> implement -> review, with review failures routing back to the planner.
  - v0.9.9.5 planner workflow role item — demonstrates Plan->Implement->Review->Plan loops.
- `+` `fs://workspace/templates/workflows/roles/orchestrator.yaml` — Orchestrator role template for multi-agent coordination.
  - Completes the role template library alongside engineer, reviewer, planner, security-reviewer, pm.

## Goal Context

- **Title**: implement v0.9.9.5 — Workflow & Agent Authoring Tooling
- **Objective**: implement v0.9.9.5 — Workflow & Agent Authoring Tooling
- **Goal ID**: `0221c10b-94ca-46fc-878a-a36687a486a5`
- **PR ID**: `b1d9211b-ccd4-41ec-b4d6-3a88e62b9acf`
- **Plan Phase**: `0.9.9.5`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
