### PR TITLE
Fix :tail full-UUID lookup with short alias

### DIFF
--- a/crates/ta-daemon/src/api/goal_output.rs
+++ b/crates/ta-daemon/src/api/goal_output.rs
@@ -154,16 +154,22 @@ pub async fn list_active_output(State(state): State<Arc<AppState>>) -> impl Into
 }
 
 /// Resolve a short goal ID prefix to a full ID.
-async fn resolve_goal_id(state: &AppState, prefix: &str) -> Option<String> {
+async fn resolve_goal_id(state: &AppState, query: &str) -> Option<String> {
     let active = state.goal_output.active_goals().await;
     // Exact match.
-    if active.contains(&prefix.to_string()) {
-        return Some(prefix.to_string());
+    if active.contains(&query.to_string()) {
+        return Some(query.to_string());
     }
-    // Prefix match.
-    let matches: Vec<_> = active.iter().filter(|id| id.starts_with(prefix)).collect();
-    if matches.len() == 1 {
-        return Some(matches[0].clone());
+    // Forward prefix: query is a prefix of an active key (e.g. short ID → full UUID).
+    let forward: Vec<_> = active.iter().filter(|id| id.starts_with(query)).collect();
+    if forward.len() == 1 {
+        return Some(forward[0].clone());
+    }
+    // Reverse prefix: an active key is a prefix of the query (e.g. alias "d01f0930"
+    // matches query "d01f0930-bc2f-432f-bbf3-40c75b991e15").
+    let reverse: Vec<_> = active.iter().filter(|id| query.starts_with(id.as_str())).collect();
+    if reverse.len() == 1 {
+        return Some(reverse[0].clone());
     }
     None
 }


### PR DESCRIPTION
## Summary
- `resolve_goal_id()` only checked forward prefix match (query is prefix of key), but the stderr alias registers the **short** UUID (e.g. `d01f0930`) while the TUI queries the **full** UUID (`d01f0930-bc2f-432f-bbf3-40c75b991e15`)
- Added reverse prefix check: if a registered key is a prefix of the query, resolve to it
- This is the root cause of the persistent "No active output stream" error — the 5x retry logic from PR #134 didn't help because the mismatch was in key resolution, not timing

## Test plan
- [x] `cargo test -p ta-daemon -- goal_output` — 4/4 pass
- [x] `cargo clippy -p ta-daemon -- -D warnings` — clean

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)