### PR TITLE
v0.10.17.1 — Shell reliability & command timeout fixes

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2867,6 +2867,19 @@ Tests: 25 new tests (name validation, template resolution, scaffold generation, 
 
 ---
 
+### v0.10.17.1 — Shell Reliability & Command Timeout Fixes
+<!-- status: in_progress -->
+**Goal**: Fix three reliability issues in the TUI shell: auto-tail race condition (still failing despite retries), draft view scrollback not rendering full output, and `draft apply` timing out due to pre-commit verification.
+
+#### Items
+1. [ ] **Auto-tail client-side prefix resolution**: When the UUID-based tail lookup fails, query `active-output` and do client-side prefix matching to find the output channel. Eliminates dependency on stderr alias registration timing.
+2. [ ] **`draft apply` as long-running command**: Add `draft apply` to daemon's `long_running` patterns so it streams output instead of timing out at 120s. Pre-commit verification (fmt + clippy + test) easily exceeds this.
+3. [ ] **Scrollback pre-slicing** (from v0.10.15.1): Already implemented — pre-slices logical lines to bypass ratatui's `u16` scroll overflow. Verify working with rebuilt binary.
+
+#### Version: `0.10.17-alpha.1`
+
+---
+
 ### v0.10.18 — Deferred Items: Workflow & Multi-Project
 <!-- status: pending -->
 **Goal**: Address remaining deferred items from workflow engine and multi-project phases.

--- a/apps/ta-cli/src/commands/shell_tui.rs
+++ b/apps/ta-cli/src/commands/shell_tui.rs
@@ -1776,21 +1776,36 @@ async fn start_tail_stream(
         "─── live output ───".to_string(),
     ));
 
-    // Connect to goal output SSE stream. Retry a few times because the output
-    // channel alias (goal UUID → output key) may not be registered yet when
-    // auto-tail fires immediately after a goal_started event.
-    let url = format!("{}/api/goals/{}/output", base_url, target);
+    // Connect to goal output SSE stream. Retry with escalating strategies:
+    // 1. Try the exact target (may be full UUID, short ID, or output key)
+    // 2. On 404, query active-output and do client-side prefix match
+    // 3. Retry with delays since the channel may not be registered yet
     let mut resp_result = None;
+    let mut resolved_target = target.clone();
     for attempt in 0..5 {
         if attempt > 0 {
             tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         }
+        let url = format!("{}/api/goals/{}/output", base_url, resolved_target);
         match client.get(&url).send().await {
             Ok(r) if r.status().is_success() => {
                 resp_result = Some(r);
                 break;
             }
-            Ok(_) if attempt < 4 => continue, // Retry on 404
+            Ok(_) if attempt < 4 => {
+                // On 404, try client-side prefix resolution against active goals.
+                // The output channel uses a human-friendly key (e.g., "v0.10.17 — ...")
+                // but auto-tail passes the full UUID from the SSE event. The daemon's
+                // reverse-prefix match may not find it if the alias isn't registered yet.
+                if attempt == 1 {
+                    if let Some(matched) =
+                        resolve_via_active_output(&client, base_url, &target).await
+                    {
+                        resolved_target = matched;
+                    }
+                }
+                continue;
+            }
             Ok(r) => {
                 let json: serde_json::Value = r.json().await.unwrap_or_default();
                 let err = json["error"].as_str().unwrap_or("unknown error");
@@ -2116,6 +2131,35 @@ fn handle_follow_up_picker(app: &mut App, text: &str) {
 
 /// Parse `:tail [id] [--lines <count>]` arguments.
 ///
+/// Client-side prefix resolution: query `/api/goals/active-output` and find
+/// a goal whose key starts with the given prefix (short UUID match).
+async fn resolve_via_active_output(
+    client: &reqwest::Client,
+    base_url: &str,
+    prefix: &str,
+) -> Option<String> {
+    let url = format!("{}/api/goals/active-output", base_url);
+    let resp = client.get(&url).send().await.ok()?;
+    let json: serde_json::Value = resp.json().await.ok()?;
+    let goals: Vec<String> = json["goals"]
+        .as_array()?
+        .iter()
+        .filter_map(|v| v.as_str().map(String::from))
+        .collect();
+    // Try: an active goal whose key starts with our prefix (short UUID).
+    let short = &prefix[..8.min(prefix.len())];
+    for g in &goals {
+        if g.starts_with(short) || g.starts_with(prefix) {
+            return Some(g.clone());
+        }
+    }
+    // Fallback: if there's exactly one active goal, use it.
+    if goals.len() == 1 {
+        return Some(goals[0].clone());
+    }
+    None
+}
+
 /// Returns `(goal_id, backfill_lines)`. If `--lines` is not specified, uses
 /// the provided `default_backfill` from config.
 pub(crate) fn parse_tail_args(text: &str, default_backfill: usize) -> (Option<String>, usize) {

--- a/crates/ta-daemon/src/config.rs
+++ b/crates/ta-daemon/src/config.rs
@@ -151,6 +151,8 @@ impl Default for CommandConfig {
                 "plan from *".to_string(),
                 "ta release run *".to_string(),
                 "release *".to_string(),
+                "ta draft apply *".to_string(),
+                "draft apply *".to_string(),
             ],
             long_timeout_secs: 3600,
         }


### PR DESCRIPTION
## Summary
- **Auto-tail fix**: When UUID-based tail lookup fails after retries, query `/api/goals/active-output` and do client-side prefix matching. This eliminates the dependency on stderr alias registration timing that caused persistent "No active output stream" errors.
- **Draft apply timeout fix**: Add `ta draft apply *` and `draft apply *` to daemon's `long_running` patterns. Pre-commit verification (fmt + clippy + test) easily exceeds the 120s default timeout — now streams output in background instead.
- Add v0.10.17.1 phase to PLAN.md

## Test plan
- [x] `cargo test -p ta-cli -- shell_tui::tests` — 54/54 pass
- [x] `cargo test -p ta-daemon` — 134/134 pass
- [x] `cargo clippy -p ta-cli -p ta-daemon -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)