### PR TITLE
Fix shell command routing, parsing, and disambiguation

### DIFF
--- a/apps/ta-cli/src/commands/shell.rs
+++ b/apps/ta-cli/src/commands/shell.rs
@@ -325,6 +325,27 @@ pub(crate) async fn send_input(
         return Err(anyhow::anyhow!("HTTP {}", status_code));
     }
 
+    // Check for disambiguation responses (ambiguous command parse).
+    if json["ambiguous"].as_bool() == Some(true) {
+        let mut output = String::new();
+        if let Some(msg) = json["message"].as_str() {
+            output.push_str(msg);
+            output.push('\n');
+        }
+        if let Some(options) = json["options"].as_array() {
+            for opt in options {
+                let idx = opt["index"].as_u64().unwrap_or(0);
+                let desc = opt["description"].as_str().unwrap_or("?");
+                let cmd = opt["command"].as_str().unwrap_or("?");
+                output.push_str(&format!("  {}> {}\n", idx, desc));
+                output.push_str(&format!("     command: {}\n", cmd));
+            }
+        }
+        output.push_str("\nRe-run with the exact command, or quote the title:\n");
+        output.push_str("  run \"your multi-word title here\" --flag value\n");
+        return Ok(output);
+    }
+
     // For command results, prefer stdout; for agent results, prefer response.
     if let Some(stdout) = json["stdout"].as_str() {
         let mut output = stdout.to_string();
@@ -372,8 +393,45 @@ pub(crate) async fn fetch_completions(client: &reqwest::Client, base_url: &str) 
 
 fn default_completions() -> Vec<String> {
     vec![
-        "approve", "deny", "view", "apply", "status", "plan", "goals", "drafts", "workflow",
-        "exit", "quit", "help", ":status", ":help",
+        // Shortcuts
+        "approve",
+        "deny",
+        "view",
+        "apply",
+        "goals",
+        "drafts",
+        // ta subcommands (bare word → `ta <word>`)
+        "goal",
+        "draft",
+        "audit",
+        "run",
+        "session",
+        "plan",
+        "context",
+        "credentials",
+        "events",
+        "token",
+        "dev",
+        "setup",
+        "init",
+        "agent",
+        "adapter",
+        "release",
+        "office",
+        "plugin",
+        "workflow",
+        "policy",
+        "config",
+        "gc",
+        "status",
+        "conversation",
+        // Shell built-ins
+        "exit",
+        "quit",
+        "help",
+        ":status",
+        ":help",
+        ":tail",
     ]
     .into_iter()
     .map(String::from)
@@ -746,6 +804,20 @@ pub(crate) fn render_sse_event(frame: &str) -> Option<String> {
             let turn = payload["turn"].as_u64().unwrap_or(1);
             let responder = payload["responder_id"].as_str().unwrap_or("?");
             format!("agent question answered (turn {}, by {})", turn, responder)
+        }
+        "command_failed" => {
+            let cmd = payload["command"].as_str().unwrap_or("?");
+            let code = payload["exit_code"].as_i64().unwrap_or(-1);
+            let stderr = payload["stderr"].as_str().unwrap_or("");
+            let mut msg = format!("command failed (exit {}): {}", code, cmd);
+            if !stderr.is_empty() {
+                // Show last 3 lines of stderr inline.
+                let tail: Vec<&str> = stderr.lines().rev().take(3).collect();
+                for line in tail.iter().rev() {
+                    msg.push_str(&format!("\n  {}", line));
+                }
+            }
+            msg
         }
         _ => {
             // Fallback: use summary field or event type.

--- a/crates/ta-daemon/src/api/cmd.rs
+++ b/crates/ta-daemon/src/api/cmd.rs
@@ -62,7 +62,24 @@ pub async fn execute_command(
     // Parse the command into args. Strip leading "ta " if present.
     let args_str = command_str.strip_prefix("ta ").unwrap_or(command_str);
 
-    let args: Vec<&str> = args_str.split_whitespace().collect();
+    let args: Vec<String> = match parse_command_args(args_str) {
+        ParseResult::Parsed(args) => args,
+        ParseResult::Ambiguous(options) => {
+            // Return disambiguation options for the caller to present.
+            return Json(serde_json::json!({
+                "ambiguous": true,
+                "message": "Ambiguous command — did you mean:",
+                "options": options.iter().enumerate().map(|(i, opt)| {
+                    serde_json::json!({
+                        "index": i + 1,
+                        "description": opt.description,
+                        "command": opt.command,
+                    })
+                }).collect::<Vec<_>>(),
+            }))
+            .into_response();
+        }
+    };
     if args.is_empty() {
         return (
             StatusCode::BAD_REQUEST,
@@ -81,7 +98,6 @@ pub async fn execute_command(
 
     if is_long {
         let binary = ta_binary.clone();
-        let args_owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
         let working_dir = state.project_root.clone();
         let cmd_str = command_str.to_string();
 
@@ -89,7 +105,8 @@ pub async fn execute_command(
         // Goal IDs appear in `ta run` output events; we use the command string
         // as a key until the real goal ID is known.
         let goal_output = state.goal_output.clone_ref();
-        let output_key = extract_goal_key(&args_owned);
+        let events_dir = state.events_dir.clone();
+        let output_key = extract_goal_key(&args);
         let tx = goal_output.create_channel(&output_key).await;
         let output_key_display = output_key.clone();
         let output_key_response = output_key.clone();
@@ -104,7 +121,7 @@ pub async fn execute_command(
                 .arg("--project-root")
                 .arg(&working_dir)
                 .arg("--accept-terms")
-                .args(&args_owned)
+                .args(&args)
                 .current_dir(&working_dir)
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
@@ -112,7 +129,8 @@ pub async fn execute_command(
 
             match result {
                 Ok(mut child) => {
-                    // Stream stdout and stderr line-by-line.
+                    // Stream stdout and stderr line-by-line, collecting stderr
+                    // for failure context.
                     use crate::api::goal_output::OutputLine;
                     use tokio::io::{AsyncBufReadExt, BufReader};
 
@@ -132,14 +150,22 @@ pub async fn execute_command(
                         }
                     });
 
+                    let stderr_lines = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+                    let stderr_lines2 = stderr_lines.clone();
                     let stderr_task = tokio::spawn(async move {
                         if let Some(err) = stderr {
                             let mut reader = BufReader::new(err).lines();
                             while let Ok(Some(line)) = reader.next_line().await {
                                 let _ = tx2.send(OutputLine {
                                     stream: "stderr",
-                                    line,
+                                    line: line.clone(),
                                 });
+                                // Keep last 20 lines for failure context.
+                                let mut lines = stderr_lines2.lock().await;
+                                if lines.len() >= 20 {
+                                    lines.remove(0);
+                                }
+                                lines.push(line);
                             }
                         }
                     });
@@ -154,19 +180,28 @@ pub async fn execute_command(
                         }
                         Ok(s) => {
                             let code = s.code().unwrap_or(-1);
+                            let stderr_tail = stderr_lines.lock().await.join("\n");
                             tracing::warn!(
                                 "Background command failed (exit {}): {}",
                                 code,
                                 cmd_str
                             );
+                            emit_command_failed_event(&events_dir, &cmd_str, code, &stderr_tail);
                         }
                         Err(e) => {
                             tracing::error!("Background command wait error: {} — {}", cmd_str, e);
+                            emit_command_failed_event(&events_dir, &cmd_str, -1, &e.to_string());
                         }
                     }
                 }
                 Err(e) => {
                     tracing::error!("Background command spawn error: {} — {}", cmd_str, e);
+                    emit_command_failed_event(
+                        &events_dir,
+                        &cmd_str,
+                        -1,
+                        &format!("spawn failed: {}", e),
+                    );
                 }
             }
 
@@ -206,7 +241,7 @@ pub async fn execute_command(
 
 async fn run_command(
     binary: &str,
-    args: &[&str],
+    args: &[String],
     working_dir: &std::path::Path,
     timeout: std::time::Duration,
 ) -> Result<CmdResponse, String> {
@@ -300,6 +335,348 @@ fn extract_goal_key(args: &[String]) -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
+/// Commands that take a free-form title as their first positional argument.
+/// For these, all non-flag words after the subcommand are joined into one arg.
+const TITLE_SUBCOMMANDS: &[&str] = &["run", "dev"];
+
+/// Known `--long` flags for title-subcommands, used to distinguish real flags
+/// from title text that happens to start with `--`.
+const RUN_FLAGS: &[&str] = &[
+    "--agent",
+    "--source",
+    "--objective",
+    "--phase",
+    "--follow-up",
+    "--objective-file",
+    "--no-launch",
+    "--interactive",
+    "--macro-goal",
+    "--macro",
+    "--resume",
+    "--headless",
+    "--goal-id",
+];
+
+/// Flags that take a value (the next word is consumed as the value, not title text).
+const RUN_VALUE_FLAGS: &[&str] = &[
+    "--agent",
+    "--source",
+    "--objective",
+    "--phase",
+    "--follow-up",
+    "--objective-file",
+    "--resume",
+    "--goal-id",
+];
+
+const DEV_FLAGS: &[&str] = &["--agent", "--unrestricted"];
+const DEV_VALUE_FLAGS: &[&str] = &["--agent"];
+
+/// Return the known flags for a title subcommand.
+fn known_flags_for(subcommand: &str) -> (&'static [&'static str], &'static [&'static str]) {
+    match subcommand {
+        "run" => (RUN_FLAGS, RUN_VALUE_FLAGS),
+        "dev" => (DEV_FLAGS, DEV_VALUE_FLAGS),
+        _ => (&[], &[]),
+    }
+}
+
+/// A single possible interpretation of an ambiguous command.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Interpretation {
+    /// Human-readable description (e.g., `run goal "v0.10.7 -- build Blah" with --agent claude-flow`).
+    pub description: String,
+    /// The fully-formed command string to execute if this interpretation is chosen.
+    pub command: String,
+}
+
+/// Result of parsing a command line that may be ambiguous.
+#[derive(Debug, PartialEq)]
+pub enum ParseResult {
+    /// Unambiguous parse — ready to execute.
+    Parsed(Vec<String>),
+    /// Ambiguous — multiple plausible interpretations for the user to choose from.
+    Ambiguous(Vec<Interpretation>),
+}
+
+/// Split a string into tokens, respecting double-quoted groups.
+/// `run "my title" --flag` → `["run", "my title", "--flag"]`.
+fn split_respecting_quotes(input: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+
+    for ch in input.chars() {
+        match ch {
+            '"' => {
+                in_quotes = !in_quotes;
+                // Don't include the quote character in the token.
+            }
+            c if c.is_whitespace() && !in_quotes => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            c => current.push(c),
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+/// Parse command args, joining multi-word titles for subcommands that expect them.
+///
+/// Uses known-flag awareness to distinguish real flags from title text.
+/// Detects typos like `-- source .` (should be `--source .`) and ambiguous
+/// patterns like `run v0.10.7 -- build Blah --agent claude-flow`.
+/// Respects quoted titles: `run "my title" --agent codex` is always unambiguous.
+///
+/// Returns `Parsed` for unambiguous input, `Ambiguous` with interpretations otherwise.
+fn parse_command_args(args_str: &str) -> ParseResult {
+    // If the input contains quotes, use quote-aware splitting — always unambiguous.
+    if args_str.contains('"') {
+        let tokens = split_respecting_quotes(args_str);
+        return ParseResult::Parsed(tokens);
+    }
+
+    let words: Vec<&str> = args_str.split_whitespace().collect();
+    if words.is_empty() {
+        return ParseResult::Parsed(Vec::new());
+    }
+
+    if !TITLE_SUBCOMMANDS.contains(&words[0]) || words.len() <= 1 {
+        return ParseResult::Parsed(words.iter().map(|s| s.to_string()).collect());
+    }
+
+    let subcmd = words[0];
+    let (all_flags, value_flags) = known_flags_for(subcmd);
+
+    // First pass: check for typos like `-- source .` → `--source .`.
+    // If word[i] == "--" and word[i+1] matches a known flag stem, suggest correction.
+    let mut typo_corrections: Vec<(usize, String)> = Vec::new();
+    for i in 1..words.len() {
+        if words[i] == "--" && i + 1 < words.len() {
+            let candidate = format!("--{}", words[i + 1]);
+            if all_flags.contains(&candidate.as_str()) {
+                typo_corrections.push((i, candidate));
+            }
+        }
+    }
+
+    if !typo_corrections.is_empty() {
+        return build_typo_disambiguation(
+            subcmd,
+            &words,
+            &typo_corrections,
+            all_flags,
+            value_flags,
+        );
+    }
+
+    // Second pass: parse with known-flag awareness.
+    let mut title_parts: Vec<&str> = Vec::new();
+    let mut flags: Vec<String> = Vec::new();
+    let mut has_ambiguous = false;
+    let mut i = 1;
+    while i < words.len() {
+        let word = words[i];
+        if all_flags.contains(&word) {
+            // Known flag.
+            flags.push(word.to_string());
+            i += 1;
+            if value_flags.contains(&word) && i < words.len() {
+                flags.push(words[i].to_string());
+                i += 1;
+            }
+        } else if word == "--" {
+            // Bare `--` — ambiguous (em-dash? end-of-flags?).
+            has_ambiguous = true;
+            title_parts.push(word);
+            i += 1;
+        } else if word.starts_with("--") {
+            // Unknown `--something` — could be title text or a typo.
+            has_ambiguous = true;
+            title_parts.push(word);
+            i += 1;
+        } else if flags.is_empty() {
+            title_parts.push(word);
+            i += 1;
+        } else {
+            // Bare word after flags, not consumed as a flag value — unusual.
+            title_parts.push(word);
+            i += 1;
+        }
+    }
+
+    if title_parts.is_empty() {
+        return ParseResult::Parsed(words.iter().map(|s| s.to_string()).collect());
+    }
+
+    if has_ambiguous && !flags.is_empty() {
+        // Multiple plausible parses — disambiguate.
+        return build_flag_disambiguation(subcmd, &words, &title_parts, &flags);
+    }
+
+    // Unambiguous: join title parts, preserving original whitespace from args_str.
+    let title_span = span_from_parts(args_str, &title_parts);
+    let mut result = vec![subcmd.to_string(), title_span.to_string()];
+    result.extend(flags);
+    ParseResult::Parsed(result)
+}
+
+/// Extract the contiguous substring from `args_str` that spans from the first
+/// to the last part in `parts` (preserving original whitespace between them).
+fn span_from_parts<'a>(args_str: &'a str, parts: &[&str]) -> &'a str {
+    let first = parts[0];
+    let last = parts[parts.len() - 1];
+    let start = first.as_ptr() as usize - args_str.as_ptr() as usize;
+    let end = last.as_ptr() as usize - args_str.as_ptr() as usize + last.len();
+    &args_str[start..end]
+}
+
+/// Build disambiguation for typo corrections like `-- source .` → `--source .`.
+fn build_typo_disambiguation(
+    subcmd: &str,
+    words: &[&str],
+    corrections: &[(usize, String)],
+    all_flags: &[&str],
+    value_flags: &[&str],
+) -> ParseResult {
+    let mut options = Vec::new();
+
+    // Option 1: Literal — everything after subcmd is the title (no flag interpretation).
+    let full_title = words[1..].join(" ");
+    options.push(Interpretation {
+        description: format!("{} goal \"{}\"", subcmd, full_title),
+        command: format!("ta {} \"{}\"", subcmd, full_title),
+    });
+
+    // Option 2: Corrected — apply typo fixes and re-parse.
+    let mut corrected_words: Vec<String> = Vec::new();
+    let mut skip_next = false;
+    for (idx, word) in words.iter().enumerate() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if let Some((_, correction)) = corrections.iter().find(|(ci, _)| *ci == idx) {
+            corrected_words.push(correction.clone());
+            skip_next = true; // Skip the next word (it was merged into the flag).
+        } else {
+            corrected_words.push(word.to_string());
+        }
+    }
+
+    // Parse the corrected version to build a proper description.
+    let mut title_parts = Vec::new();
+    let mut flag_parts: Vec<String> = Vec::new();
+    let mut ci = 1;
+    while ci < corrected_words.len() {
+        let w = &corrected_words[ci];
+        if all_flags.contains(&w.as_str()) {
+            flag_parts.push(w.clone());
+            ci += 1;
+            if value_flags.contains(&w.as_str()) && ci < corrected_words.len() {
+                flag_parts.push(corrected_words[ci].clone());
+                ci += 1;
+            }
+        } else {
+            title_parts.push(w.clone());
+            ci += 1;
+        }
+    }
+
+    let corrected_title = title_parts.join(" ");
+    let flag_desc = describe_flags(&flag_parts);
+    let mut cmd_parts = vec![format!("ta {}", subcmd)];
+    if !corrected_title.is_empty() {
+        cmd_parts.push(format!("\"{}\"", corrected_title));
+    }
+    cmd_parts.extend(flag_parts.iter().cloned());
+
+    let desc = if flag_desc.is_empty() {
+        format!("{} goal \"{}\"", subcmd, corrected_title)
+    } else {
+        format!("{} goal \"{}\" with {}", subcmd, corrected_title, flag_desc)
+    };
+    options.push(Interpretation {
+        description: desc,
+        command: cmd_parts.join(" "),
+    });
+
+    // Deduplicate.
+    options.dedup_by(|a, b| a.command == b.command);
+
+    if options.len() == 1 {
+        // Only one interpretation — auto-select it. Re-parse the corrected words.
+        let mut result = vec![subcmd.to_string()];
+        if !corrected_title.is_empty() {
+            result.push(corrected_title);
+        }
+        result.extend(flag_parts);
+        return ParseResult::Parsed(result);
+    }
+
+    ParseResult::Ambiguous(options)
+}
+
+/// Build disambiguation when unknown `--` tokens appear alongside known flags.
+fn build_flag_disambiguation(
+    subcmd: &str,
+    words: &[&str],
+    title_parts: &[&str],
+    flags: &[String],
+) -> ParseResult {
+    let mut options = Vec::new();
+
+    // Option 1: Everything after subcmd is the title.
+    let full_title = words[1..].join(" ");
+    options.push(Interpretation {
+        description: format!("{} goal \"{}\"", subcmd, full_title),
+        command: format!("ta {} \"{}\"", subcmd, full_title),
+    });
+
+    // Option 2: Title + flags split as parsed.
+    let title_text = title_parts.join(" ");
+    let flag_desc = describe_flags(flags);
+    let mut cmd_parts = vec![format!("ta {} \"{}\"", subcmd, title_text)];
+    cmd_parts.extend(flags.iter().cloned());
+
+    options.push(Interpretation {
+        description: format!("{} goal \"{}\" with {}", subcmd, title_text, flag_desc),
+        command: cmd_parts.join(" "),
+    });
+
+    // Deduplicate.
+    options.dedup_by(|a, b| a.command == b.command);
+
+    if options.len() == 1 {
+        let mut result = vec![subcmd.to_string(), title_text.to_string()];
+        result.extend(flags.iter().cloned());
+        return ParseResult::Parsed(result);
+    }
+
+    ParseResult::Ambiguous(options)
+}
+
+/// Produce a human-readable summary of flags (e.g., "--agent set to claude-flow, --headless").
+fn describe_flags(flags: &[String]) -> String {
+    let mut parts = Vec::new();
+    let mut i = 0;
+    while i < flags.len() {
+        if flags[i].starts_with("--") && i + 1 < flags.len() && !flags[i + 1].starts_with("--") {
+            parts.push(format!("{} set to {}", flags[i], flags[i + 1]));
+            i += 2;
+        } else {
+            parts.push(flags[i].clone());
+            i += 1;
+        }
+    }
+    parts.join(", ")
+}
+
 /// Simple glob matching: `*` matches any sequence of characters.
 fn glob_match(pattern: &str, input: &str) -> bool {
     if let Some(prefix) = pattern.strip_suffix(" *") {
@@ -308,6 +685,29 @@ fn glob_match(pattern: &str, input: &str) -> bool {
         true
     } else {
         pattern == input
+    }
+}
+
+/// Emit a `command_failed` event so the failure is visible to agents and the SSE stream.
+fn emit_command_failed_event(
+    events_dir: &std::path::Path,
+    command: &str,
+    exit_code: i32,
+    stderr_tail: &str,
+) {
+    use ta_events::schema::SessionEvent;
+    use ta_events::store::{EventStore, FsEventStore};
+
+    let store = FsEventStore::new(events_dir);
+    let event = SessionEvent::CommandFailed {
+        command: command.to_string(),
+        exit_code,
+        stderr: stderr_tail.to_string(),
+    };
+    let envelope = ta_events::schema::EventEnvelope::new(event);
+
+    if let Err(e) = store.append(&envelope) {
+        tracing::warn!("Failed to emit command_failed event: {}", e);
     }
 }
 
@@ -376,5 +776,135 @@ mod tests {
         let filter = config.access_filter();
         assert!(filter.permits("ta status"));
         assert!(filter.permits("anything"));
+    }
+
+    /// Helper to unwrap a Parsed result for simple assertions.
+    fn parsed(result: ParseResult) -> Vec<String> {
+        match result {
+            ParseResult::Parsed(args) => args,
+            ParseResult::Ambiguous(opts) => {
+                panic!("expected Parsed, got Ambiguous with {} options", opts.len())
+            }
+        }
+    }
+
+    /// Helper to unwrap an Ambiguous result.
+    fn ambiguous(result: ParseResult) -> Vec<Interpretation> {
+        match result {
+            ParseResult::Ambiguous(opts) => opts,
+            ParseResult::Parsed(args) => panic!("expected Ambiguous, got Parsed: {:?}", args),
+        }
+    }
+
+    #[test]
+    fn parse_args_run_multi_word_title() {
+        let args = parsed(parse_command_args("run v0.10.7 — Documentation Review"));
+        assert_eq!(args, vec!["run", "v0.10.7 — Documentation Review"]);
+    }
+
+    #[test]
+    fn parse_args_run_with_flags() {
+        let args = parsed(parse_command_args(
+            "run v0.10.7 Fix things --agent codex --headless",
+        ));
+        assert_eq!(
+            args,
+            vec![
+                "run",
+                "v0.10.7 Fix things",
+                "--agent",
+                "codex",
+                "--headless"
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_args_run_single_word() {
+        let args = parsed(parse_command_args("run v0.10.7"));
+        assert_eq!(args, vec!["run", "v0.10.7"]);
+    }
+
+    #[test]
+    fn parse_args_non_title_command() {
+        let args = parsed(parse_command_args("draft list"));
+        assert_eq!(args, vec!["draft", "list"]);
+    }
+
+    #[test]
+    fn parse_args_dev_bare() {
+        let args = parsed(parse_command_args("dev"));
+        assert_eq!(args, vec!["dev"]);
+    }
+
+    #[test]
+    fn parse_args_typo_dash_space_source() {
+        // `-- source .` should be detected as ambiguous: typo for `--source .`.
+        let opts = ambiguous(parse_command_args("run v0.10.7 -- source ."));
+        assert!(opts.len() >= 2, "expected at least 2 interpretations");
+        // One option should mention --source.
+        assert!(
+            opts.iter().any(|o| o.command.contains("--source")),
+            "expected a --source correction option"
+        );
+    }
+
+    #[test]
+    fn parse_args_ambiguous_unknown_flag_with_known() {
+        // `--build` is not a known run flag, but `--agent` is.
+        let opts = ambiguous(parse_command_args(
+            "run v0.10.7 --build Blah --agent claude-flow",
+        ));
+        assert!(opts.len() >= 2);
+    }
+
+    #[test]
+    fn parse_args_bare_double_dash_no_known_flags() {
+        // `run v0.10.7 -- build Blah` with no known flags present.
+        // Only one interpretation is possible (everything is the title), so
+        // it should be Parsed, not Ambiguous.
+        let args = parsed(parse_command_args("run v0.10.7 -- build Blah"));
+        assert_eq!(args, vec!["run", "v0.10.7 -- build Blah"]);
+    }
+
+    #[test]
+    fn parse_args_em_dash_unicode() {
+        // Real em-dash (—) is not `--`, should always be unambiguous title text.
+        let args = parsed(parse_command_args(
+            "run v0.10.7 — Documentation Review & Consolidation",
+        ));
+        assert_eq!(
+            args,
+            vec!["run", "v0.10.7 — Documentation Review & Consolidation"]
+        );
+    }
+
+    #[test]
+    fn parse_args_quoted_title() {
+        // Quoted titles are always unambiguous — no disambiguation needed.
+        let args = parsed(parse_command_args(
+            "run \"v0.10.7 -- build Blah\" --agent claude-flow",
+        ));
+        assert_eq!(
+            args,
+            vec!["run", "v0.10.7 -- build Blah", "--agent", "claude-flow"]
+        );
+    }
+
+    #[test]
+    fn parse_args_quoted_title_with_flags() {
+        let args = parsed(parse_command_args(
+            "run \"Fix the thing\" --headless --agent codex",
+        ));
+        assert_eq!(
+            args,
+            vec!["run", "Fix the thing", "--headless", "--agent", "codex"]
+        );
+    }
+
+    #[test]
+    fn split_quotes_basic() {
+        let tokens = split_respecting_quotes("run \"hello world\" --flag");
+        assert_eq!(tokens, vec!["run", "hello world", "--flag"]);
     }
 }

--- a/crates/ta-daemon/src/api/input.rs
+++ b/crates/ta-daemon/src/api/input.rs
@@ -146,6 +146,14 @@ pub fn route_input(text: &str, config: &ShellConfig) -> RouteDecision {
         }
     }
 
+    // Check if the first word is a known `ta` subcommand.
+    // This lets users type `run ...` instead of `ta run ...`.
+    if let Some(first_word) = text.split_whitespace().next() {
+        if config.ta_subcommands.iter().any(|s| s == first_word) {
+            return RouteDecision::Command(format!("ta {}", text));
+        }
+    }
+
     // No route matched — send to agent.
     RouteDecision::Agent(text.to_string())
 }
@@ -201,17 +209,6 @@ mod tests {
     }
 
     #[test]
-    fn route_to_agent() {
-        let config = default_config();
-        match route_input("What should we work on next?", &config) {
-            RouteDecision::Agent(prompt) => {
-                assert_eq!(prompt, "What should we work on next?");
-            }
-            _ => panic!("expected Agent"),
-        }
-    }
-
-    #[test]
     fn shortcut_expansion() {
         let config = default_config();
         match route_input("approve abc123", &config) {
@@ -253,6 +250,48 @@ mod tests {
         match route_input("release", &config) {
             RouteDecision::Command(cmd) => assert_eq!(cmd, "ta release run"),
             _ => panic!("expected Command from release shortcut"),
+        }
+    }
+
+    #[test]
+    fn bare_subcommand_routes_to_ta() {
+        let config = default_config();
+        // `run` is a ta subcommand — should auto-prefix with `ta `.
+        match route_input("run v0.10.7 — Documentation Review", &config) {
+            RouteDecision::Command(cmd) => {
+                assert_eq!(cmd, "ta run v0.10.7 — Documentation Review")
+            }
+            _ => panic!("expected Command from subcommand match"),
+        }
+    }
+
+    #[test]
+    fn bare_subcommand_dev() {
+        let config = default_config();
+        match route_input("dev", &config) {
+            RouteDecision::Command(cmd) => assert_eq!(cmd, "ta dev"),
+            _ => panic!("expected Command from subcommand match"),
+        }
+    }
+
+    #[test]
+    fn bare_subcommand_goal_with_args() {
+        let config = default_config();
+        match route_input("goal list", &config) {
+            RouteDecision::Command(cmd) => assert_eq!(cmd, "ta goal list"),
+            _ => panic!("expected Command from subcommand match"),
+        }
+    }
+
+    #[test]
+    fn unknown_word_routes_to_agent() {
+        let config = default_config();
+        // Not a subcommand — should go to agent.
+        match route_input("What should we work on next?", &config) {
+            RouteDecision::Agent(prompt) => {
+                assert_eq!(prompt, "What should we work on next?");
+            }
+            _ => panic!("expected Agent"),
         }
     }
 }

--- a/crates/ta-daemon/src/config.rs
+++ b/crates/ta-daemon/src/config.rs
@@ -169,6 +169,43 @@ pub struct ShellConfig {
     pub routes: Vec<RouteEntry>,
     #[serde(default)]
     pub shortcuts: Vec<ShortcutEntry>,
+    /// Known `ta` subcommands. Bare words matching these are auto-prefixed
+    /// with `ta ` so users can type `run ...` instead of `ta run ...`.
+    #[serde(default = "default_ta_subcommands")]
+    pub ta_subcommands: Vec<String>,
+}
+
+fn default_ta_subcommands() -> Vec<String> {
+    [
+        "goal",
+        "draft",
+        "audit",
+        "run",
+        "session",
+        "plan",
+        "context",
+        "credentials",
+        "events",
+        "token",
+        "dev",
+        "setup",
+        "init",
+        "agent",
+        "adapter",
+        "release",
+        "office",
+        "plugin",
+        "workflow",
+        "policy",
+        "config",
+        "gc",
+        "status",
+        "serve",
+        "conversation",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
 }
 
 impl Default for ShellConfig {
@@ -232,6 +269,7 @@ impl Default for ShellConfig {
                     expand: "ta release run".to_string(),
                 },
             ],
+            ta_subcommands: default_ta_subcommands(),
         }
     }
 }
@@ -484,6 +522,9 @@ mod tests {
         assert!(!config.shortcuts.is_empty());
         assert_eq!(config.routes[0].prefix, "ta ");
         assert_eq!(config.shortcuts[0].r#match, "approve");
+        assert!(config.ta_subcommands.contains(&"run".to_string()));
+        assert!(config.ta_subcommands.contains(&"dev".to_string()));
+        assert!(config.ta_subcommands.contains(&"goal".to_string()));
     }
 
     #[test]

--- a/crates/ta-events/src/schema.rs
+++ b/crates/ta-events/src/schema.rs
@@ -215,6 +215,13 @@ pub enum SessionEvent {
         turn_count: u32,
         outcome: String,
     },
+
+    /// A background command (e.g., `ta run`) failed.
+    CommandFailed {
+        command: String,
+        exit_code: i32,
+        stderr: String,
+    },
 }
 
 fn default_response_hint() -> String {
@@ -244,6 +251,7 @@ impl SessionEvent {
             Self::AgentQuestionAnswered { .. } => "agent_question_answered",
             Self::InteractiveSessionStarted { .. } => "interactive_session_started",
             Self::InteractiveSessionCompleted { .. } => "interactive_session_completed",
+            Self::CommandFailed { .. } => "command_failed",
         }
     }
 
@@ -323,6 +331,13 @@ impl SessionEvent {
                     "respond",
                     format!("ta interact respond {}", iid),
                     format!("Respond to agent question {}", short_id),
+                )]
+            }
+            Self::CommandFailed { command, .. } => {
+                vec![EventAction::new(
+                    "retry",
+                    command.clone(),
+                    format!("Retry: {}", command),
                 )]
             }
             // All other events have no suggested actions.

--- a/scripts/ta-shell.sh
+++ b/scripts/ta-shell.sh
@@ -30,6 +30,7 @@ DAEMON_URL="http://${BIND}:${PORT}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="${SCRIPT_DIR}/.."
 DEV_SCRIPT="${REPO_ROOT}/dev"
+DAEMON_LOG="${REPO_ROOT}/.ta/daemon.log"
 
 # ── Build ─────────────────────────────────────────────────────
 if [[ "$SKIP_BUILD" == false ]]; then
@@ -119,7 +120,8 @@ if daemon_healthy; then
     fi
 
     echo "Starting daemon at ${DAEMON_URL} ..."
-    "$DAEMON_BIN" --api --project-root "$PROJECT_ROOT" &
+    mkdir -p "$(dirname "$DAEMON_LOG")"
+    "$DAEMON_BIN" --api --project-root "$PROJECT_ROOT" >> "$DAEMON_LOG" 2>&1 &
     DAEMON_PID=$!
 
     for i in $(seq 1 20); do
@@ -145,7 +147,8 @@ if daemon_healthy; then
   fi
 else
   echo "Starting daemon at ${DAEMON_URL} ..."
-  "$DAEMON_BIN" --api --project-root "$PROJECT_ROOT" &
+  mkdir -p "$(dirname "$DAEMON_LOG")"
+  "$DAEMON_BIN" --api --project-root "$PROJECT_ROOT" >> "$DAEMON_LOG" 2>&1 &
   DAEMON_PID=$!
 
   # Wait up to 10 seconds for the daemon to become healthy.
@@ -170,4 +173,5 @@ else
 fi
 
 # ── Launch the shell ─────────────────────────────────────────
+echo "Daemon log: ${DAEMON_LOG}"
 exec "$TA_BIN" shell --url "$DAEMON_URL" "${SHELL_ARGS[@]}"


### PR DESCRIPTION
## Summary
- Route all `ta` subcommands as bare commands in the shell via `ta_subcommands` config list — no need to add individual shortcuts
- Fix multi-word title splitting for `run`/`dev` commands using known-flag-aware parser (fixes exit code 2 on `run v0.10.7 — Documentation Review`)
- Detect ambiguous input and typos (e.g., `-- source .` vs `--source .`) and present numbered disambiguation options
- Add `CommandFailed` event to `SessionEvent` so agents have context when background commands fail
- Redirect daemon stdout/stderr to `.ta/daemon.log` instead of bleeding into the TUI terminal
- Support quoted titles (`run "my title" --flag`) for unambiguous parsing

## Test plan
- [x] 20 unit tests in `cmd::tests` covering multi-word titles, flags, typos, bare `--`, unicode em-dash, quoted titles, and ambiguous patterns
- [x] 4 unit tests in `input::tests` for bare subcommand routing
- [x] Full `cargo test --workspace`, `cargo clippy`, `cargo fmt --check` pass
- [ ] Manual: start daemon via `ta-shell.sh`, verify daemon logs go to `.ta/daemon.log`
- [ ] Manual: run `run v0.10.7 — Documentation Review` in shell, verify it routes correctly
- [ ] Manual: run `run v0.10.7 -- source .` to see disambiguation prompt

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)