### PR TITLE
v0.10.18.2 — Shell TUI: Scrollback & Command Output Visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "chrono",
  "glob",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3010,7 +3010,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3064,7 +3064,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3177,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "chrono",
  "rmcp",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "chrono",
  "glob",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "chrono",
  "glob",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3276,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.10.18-alpha.1"
+version = "0.10.18-alpha.2"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2917,17 +2917,19 @@ Tests: 25 new tests (name validation, template resolution, scaffold generation, 
 ---
 
 ### v0.10.18.2 — Shell TUI: Scrollback & Command Output Visibility
-<!-- status: pending -->
+<!-- status: done -->
 **Goal**: Fix the fundamental visibility problem in `ta shell` where command output that exceeds the terminal window height is lost — the user cannot scroll back to see earlier output lines.
 
 #### Problem
 When an agent or command produces output longer than the visible terminal area in `ta shell`, lines that scroll past the top of the window are gone. There is no way to scroll up to review them. This makes `ta shell` unusable for any command with substantial output (build logs, test results, long diffs). The user reported this as a recurring blocker.
 
-#### Items
-1. [ ] **Scrollback buffer for command output pane**: The shell TUI output widget must retain a scrollback buffer (minimum 10,000 lines, configurable via `[shell] scrollback_lines` in `.ta/shell.toml`). All command output appended to the buffer persists even when it scrolls past the visible area. The widget renders a sliding window over the buffer based on scroll position.
-2. [ ] **Keyboard scroll navigation**: Up/Down arrow keys (when not in input mode), PgUp/PgDn, and Home/End scroll through the output buffer. Scroll position indicator shows "line N of M" or a visual scrollbar in the right margin. When new output arrives and the user is scrolled to the bottom, auto-scroll follows new content. When the user has scrolled up, new output does NOT auto-scroll — a "new output ↓" indicator appears instead.
-3. [ ] **Test: scrollback preserves and retrieves past output**: Integration test that pushes 500+ lines into the output buffer, verifies the buffer retains all lines, scrolls to line 0, and asserts the first line content matches. Verifies scroll-to-bottom returns to the latest line.
-4. [ ] **Test: auto-scroll vs manual scroll behavior**: Test that verifies: (a) when scroll position is at bottom and new content arrives, view follows; (b) when scroll position is NOT at bottom and new content arrives, view stays put and a "new output" flag is set.
+#### Completed
+1. [x] **Scrollback buffer for command output pane**: TUI output widget retains a scrollback buffer (default 50,000 lines, minimum 10,000 enforced). Configurable via `[shell] scrollback_lines` in `.ta/workflow.toml` — overrides `output_buffer_lines` when set. Added `ShellConfig::effective_scrollback()` method with minimum enforcement. Buffer renders a sliding window over stored lines based on scroll position.
+2. [x] **Keyboard scroll navigation**: Shift+Up/Down scroll output 1 line, PgUp/PgDn scroll 10 lines, Shift+Home/End scroll to top/bottom. Status bar shows "line N of M" scroll position indicator when scrolled up. "New output" badge with down-arrow appears when new content arrives while scrolled up. Auto-scroll follows new content when at bottom; holds position when scrolled up. Visual scrollbar in right margin already present from prior work.
+3. [x] **Test: scrollback preserves and retrieves past output**: `scrollback_preserves_and_retrieves_past_output` — pushes 600 lines, verifies all retained, verifies first/last line content, scrolls to top, verifies first line accessible, scrolls to bottom, verifies latest line.
+4. [x] **Test: auto-scroll vs manual scroll behavior**: `auto_scroll_follows_when_at_bottom` — verifies scroll_offset stays 0 and no unread when at bottom. `no_auto_scroll_when_scrolled_up` — verifies scroll_offset unchanged and unread_events incremented when scrolled up. Plus `scrollback_lines_config_alias` verifying the config alias and minimum enforcement.
+
+4 new tests. Version bumped to `0.10.18-alpha.2`.
 
 #### Version: `0.10.18-alpha.2`
 

--- a/apps/ta-cli/src/commands/shell_tui.rs
+++ b/apps/ta-cli/src/commands/shell_tui.rs
@@ -516,7 +516,7 @@ async fn run_tui(
     app.status = initial_status;
     app.daemon_connected = true;
     app.completions = completions;
-    app.output_buffer_limit = shell_config.output_buffer_lines;
+    app.output_buffer_limit = shell_config.effective_scrollback();
     app.auto_tail = shell_config.auto_tail;
     app.tail_backfill_lines = shell_config.tail_backfill_lines;
 
@@ -857,8 +857,22 @@ async fn handle_terminal_event(
                 (KeyCode::Delete, _) => app.delete(),
                 (KeyCode::Left, _) => app.cursor_left(),
                 (KeyCode::Right, _) => app.cursor_right(),
+                // Shift+Home/End scroll output; plain Home/End move cursor (v0.10.18.2).
+                (KeyCode::Home, m) if m.contains(KeyModifiers::SHIFT) => {
+                    app.scroll_up(app.output.len());
+                }
+                (KeyCode::End, m) if m.contains(KeyModifiers::SHIFT) => {
+                    app.scroll_to_bottom();
+                }
                 (KeyCode::Home, _) => app.home(),
                 (KeyCode::End, _) => app.end(),
+                // Shift+Up/Down scroll output 1 line; plain Up/Down navigate history (v0.10.18.2).
+                (KeyCode::Up, m) if m.contains(KeyModifiers::SHIFT) => {
+                    app.scroll_up(1);
+                }
+                (KeyCode::Down, m) if m.contains(KeyModifiers::SHIFT) => {
+                    app.scroll_down(1);
+                }
                 (KeyCode::Up, _) => app.history_up(),
                 (KeyCode::Down, _) => app.history_down(),
                 (KeyCode::Tab, _) => app.tab_complete(),
@@ -1419,11 +1433,23 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
         ));
     }
 
-    // Unread event badge.
+    // Scroll position indicator (v0.10.18.2).
+    if app.scroll_offset > 0 {
+        // Calculate current visible line range.
+        let total_lines = app.output.len();
+        let visible_line = total_lines.saturating_sub(app.scroll_offset);
+        spans.push(Span::raw("│"));
+        spans.push(Span::styled(
+            format!(" line {} of {} ", visible_line, total_lines),
+            Style::default().fg(Color::White),
+        ));
+    }
+
+    // Unread event badge — shows "new output" when scrolled up (v0.10.18.2).
     if app.unread_events > 0 {
         spans.push(Span::raw("│"));
         spans.push(Span::styled(
-            format!(" {} unread ", app.unread_events),
+            format!(" {} new output \u{2193} ", app.unread_events),
             Style::default()
                 .fg(Color::Black)
                 .bg(Color::Yellow)
@@ -2288,10 +2314,17 @@ Shell commands:
   :status            Refresh the status bar
   clear              Clear the output pane
   Ctrl-L             Clear the output pane
-  PgUp / PgDn        Scroll output (retained history, configurable: shell.output_buffer_lines)
+  PgUp / PgDn        Scroll output 10 lines
+  Shift+Up / Down    Scroll output 1 line
+  Shift+Home / End   Scroll to top / bottom of output
   Tab                Auto-complete commands
   Ctrl-W             Toggle split pane (shell | agent side-by-side)
-  Ctrl-C / exit      Exit the shell (Ctrl-C detaches when tailing)";
+  Ctrl-C / exit      Exit the shell (Ctrl-C detaches when tailing)
+
+Scrollback:
+  Output is retained in a scrollback buffer (default: 50000 lines).
+  Configure via [shell] scrollback_lines in .ta/workflow.toml (minimum: 10000).
+  Status bar shows scroll position and new output indicator when scrolled up.";
 
 #[cfg(test)]
 mod tests {
@@ -3108,5 +3141,126 @@ mod tests {
         app.scroll_up(999_999);
         // Should clamp to output.len() at most.
         assert!(app.scroll_offset <= app.output.len());
+    }
+
+    // -- v0.10.18.2 scrollback & scroll navigation tests --
+
+    #[test]
+    fn scrollback_preserves_and_retrieves_past_output() {
+        // Item 3: Push 500+ lines, verify buffer retains all, scroll to top,
+        // verify first line, scroll to bottom, verify latest line.
+        let mut app = App::new(
+            "http://localhost".into(),
+            None,
+            std::path::PathBuf::from("/tmp"),
+        );
+        // Ensure buffer limit is well above 500.
+        app.output_buffer_limit = 50_000;
+
+        // Push 600 lines.
+        for i in 0..600 {
+            app.push_output(OutputLine::command(format!("output-line-{}", i)));
+        }
+
+        // Buffer retains all 600 lines.
+        assert_eq!(app.output.len(), 600);
+
+        // Verify first line content.
+        assert_eq!(app.output[0].text, "output-line-0");
+
+        // Verify last line content.
+        assert_eq!(app.output[599].text, "output-line-599");
+
+        // Scroll to top (scroll up by total line count).
+        app.scroll_up(app.output.len());
+        assert!(app.scroll_offset > 0);
+
+        // First line is still accessible in the buffer.
+        assert_eq!(app.output[0].text, "output-line-0");
+
+        // Scroll back to bottom.
+        app.scroll_to_bottom();
+        assert_eq!(app.scroll_offset, 0);
+
+        // Latest line is still there.
+        assert_eq!(app.output[app.output.len() - 1].text, "output-line-599");
+    }
+
+    #[test]
+    fn auto_scroll_follows_when_at_bottom() {
+        // Item 4a: When scroll_offset is 0 (at bottom) and new content arrives,
+        // scroll_offset stays at 0 and unread_events is not incremented.
+        let mut app = App::new(
+            "http://localhost".into(),
+            None,
+            std::path::PathBuf::from("/tmp"),
+        );
+
+        // Start at bottom (scroll_offset = 0).
+        assert_eq!(app.scroll_offset, 0);
+
+        // Push new content.
+        app.push_output(OutputLine::command("line 1".into()));
+        app.push_output(OutputLine::command("line 2".into()));
+        app.push_output(OutputLine::command("line 3".into()));
+
+        // Should still be at bottom, no unread.
+        assert_eq!(app.scroll_offset, 0);
+        assert_eq!(app.unread_events, 0);
+    }
+
+    #[test]
+    fn no_auto_scroll_when_scrolled_up() {
+        // Item 4b: When scroll_offset is NOT 0 (scrolled up) and new content
+        // arrives, scroll_offset stays put and unread flag is set.
+        let mut app = App::new(
+            "http://localhost".into(),
+            None,
+            std::path::PathBuf::from("/tmp"),
+        );
+
+        // Add initial content.
+        for i in 0..50 {
+            app.push_output(OutputLine::command(format!("line {}", i)));
+        }
+
+        // Scroll up.
+        app.scroll_up(10);
+        assert_eq!(app.scroll_offset, 10);
+        assert_eq!(app.unread_events, 0);
+
+        // New content arrives while scrolled up.
+        app.push_output(OutputLine::command("new line A".into()));
+        app.push_output(OutputLine::command("new line B".into()));
+
+        // Scroll offset should NOT change (no auto-scroll).
+        assert_eq!(app.scroll_offset, 10);
+
+        // Unread events should be incremented.
+        assert_eq!(app.unread_events, 2);
+
+        // Scrolling to bottom clears unread.
+        app.scroll_to_bottom();
+        assert_eq!(app.scroll_offset, 0);
+        assert_eq!(app.unread_events, 0);
+    }
+
+    #[test]
+    fn scrollback_lines_config_alias() {
+        // Verify that ShellConfig::effective_scrollback() uses scrollback_lines
+        // when set, and enforces the 10,000 minimum.
+        use ta_submit::ShellConfig;
+
+        let mut config = ShellConfig::default();
+        // Default: uses output_buffer_lines (50000).
+        assert_eq!(config.effective_scrollback(), 50_000);
+
+        // scrollback_lines overrides.
+        config.scrollback_lines = Some(20_000);
+        assert_eq!(config.effective_scrollback(), 20_000);
+
+        // Minimum enforced at 10,000.
+        config.scrollback_lines = Some(5_000);
+        assert_eq!(config.effective_scrollback(), 10_000);
     }
 }

--- a/crates/ta-submit/src/config.rs
+++ b/crates/ta-submit/src/config.rs
@@ -336,14 +336,28 @@ pub struct ShellConfig {
     #[serde(default = "default_tail_backfill_lines")]
     pub tail_backfill_lines: usize,
 
-    /// Maximum number of lines retained in the TUI output buffer. Default: 10000.
+    /// Maximum number of lines retained in the TUI output buffer. Default: 50000.
     /// Older lines are dropped when this limit is exceeded.
     #[serde(default = "default_output_buffer_lines")]
     pub output_buffer_lines: usize,
 
+    /// Alias for `output_buffer_lines` — configurable as `scrollback_lines` (v0.10.18.2).
+    /// If set, overrides `output_buffer_lines`. Minimum enforced: 10,000.
+    #[serde(default)]
+    pub scrollback_lines: Option<usize>,
+
     /// Automatically tail agent output when a goal starts. Default: true.
     #[serde(default = "default_auto_tail")]
     pub auto_tail: bool,
+}
+
+impl ShellConfig {
+    /// Effective scrollback buffer size: `scrollback_lines` if set, else `output_buffer_lines`.
+    /// Enforces a minimum of 10,000 lines.
+    pub fn effective_scrollback(&self) -> usize {
+        let raw = self.scrollback_lines.unwrap_or(self.output_buffer_lines);
+        raw.max(10_000)
+    }
 }
 
 impl Default for ShellConfig {
@@ -351,6 +365,7 @@ impl Default for ShellConfig {
         Self {
             tail_backfill_lines: default_tail_backfill_lines(),
             output_buffer_lines: default_output_buffer_lines(),
+            scrollback_lines: None,
             auto_tail: default_auto_tail(),
         }
     }
@@ -582,7 +597,9 @@ adapter = "git"
         let config = ShellConfig::default();
         assert_eq!(config.tail_backfill_lines, 5);
         assert_eq!(config.output_buffer_lines, 50000);
+        assert!(config.scrollback_lines.is_none());
         assert!(config.auto_tail);
+        assert_eq!(config.effective_scrollback(), 50000);
     }
 
     #[test]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -523,8 +523,10 @@ The `[shell]` section in `.ta/workflow.toml` controls the TUI shell behavior:
 [shell]
 # Lines to show when attaching to a tail stream. Default: 5.
 tail_backfill_lines = 5
-# Maximum lines retained in the scrollable output buffer. Default: 10000.
-output_buffer_lines = 10000
+# Maximum lines retained in the scrollable output buffer. Default: 50000.
+output_buffer_lines = 50000
+# Alias for output_buffer_lines. If set, overrides it. Minimum: 10000.
+# scrollback_lines = 20000
 # Auto-tail agent output when a goal starts. Default: true.
 auto_tail = true
 ```
@@ -2341,9 +2343,9 @@ The TUI shell provides a three-zone layout:
 └─────────────────────────────────────────────────────────┘
 ```
 
-- **Output pane** (top): Command responses, SSE event notifications, and live agent output. Events are rendered in dimmed styling; agent stdout appears in white, stderr in yellow. Auto-scrolls to bottom; use PgUp/PgDn to scroll back. Retained as a scrollable buffer (configurable limit, default 10000 lines). Unread events are tracked when scrolled up.
+- **Output pane** (top): Command responses, SSE event notifications, and live agent output. Events are rendered in dimmed styling; agent stdout appears in white, stderr in yellow. Auto-scrolls to bottom when at the end; holds position when scrolled up. Retained as a scrollable buffer (configurable limit, default 50,000 lines, minimum 10,000). Use Shift+Up/Down for line-by-line scroll, PgUp/PgDn for 10-line jumps, or Shift+Home/End to jump to top/bottom. A visual scrollbar appears in the right margin when the buffer exceeds the visible area.
 - **Input area** (middle): Text input with cursor movement, command history (up/down), and tab-completion.
-- **Status bar** (bottom): Project name, version, agent count, draft count, daemon connection indicator (green/red dot), tailing indicator (green badge when streaming agent output), unread event badge, and workflow stage indicator.
+- **Status bar** (bottom): Project name, version, agent count, draft count, daemon connection indicator (green/red dot), scroll position ("line N of M" when scrolled up), "new output" badge with count when new content arrives while scrolled up, tailing indicator (green badge when streaming agent output), and workflow stage indicator.
 
 #### Using the shell
 
@@ -2367,7 +2369,9 @@ Built-in shell commands:
 | `:follow-up [filter]` | List follow-up candidates (failed goals, denied drafts); filter by keyword |
 | `:status` | Refresh the status bar |
 | `clear` / `Ctrl-L` | Clear the output pane |
-| `PgUp` / `PgDn` | Scroll output |
+| `Shift+Up` / `Shift+Down` | Scroll output 1 line |
+| `PgUp` / `PgDn` | Scroll output 10 lines |
+| `Shift+Home` / `Shift+End` | Scroll to top/bottom of output |
 | `Tab` | Auto-complete commands |
 | `Ctrl-W` | Toggle split-pane mode (agent output on the right) |
 | `Ctrl-A` / `Ctrl-E` | Jump to start/end of input |


### PR DESCRIPTION
## Summary

Changes from goal: v0.10.18.2 — Shell TUI: Scrollback & Command Output Visibility

**Why**: Fix the fundamental visibility problem in `ta shell` where command output that exceeds the terminal window height is lost — the user cannot scroll back to see earlier output lines.

**Impact**: 7 file(s) changed

## Changes (7 file(s))

- `~` `fs://workspace/.git/index`
- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/Cargo.toml` — Bumped workspace version from 0.10.18-alpha.1 to 0.10.18-alpha.2
  - Version management policy requires bumping version for each completed phase
- `~` `fs://workspace/PLAN.md` — Marked all 4 items in v0.10.18.2 as completed with detailed descriptions. Added test count (4 new tests) and version bump note.
  - Phase completion requires updating the plan with what was accomplished
- `~` `fs://workspace/apps/ta-cli/src/commands/shell_tui.rs` — Added Shift+Up/Down keybindings for 1-line scroll, Shift+Home/End for scroll-to-top/bottom. Added 'line N of M' scroll position indicator and 'new output' badge with down-arrow in status bar. Updated help text with new scroll keybindings and scrollback documentation. Uses effective_scrollback() for buffer limit. Added 4 new tests: scrollback_preserves_and_retrieves_past_output, auto_scroll_follows_when_at_bottom, no_auto_scroll_when_scrolled_up, scrollback_lines_config_alias.
  - Users could not scroll through long command output in ta shell — lines that scrolled past the visible area were inaccessible. No indication of scroll position or new content arriving while scrolled up.
- `~` `fs://workspace/crates/ta-submit/src/config.rs` — Added scrollback_lines Option<usize> field to ShellConfig as alias for output_buffer_lines. Added effective_scrollback() method that returns scrollback_lines if set, else output_buffer_lines, with 10,000 minimum enforced. Updated shell_config_defaults test.
  - Plan specifies scrollback_lines as the config key name. The alias provides a clearer name while maintaining backward compatibility with output_buffer_lines. Minimum enforcement prevents usability issues from too-small buffers.
- `~` `fs://workspace/docs/USAGE.md` — Updated shell config example to show scrollback_lines alias and correct default (50000). Updated output pane description with scroll behavior details. Added Shift+Up/Down and Shift+Home/End to keyboard shortcuts table. Updated status bar description with scroll position and new output indicators.
  - New user-facing scroll features need documentation in the onboarding guide

## Goal Context

- **Title**: v0.10.18.2 — Shell TUI: Scrollback & Command Output Visibility
- **Objective**: v0.10.18.2 — Shell TUI: Scrollback & Command Output Visibility
- **Goal ID**: `099c01f3-a6c7-47a1-b41e-85c3b19ef98c`
- **PR ID**: `9749f6ee-e92e-4056-b516-aa7f2d90ad40`
- **Plan Phase**: `0.10.18.2`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
