### PR TITLE
Fix :tail not resolving goal UUID to output stream

### DIFF
--- a/crates/ta-daemon/src/api/cmd.rs
+++ b/crates/ta-daemon/src/api/cmd.rs
@@ -152,10 +152,19 @@ pub async fn execute_command(
 
                     let stderr_lines = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
                     let stderr_lines2 = stderr_lines.clone();
+                    let goal_output2 = goal_output.clone();
+                    let output_key2 = output_key.clone();
                     let stderr_task = tokio::spawn(async move {
                         if let Some(err) = stderr {
                             let mut reader = BufReader::new(err).lines();
                             while let Ok(Some(line)) = reader.next_line().await {
+                                // Detect [goal started] events and register the goal UUID
+                                // as an alias so :tail <uuid> resolves to this channel.
+                                if line.contains("[goal started]") {
+                                    if let Some(goal_uuid) = extract_goal_uuid_from_event(&line) {
+                                        goal_output2.add_alias(&goal_uuid, &output_key2).await;
+                                    }
+                                }
                                 let _ = tx2.send(OutputLine {
                                     stream: "stderr",
                                     line: line.clone(),
@@ -405,6 +414,23 @@ fn extract_goal_key(args: &[String]) -> String {
     }
     // Fallback to UUID.
     uuid::Uuid::new_v4().to_string()
+}
+
+/// Extract a goal UUID from a `[goal started]` event line.
+/// Expected format: `[goal started] "title" (uuid)`
+fn extract_goal_uuid_from_event(line: &str) -> Option<String> {
+    let paren_start = line.rfind('(')?;
+    let paren_end = line.rfind(')')?;
+    if paren_end <= paren_start + 1 {
+        return None;
+    }
+    let candidate = &line[paren_start + 1..paren_end];
+    // Validate it looks like a UUID (8-4-4-4-12 or at least 8+ hex chars).
+    if candidate.len() >= 8 && candidate.chars().all(|c| c.is_ascii_hexdigit() || c == '-') {
+        Some(candidate.to_string())
+    } else {
+        None
+    }
 }
 
 /// Commands that take a free-form title as their first positional argument.
@@ -978,5 +1004,35 @@ mod tests {
     fn split_quotes_basic() {
         let tokens = split_respecting_quotes("run \"hello world\" --flag");
         assert_eq!(tokens, vec!["run", "hello world", "--flag"]);
+    }
+
+    #[test]
+    fn extract_goal_uuid_from_goal_started_event() {
+        let line =
+            r#"[goal started] "v0.10.13 — ta plan add" (492fac59-eda4-4e87-bf65-9e2edd2e70ce)"#;
+        assert_eq!(
+            extract_goal_uuid_from_event(line),
+            Some("492fac59-eda4-4e87-bf65-9e2edd2e70ce".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_goal_uuid_short_id() {
+        let line = r#"[goal started] "title" (abcd1234)"#;
+        assert_eq!(
+            extract_goal_uuid_from_event(line),
+            Some("abcd1234".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_goal_uuid_no_parens() {
+        assert_eq!(extract_goal_uuid_from_event("no parens here"), None);
+    }
+
+    #[test]
+    fn extract_goal_uuid_non_hex() {
+        let line = r#"[goal started] "title" (not-hex-zzzz)"#;
+        assert_eq!(extract_goal_uuid_from_event(line), None);
     }
 }

--- a/crates/ta-daemon/src/api/goal_output.rs
+++ b/crates/ta-daemon/src/api/goal_output.rs
@@ -60,6 +60,18 @@ impl GoalOutputManager {
         channels.get(goal_id).map(|tx| tx.subscribe())
     }
 
+    /// Register an alias so that `alias` resolves to the same channel as `primary`.
+    /// Used to map goal UUIDs to the human-friendly output key (e.g., "v0.10.13").
+    pub async fn add_alias(&self, alias: &str, primary: &str) {
+        let channels = self.channels.lock().await;
+        if let Some(tx) = channels.get(primary) {
+            let tx = tx.clone();
+            drop(channels);
+            let mut channels = self.channels.lock().await;
+            channels.insert(alias.to_string(), tx);
+        }
+    }
+
     /// Remove a goal's channel (call when the goal process exits).
     pub async fn remove_channel(&self, goal_id: &str) {
         let mut channels = self.channels.lock().await;
@@ -189,5 +201,38 @@ mod tests {
     async fn subscribe_nonexistent_returns_none() {
         let mgr = GoalOutputManager::new();
         assert!(mgr.subscribe("nope").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn alias_resolves_to_same_channel() {
+        let mgr = GoalOutputManager::new();
+        let tx = mgr.create_channel("v0.10.13").await;
+
+        // Add alias (goal UUID → output key).
+        mgr.add_alias("492fac59-eda4-4e87-bf65-9e2edd2e70ce", "v0.10.13")
+            .await;
+
+        // Subscribe via alias.
+        let mut rx = mgr
+            .subscribe("492fac59-eda4-4e87-bf65-9e2edd2e70ce")
+            .await
+            .unwrap();
+
+        // Send via primary key's sender — alias subscriber receives it.
+        tx.send(OutputLine {
+            stream: "stdout",
+            line: "from primary".to_string(),
+        })
+        .unwrap();
+        let line = rx.recv().await.unwrap();
+        assert_eq!(line.line, "from primary");
+    }
+
+    #[tokio::test]
+    async fn alias_nonexistent_primary_is_noop() {
+        let mgr = GoalOutputManager::new();
+        // Should not panic or create a channel.
+        mgr.add_alias("alias", "nonexistent").await;
+        assert!(mgr.subscribe("alias").await.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Output channels are keyed by human-friendly names (e.g., `v0.10.13`) but `:tail` and auto-tail look up by goal UUID — these never matched
- When `[goal started]` is detected in subprocess stderr, the goal UUID is now registered as an alias to the same broadcast channel
- Adds `add_alias()` to `GoalOutputManager` so both the friendly key and UUID resolve to the same stream

## Test plan
- [x] `cargo test -p ta-daemon` — all pass (4 new tests for alias + UUID extraction)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean