### PR TITLE
Implement v0.10.10 — Daemon Version Guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2921,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "chrono",
  "rmcp",
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -3089,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -3104,7 +3104,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "serde",
  "serde_json",
@@ -3117,7 +3117,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.10.9-alpha"
+version = "0.10.10-alpha"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2622,7 +2622,7 @@ The follow-up resolver doesn't assume git. It works from TA's own state:
 ---
 
 ### v0.10.10 — Daemon Version Guard
-<!-- status: pending -->
+<!-- status: done -->
 **Goal**: `ta shell` (and other CLI commands that talk to the daemon) should detect when the running daemon is an older version than the CLI and offer to restart it — rather than silently connecting to a stale daemon.
 
 #### Problem
@@ -2639,14 +2639,20 @@ After `./install_local.sh` rebuilds and installs new `ta` and `ta-daemon` binari
 4. If the user accepts, the CLI stops the old daemon (`POST /api/shutdown` or signal), waits for exit, then spawns the new one.
 5. If the user declines, proceed with a warning in the status bar (e.g., `daemon (stale)`).
 
-#### Items
-1. [ ] `GET /api/status` response includes `daemon_version` field (add if not present)
-2. [ ] `check_daemon_version()` in CLI: compare `env!("CARGO_PKG_VERSION")` to daemon's reported version
-3. [ ] Wire into `ta shell` startup: check version before entering TUI loop, prompt if mismatch
-4. [ ] Wire into `ta run` / `ta dev`: same check before launching agent
-5. [ ] Restart flow: graceful shutdown → wait for exit → spawn new daemon
-6. [ ] `--no-version-check` flag to skip (for CI or scripted use)
-7. [ ] Status bar indicator: show `(stale)` if user declined restart
+#### Completed
+1. ✅ `GET /api/status` response includes `daemon_version` field — added alongside existing `version` field in `ProjectStatus`
+2. ✅ `check_daemon_version()` in `version_guard.rs`: compares `env!("CARGO_PKG_VERSION")` to daemon's reported version, prompts interactively, returns `VersionGuardResult` enum
+3. ✅ Wired into `ta shell` startup (both classic and TUI modes): version check runs before entering the shell loop, prompts user to restart if mismatch
+4. ✅ Wired into `ta dev`: version check before launching orchestrator agent
+5. ✅ Restart flow: `POST /api/shutdown` graceful endpoint → wait for exit (5s timeout) → find daemon binary (sibling or PATH) → spawn new daemon → wait for healthy (10s) → verify version matches
+6. ✅ `--no-version-check` global CLI flag to skip (for CI or scripted use)
+7. ✅ TUI status bar: shows `◉ daemon (stale)` in yellow if daemon version doesn't match CLI version
+
+#### Remaining
+- `ta run` does not use the daemon API directly — no version check needed (it manages staging workspaces locally)
+
+#### Tests
+- 3 unit tests in `version_guard.rs`: variant construction, `find_daemon_binary` safety, stale result version extraction
 
 #### Version: `0.10.10-alpha`
 

--- a/apps/ta-cli/src/commands/dev.rs
+++ b/apps/ta-cli/src/commands/dev.rs
@@ -334,6 +334,7 @@ pub fn execute(
     project_root: &Path,
     agent: Option<&str>,
     unrestricted: bool,
+    no_version_check: bool,
 ) -> anyhow::Result<()> {
     let project_root = project_root
         .canonicalize()
@@ -341,6 +342,20 @@ pub fn execute(
 
     // Generate a session ID for audit trail.
     let session_id = uuid::Uuid::new_v4().to_string();
+
+    // Version guard check: warn if a running daemon has a different version (v0.10.10).
+    if !no_version_check {
+        let base_url = super::shell::resolve_daemon_url(&project_root);
+        let rt = tokio::runtime::Runtime::new()?;
+        let client = reqwest::Client::new();
+        let _guard = super::version_guard::check_daemon_version(
+            &client,
+            &base_url,
+            &project_root,
+            true, // interactive
+            &rt,
+        );
+    }
 
     println!("Starting interactive developer loop...");
     println!("  Project: {}", project_root.display());

--- a/apps/ta-cli/src/commands/mod.rs
+++ b/apps/ta-cli/src/commands/mod.rs
@@ -30,4 +30,5 @@ pub mod status;
 pub mod terms;
 pub mod token;
 pub mod verify;
+pub mod version_guard;
 pub mod workflow;

--- a/apps/ta-cli/src/commands/shell.rs
+++ b/apps/ta-cli/src/commands/shell.rs
@@ -44,6 +44,7 @@ pub fn execute(
     daemon_url: Option<&str>,
     init: bool,
     classic: bool,
+    no_version_check: bool,
 ) -> anyhow::Result<()> {
     if init {
         return init_config(project_root);
@@ -51,7 +52,7 @@ pub fn execute(
 
     // Default to TUI mode; --classic falls back to rustyline.
     if !classic {
-        return super::shell_tui::run(project_root, attach, daemon_url, false);
+        return super::shell_tui::run(project_root, attach, daemon_url, false, no_version_check);
     }
 
     let base_url = daemon_url
@@ -59,6 +60,21 @@ pub fn execute(
         .unwrap_or_else(|| resolve_daemon_url(project_root));
 
     let rt = tokio::runtime::Runtime::new()?;
+
+    // Version guard check (v0.10.10).
+    if !no_version_check {
+        let client = reqwest::Client::new();
+        let _guard = super::version_guard::check_daemon_version(
+            &client,
+            &base_url,
+            project_root,
+            true, // interactive
+            &rt,
+        );
+        // All results (Match, Stale, Restarted, Unreachable) proceed —
+        // the function already printed warnings/prompts as needed.
+    }
+
     rt.block_on(run_shell(base_url, attach.map(|s| s.to_string())))
 }
 

--- a/apps/ta-cli/src/commands/shell_tui.rs
+++ b/apps/ta-cli/src/commands/shell_tui.rs
@@ -351,6 +351,7 @@ pub fn run(
     attach: Option<&str>,
     daemon_url: Option<&str>,
     init: bool,
+    no_version_check: bool,
 ) -> anyhow::Result<()> {
     if init {
         return super::shell::init_config(project_root);
@@ -361,6 +362,20 @@ pub fn run(
         .unwrap_or_else(|| resolve_daemon_url(project_root));
 
     let rt = tokio::runtime::Runtime::new()?;
+
+    // Version guard check (v0.10.10).
+    if !no_version_check {
+        let client = reqwest::Client::new();
+        let _guard = super::version_guard::check_daemon_version(
+            &client,
+            &base_url,
+            project_root,
+            true, // interactive — TUI hasn't started yet, stdin is available
+            &rt,
+        );
+        // All results proceed — the function already printed warnings/prompts.
+    }
+
     rt.block_on(run_tui(base_url, attach.map(|s| s.to_string())))
 }
 
@@ -801,10 +816,18 @@ fn draw_input(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
-    let daemon_indicator = if app.daemon_connected {
-        Span::styled(" ◉ daemon ", Style::default().fg(Color::Green))
-    } else {
+    let cli_version = env!("CARGO_PKG_VERSION");
+    let is_stale = app.daemon_connected
+        && !app.status.version.is_empty()
+        && app.status.version != "?"
+        && app.status.version != cli_version;
+
+    let daemon_indicator = if !app.daemon_connected {
         Span::styled(" ◉ daemon ", Style::default().fg(Color::Red))
+    } else if is_stale {
+        Span::styled(" ◉ daemon (stale) ", Style::default().fg(Color::Yellow))
+    } else {
+        Span::styled(" ◉ daemon ", Style::default().fg(Color::Green))
     };
 
     let phase_str = app.status.next_phase.as_deref().unwrap_or("(none)");

--- a/apps/ta-cli/src/commands/version_guard.rs
+++ b/apps/ta-cli/src/commands/version_guard.rs
@@ -1,0 +1,290 @@
+// version_guard.rs — Daemon version guard (v0.10.10).
+//
+// Detects when the running daemon is an older (or newer) version than the CLI
+// and offers to restart it. Prevents confusion from stale daemons after upgrades.
+//
+// Used by `ta shell`, `ta run`, and `ta dev` before connecting to the daemon.
+
+use std::io::{self, Write};
+use std::path::Path;
+use std::process::Command;
+
+/// Result of a version guard check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionGuardResult {
+    /// Versions match — proceed normally.
+    Match,
+    /// Mismatch detected but user declined restart (or non-interactive).
+    /// The status bar should show "(stale)".
+    Stale {
+        daemon_version: String,
+        cli_version: String,
+    },
+    /// Daemon was restarted with the matching version.
+    Restarted,
+    /// Daemon is unreachable — caller should handle as usual.
+    Unreachable,
+}
+
+/// Check the daemon version against the CLI version and optionally restart.
+///
+/// If `interactive` is true, prompts the user to restart on mismatch.
+/// If `interactive` is false (e.g., `--no-version-check`), skips the check entirely.
+///
+/// Returns `VersionGuardResult` indicating what happened.
+pub fn check_daemon_version(
+    client: &reqwest::Client,
+    base_url: &str,
+    project_root: &Path,
+    interactive: bool,
+    rt: &tokio::runtime::Runtime,
+) -> VersionGuardResult {
+    let cli_version = env!("CARGO_PKG_VERSION");
+
+    // Fetch daemon status.
+    let status = rt.block_on(super::shell::fetch_status(client, base_url));
+
+    if status.version.is_empty() || status.version == "?" {
+        return VersionGuardResult::Unreachable;
+    }
+
+    if status.version == cli_version {
+        return VersionGuardResult::Match;
+    }
+
+    // Version mismatch detected.
+    eprintln!(
+        "Daemon version mismatch: daemon v{}, CLI v{}",
+        status.version, cli_version
+    );
+
+    if !interactive {
+        eprintln!("  Proceeding with mismatched daemon (--no-version-check).");
+        return VersionGuardResult::Stale {
+            daemon_version: status.version,
+            cli_version: cli_version.to_string(),
+        };
+    }
+
+    // Prompt user.
+    eprint!("Restart daemon with the new version? [Y/n] ");
+    let _ = io::stderr().flush();
+
+    let mut answer = String::new();
+    if io::stdin().read_line(&mut answer).is_err() {
+        // Non-interactive stdin (pipe, etc.) — don't restart.
+        eprintln!("  (non-interactive — skipping restart)");
+        return VersionGuardResult::Stale {
+            daemon_version: status.version,
+            cli_version: cli_version.to_string(),
+        };
+    }
+
+    let answer = answer.trim().to_lowercase();
+    if answer == "n" || answer == "no" {
+        eprintln!("  Proceeding with stale daemon.");
+        return VersionGuardResult::Stale {
+            daemon_version: status.version,
+            cli_version: cli_version.to_string(),
+        };
+    }
+
+    // User accepted (default is yes) — restart the daemon.
+    match restart_daemon(client, base_url, project_root, rt) {
+        Ok(()) => VersionGuardResult::Restarted,
+        Err(e) => {
+            eprintln!("  Failed to restart daemon: {}", e);
+            eprintln!("  Proceeding with stale daemon.");
+            VersionGuardResult::Stale {
+                daemon_version: status.version,
+                cli_version: cli_version.to_string(),
+            }
+        }
+    }
+}
+
+/// Restart the daemon: send shutdown request, wait for exit, spawn new one.
+fn restart_daemon(
+    client: &reqwest::Client,
+    base_url: &str,
+    project_root: &Path,
+    rt: &tokio::runtime::Runtime,
+) -> anyhow::Result<()> {
+    eprintln!("  Shutting down old daemon...");
+
+    // Send graceful shutdown request.
+    let shutdown_url = format!("{}/api/shutdown", base_url);
+    let _ = rt.block_on(client.post(&shutdown_url).send());
+
+    // Wait for the daemon to actually exit (up to 5 seconds).
+    for _ in 0..10 {
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let check_url = format!("{}/api/status", base_url);
+        let still_running = rt.block_on(async {
+            client
+                .get(&check_url)
+                .timeout(std::time::Duration::from_secs(1))
+                .send()
+                .await
+                .is_ok()
+        });
+        if !still_running {
+            break;
+        }
+    }
+
+    // Verify it's actually down.
+    let check_url = format!("{}/api/status", base_url);
+    let still_running = rt.block_on(async {
+        client
+            .get(&check_url)
+            .timeout(std::time::Duration::from_secs(1))
+            .send()
+            .await
+            .is_ok()
+    });
+    if still_running {
+        return Err(anyhow::anyhow!(
+            "Old daemon did not shut down within 5 seconds. \
+             Kill it manually: pkill -f 'ta-daemon'"
+        ));
+    }
+
+    // Find the daemon binary — prefer the one next to our own binary.
+    let daemon_bin = find_daemon_binary()?;
+
+    eprintln!("  Starting new daemon: {}", daemon_bin.display());
+
+    // Parse bind/port from the base_url.
+    let log_path = project_root.join(".ta").join("daemon.log");
+    let log_file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|e| anyhow::anyhow!("Cannot open daemon log {}: {}", log_path.display(), e))?;
+
+    let stderr_log = log_file
+        .try_clone()
+        .map_err(|e| anyhow::anyhow!("Cannot clone log file handle: {}", e))?;
+
+    let child = Command::new(&daemon_bin)
+        .arg("--api")
+        .arg("--project-root")
+        .arg(project_root)
+        .stdout(log_file)
+        .stderr(stderr_log)
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("Cannot spawn {}: {}", daemon_bin.display(), e))?;
+
+    eprintln!("  New daemon started (pid {})", child.id());
+
+    // Wait for it to become healthy (up to 10 seconds).
+    for i in 0..20 {
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        let healthy = rt.block_on(async {
+            client
+                .get(&check_url)
+                .timeout(std::time::Duration::from_secs(2))
+                .send()
+                .await
+                .is_ok()
+        });
+        if healthy {
+            // Verify the new daemon has the right version.
+            let status = rt.block_on(super::shell::fetch_status(client, base_url));
+            let cli_version = env!("CARGO_PKG_VERSION");
+            if status.version == cli_version {
+                eprintln!("  Daemon restarted successfully (v{}).", cli_version);
+            } else {
+                eprintln!(
+                    "  Warning: new daemon is v{}, expected v{} — the installed binary may be outdated.",
+                    status.version, cli_version
+                );
+            }
+            return Ok(());
+        }
+        if i == 9 {
+            eprintln!("  Still waiting for new daemon to start...");
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "New daemon did not become healthy within 10 seconds. \
+         Check log: {}",
+        log_path.display()
+    ))
+}
+
+/// Find the `ta-daemon` binary.
+///
+/// Search order:
+///   1. Same directory as the current `ta` binary
+///   2. PATH lookup
+fn find_daemon_binary() -> anyhow::Result<std::path::PathBuf> {
+    // Try sibling of the current executable.
+    if let Ok(current_exe) = std::env::current_exe() {
+        if let Some(dir) = current_exe.parent() {
+            let sibling = dir.join("ta-daemon");
+            if sibling.exists() {
+                return Ok(sibling);
+            }
+        }
+    }
+
+    // Try PATH lookup.
+    if let Ok(output) = Command::new("which").arg("ta-daemon").output() {
+        if output.status.success() {
+            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !path.is_empty() {
+                return Ok(std::path::PathBuf::from(path));
+            }
+        }
+    }
+
+    Err(anyhow::anyhow!(
+        "Cannot find 'ta-daemon' binary. \
+         Ensure it is in the same directory as 'ta' or on your PATH."
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_guard_result_variants() {
+        let m = VersionGuardResult::Match;
+        assert_eq!(m, VersionGuardResult::Match);
+
+        let s = VersionGuardResult::Stale {
+            daemon_version: "0.10.9-alpha".to_string(),
+            cli_version: "0.10.10-alpha".to_string(),
+        };
+        assert!(matches!(s, VersionGuardResult::Stale { .. }));
+    }
+
+    #[test]
+    fn find_daemon_binary_does_not_panic() {
+        // This may succeed or fail depending on the environment,
+        // but it should not panic.
+        let _ = find_daemon_binary();
+    }
+
+    #[test]
+    fn stale_result_carries_versions() {
+        let result = VersionGuardResult::Stale {
+            daemon_version: "0.10.5-alpha".to_string(),
+            cli_version: "0.10.10-alpha".to_string(),
+        };
+        match result {
+            VersionGuardResult::Stale {
+                daemon_version,
+                cli_version,
+            } => {
+                assert_eq!(daemon_version, "0.10.5-alpha");
+                assert_eq!(cli_version, "0.10.10-alpha");
+            }
+            _ => panic!("expected Stale"),
+        }
+    }
+}

--- a/apps/ta-cli/src/main.rs
+++ b/apps/ta-cli/src/main.rs
@@ -34,6 +34,10 @@ struct Cli {
     #[arg(long, global = true)]
     accept_terms: bool,
 
+    /// Skip the daemon version guard check (for CI or scripted use).
+    #[arg(long, global = true)]
+    no_version_check: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -433,7 +437,13 @@ fn main() -> anyhow::Result<()> {
         Commands::Dev {
             agent,
             unrestricted,
-        } => commands::dev::execute(&config, &project_root, agent.as_deref(), *unrestricted),
+        } => commands::dev::execute(
+            &config,
+            &project_root,
+            agent.as_deref(),
+            *unrestricted,
+            cli.no_version_check,
+        ),
         Commands::Session { command } => commands::session::execute(command, &config),
         Commands::Plan { command } => commands::plan::execute(command, &config),
         Commands::Context { command } => commands::context::execute(command, &config),
@@ -454,6 +464,7 @@ fn main() -> anyhow::Result<()> {
             url.as_deref(),
             *init,
             *classic,
+            cli.no_version_check,
         ),
         Commands::Office { command } => commands::office::execute(command, &project_root),
         Commands::Plugin { command } => {

--- a/crates/ta-daemon/src/api/mod.rs
+++ b/crates/ta-daemon/src/api/mod.rs
@@ -238,6 +238,26 @@ async fn reload_office(
     }
 }
 
+/// `POST /api/shutdown` — Graceful daemon shutdown (v0.10.10).
+///
+/// Responds with 200 and then exits the process. Used by the CLI's
+/// version guard to restart the daemon with a matching version.
+async fn shutdown_daemon(
+    axum::extract::State(_state): axum::extract::State<Arc<AppState>>,
+) -> impl IntoResponse {
+    tracing::info!("Shutdown requested via POST /api/shutdown");
+    // Spawn the exit on a short delay so the response is sent first.
+    tokio::spawn(async {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        std::process::exit(0);
+    });
+    Json(serde_json::json!({
+        "status": "shutting_down",
+        "message": "Daemon is shutting down gracefully."
+    }))
+    .into_response()
+}
+
 /// Build the full API router with auth middleware.
 pub fn build_api_router(state: Arc<AppState>) -> Router {
     Router::new()
@@ -277,6 +297,8 @@ pub fn build_api_router(state: Arc<AppState>) -> Router {
             get(get_project).delete(remove_project),
         )
         .route("/api/office/reload", post(reload_office))
+        // Daemon lifecycle routes (v0.10.10).
+        .route("/api/shutdown", post(shutdown_daemon))
         // Auth middleware on all API routes.
         .layer(middleware::from_fn_with_state(
             state.clone(),

--- a/crates/ta-daemon/src/api/status.rs
+++ b/crates/ta-daemon/src/api/status.rs
@@ -19,6 +19,9 @@ use crate::api::AppState;
 pub struct ProjectStatus {
     pub project: String,
     pub version: String,
+    /// Explicit daemon version field for version guard checks.
+    /// Always matches `version` but provides a stable API contract.
+    pub daemon_version: String,
     pub current_phase: Option<PhaseInfo>,
     pub active_agents: Vec<AgentInfo>,
     pub pending_drafts: usize,
@@ -128,7 +131,8 @@ pub async fn project_status(State(state): State<Arc<AppState>>) -> impl IntoResp
 
     Json(ProjectStatus {
         project: project_name,
-        version,
+        version: version.clone(),
+        daemon_version: version,
         current_phase,
         active_agents,
         pending_drafts,

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: v0.10.9-alpha
+**Version**: v0.10.10-alpha
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 
@@ -2119,6 +2119,27 @@ curl -s http://127.0.0.1:7700/api/status | head
 
 If the daemon is not running, `ta shell` will show connection errors on startup.
 
+#### Daemon Version Guard
+
+When `ta shell` or `ta dev` connects to the daemon, it checks whether the daemon version matches the CLI version. After an upgrade (e.g., `./install_local.sh`), the old daemon process may still be running with the previous version. The version guard detects this and prompts you:
+
+```
+Daemon version mismatch: daemon v0.10.6-alpha, CLI v0.10.10-alpha
+Restart daemon with the new version? [Y/n]
+```
+
+- **Yes** (default): The CLI sends a graceful shutdown request, waits for the old daemon to exit, starts the new one, and verifies it's healthy.
+- **No**: The shell proceeds but shows `daemon (stale)` in the status bar so you know you're running against a mismatched daemon.
+
+To skip the version check (useful in CI or scripts):
+
+```bash
+ta --no-version-check shell
+ta --no-version-check dev
+```
+
+The `--no-version-check` flag is global — it works with any subcommand.
+
 #### Starting the shell
 
 ```bash
@@ -3981,6 +4002,7 @@ TA has a working end-to-end workflow: staging isolation, agent wrapping, draft r
 | v0.10.7 | Documentation review & consolidation | Done |
 | v0.10.8 | Pre-draft verification gate | Done |
 | v0.10.9 | Smart follow-up UX | Done |
+| v0.10.10 | Daemon version guard | Done |
 
 See [PLAN.md](../PLAN.md) for full details on each phase.
 


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.10.10 — Daemon Version Guard

**Why**: `ta shell` (and other CLI commands that talk to the daemon) should detect when the running daemon is an older version than the CLI and offer to restart it — rather than silently connecting to a stale daemon.

**Impact**: 13 file(s) changed

## Changes (13 file(s))

- `~` `fs://workspace/.git/index`
- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/Cargo.toml` — Bumped workspace version from 0.10.9-alpha to 0.10.10-alpha.
  - Version bump for v0.10.10 release.
- `~` `fs://workspace/PLAN.md` — Replaced all 7 v0.10.10 unchecked items with completed items (checkmarks) plus implementation details. Added Remaining note about ta run not needing version check. Added test count (3 tests in version_guard.rs).
  - Plan progress tracking must reflect what was actually implemented.
- `~` `fs://workspace/apps/ta-cli/src/commands/dev.rs` — Updated execute() to accept no_version_check parameter. Added version guard check before launching the orchestrator agent — resolves daemon URL from project root and calls check_daemon_version().
  - ta dev uses MCP tools served by the daemon, so a stale daemon could cause confusing behavior with outdated tool implementations.
- `~` `fs://workspace/apps/ta-cli/src/commands/mod.rs` — Added `pub mod version_guard` to the module list.
  - Required to compile the new version_guard.rs module.
- `~` `fs://workspace/apps/ta-cli/src/commands/shell.rs` — Updated execute() to accept no_version_check parameter. Added version guard check before entering classic shell REPL — calls check_daemon_version() with interactive=true.
  - Classic shell mode needs the same version guard as TUI mode. The check runs before the shell loop so stdin is available for the Y/n prompt.
- `~` `fs://workspace/apps/ta-cli/src/commands/shell_tui.rs` — Updated run() to accept no_version_check parameter. Added version guard check before entering TUI event loop. Updated draw_status_bar() to show '◉ daemon (stale)' in yellow when the daemon version doesn't match the CLI version.
  - TUI shell needs both the startup prompt and a persistent visual indicator so users always know if they're connected to a mismatched daemon.
- `+` `fs://workspace/apps/ta-cli/src/commands/version_guard.rs` — New module implementing daemon version guard logic. Contains: VersionGuardResult enum (Match/Stale/Restarted/Unreachable), check_daemon_version() with interactive Y/n prompt, restart_daemon() with graceful POST /api/shutdown → wait → spawn → verify flow, find_daemon_binary() to locate ta-daemon (sibling or PATH). 3 unit tests.
  - Core feature: users should not silently connect to a stale daemon after upgrading. The interactive prompt and automatic restart make version mismatches frictionless to resolve.
- `~` `fs://workspace/apps/ta-cli/src/main.rs` — Added --no-version-check global CLI flag. Updated Shell dispatch to pass no_version_check to shell::execute(). Updated Dev dispatch to pass no_version_check to dev::execute().
  - CLI surface for the version guard: global flag makes it available to any subcommand, and dispatch changes wire it through to the commands that need it.
- `~` `fs://workspace/crates/ta-daemon/src/api/mod.rs` — Added POST /api/shutdown endpoint with graceful shutdown handler. The handler responds with 200 and then exits the process after a 250ms delay (so the response is sent first). Added the route to build_api_router().
  - The version guard needs a way to gracefully stop the old daemon before spawning a new one. Signal-based shutdown (pkill) is fragile and platform-specific; an HTTP endpoint is reliable and cross-platform.
- `~` `fs://workspace/crates/ta-daemon/src/api/status.rs` — Added daemon_version field to ProjectStatus struct. Set it to the same value as the existing version field in the handler.
  - Provides an explicit, stable API contract for version guard checks. The daemon_version field is specifically for programmatic comparison, while version remains for display.
- `~` `fs://workspace/docs/USAGE.md` — Updated version from v0.10.9-alpha to v0.10.10-alpha. Added 'Daemon Version Guard' section under Interactive Shell with prompt example, behavior description, and --no-version-check flag documentation. Added v0.10.10 to roadmap table.
  - User-facing documentation must cover the new version guard feature, its UX, and how to disable it.

## Goal Context

- **Title**: Implement v0.10.10 — Daemon Version Guard
- **Objective**: Implement v0.10.10 — Daemon Version Guard
- **Goal ID**: `bf3b54e3-8e2e-4d87-ad65-449faac8dc91`
- **PR ID**: `28395dfb-8a32-48fe-b94f-80d2f77d70e6`
- **Plan Phase**: `0.10.10`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
