### PR TITLE
Add Discord command listener mode (--listen)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -3535,7 +3535,7 @@ Alternative sources (no registry needed):
 
 ### v0.12.1 — Template Projects & Bootstrap Flow
 <!-- status: pending -->
-**Goal**: `ta new` generates projects with `project.toml` plugin declarations so downstream users get a complete, working setup from `ta setup` alone. Template projects in the Trusted-Autonomy org serve as reference implementations.
+**Goal**: `ta new` generates projects with `project.toml` plugin declarations so downstream users get a complete, working setup from `ta setup` alone. Template projects in the Trusted-Autonomy org serve as reference implementations. Also: replace the quick-fix Discord command listener with a proper slash-command-based bidirectional integration.
 
 #### Items
 1. [ ] **`ta new --plugins` flag**: Declare required plugins at project creation. `ta new --name my-bot --plugins discord,slack --vcs git` generates a `project.toml` with those declarations pre-filled.
@@ -3546,6 +3546,18 @@ Alternative sources (no registry needed):
 6. [ ] **Reference template: ta-perforce-template**: Demonstrates Perforce VCS adapter for game studios / enterprise environments.
 7. [ ] **Template listing**: `ta new --list-templates` shows available templates from both built-in and registry sources.
 8. [ ] **Test: end-to-end bootstrap flow**: Test that `ta new --plugins discord --vcs git` → `ta setup` → `ta-daemon` starts with the Discord plugin loaded and VCS configured.
+
+#### Discord command listener tech debt (from quick-fix in v0.10.18)
+The current `--listen` mode on `ta-channel-discord` is a quick integration that works but has several limitations. These should be addressed here alongside the Discord template project:
+
+9. [ ] **Discord slash commands**: Register `/ta` slash command via Discord Application Commands API instead of message-prefix matching. Benefits: auto-complete, built-in help, no MESSAGE_CONTENT intent required, works in servers with strict permissions.
+10. [ ] **Interaction callback handler**: Handle button clicks from `deliver_question` embeds. Currently button `custom_id` values (e.g., `ta_{interaction_id}_yes`) are sent to Discord but no handler receives them. Add an HTTP endpoint or Gateway handler that receives interaction callbacks and POSTs answers to the daemon's `/api/interactions/:id/respond`.
+11. [ ] **Gateway reconnect with resume**: Current listener reconnects from scratch on disconnect. Implement Discord's resume protocol (session_id + last sequence number) for seamless reconnection without missed events.
+12. [ ] **Daemon auto-launches listener**: The daemon should auto-start `ta-channel-discord --listen` when `default_channels` includes `"discord"` in `daemon.toml`, instead of requiring a separate manual process. Lifecycle: daemon starts → spawns listener → monitors health → restarts on crash.
+13. [ ] **Rate limiting**: Add rate limiting on command forwarding to prevent Discord abuse from flooding the daemon API.
+14. [ ] **Response threading**: Post command responses as thread replies to the original message instead of top-level messages, to keep the channel clean.
+15. [ ] **Long-running command status**: For commands that take >5s (e.g., `ta run`), post an initial "Running..." message, then edit it with the result when done. Use Discord message editing API.
+16. [ ] **Remove `--listen` flag**: Once the daemon manages the listener lifecycle (item 12), the standalone `--listen` mode becomes internal. The user-facing entry point is `ta daemon start` with Discord configured in `daemon.toml`.
 
 #### Version: `0.12.1-alpha`
 

--- a/plugins/ta-channel-discord/Cargo.lock
+++ b/plugins/ta-channel-discord/Cargo.lock
@@ -21,10 +21,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -55,6 +70,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +113,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -96,6 +156,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,9 +185,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -214,7 +303,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -480,7 +569,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -495,13 +584,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -538,12 +627,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -553,7 +663,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -600,7 +719,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -726,10 +845,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -800,10 +940,21 @@ dependencies = [
 name = "ta-channel-discord"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -812,7 +963,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -861,6 +1023,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -885,6 +1048,22 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -958,6 +1137,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,10 +1187,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1088,6 +1305,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/plugins/ta-channel-discord/Cargo.toml
+++ b/plugins/ta-channel-discord/Cargo.toml
@@ -15,4 +15,6 @@ path = "src/main.rs"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-tokio = { version = "1", features = ["rt", "macros", "io-util"] }
+tokio = { version = "1", features = ["rt", "macros", "io-util", "signal", "time"] }
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+futures-util = "0.3"

--- a/plugins/ta-channel-discord/channel.toml
+++ b/plugins/ta-channel-discord/channel.toml
@@ -1,7 +1,11 @@
 name = "discord"
-version = "0.1.0"
+version = "0.2.0"
 command = "ta-channel-discord"
 protocol = "json-stdio"
-capabilities = ["deliver_question"]
-description = "Discord channel plugin for Trusted Autonomy — posts agent questions as rich embeds with button components"
+capabilities = ["deliver_question", "receive_commands"]
+description = "Discord channel plugin — posts agent questions as rich embeds, listens for commands"
 timeout_secs = 30
+
+# Listen mode: `ta-channel-discord --listen`
+# Persistent bot that watches for messages prefixed with "ta " and forwards
+# them to the daemon HTTP API. Env vars: TA_DAEMON_URL, TA_DISCORD_PREFIX.

--- a/plugins/ta-channel-discord/src/listener.rs
+++ b/plugins/ta-channel-discord/src/listener.rs
@@ -1,0 +1,400 @@
+//! Discord Gateway listener — connects to Discord WebSocket, watches for
+//! messages with a configurable prefix, and forwards them to the TA daemon
+//! HTTP API (`POST /api/cmd`).
+//!
+//! This is a quick integration for dev use. Known tech debt (tracked in
+//! PLAN.md v0.12.1):
+//! - No slash command registration (uses message prefix matching)
+//! - No interaction callback handling (button clicks from deliver_question)
+//! - No reconnect backoff / resume (reconnects from scratch)
+//! - Hardcoded intents (GUILD_MESSAGES + MESSAGE_CONTENT)
+//! - No rate limiting on command forwarding
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio_tungstenite::tungstenite::Message;
+
+const GATEWAY_URL: &str = "wss://gateway.discord.gg/?v=10&encoding=json";
+
+/// Discord Gateway op codes.
+const OP_DISPATCH: u64 = 0;
+const OP_HELLO: u64 = 10;
+const OP_HEARTBEAT_ACK: u64 = 11;
+
+/// Run the persistent listener loop.
+pub async fn run(token: &str, channel_id: &str, daemon_url: &str, prefix: &str) {
+    eprintln!("[discord-listener] Connecting to Discord Gateway...");
+    eprintln!(
+        "[discord-listener] Watching channel {} for prefix {:?}",
+        channel_id, prefix
+    );
+    eprintln!(
+        "[discord-listener] Forwarding commands to {}/api/cmd",
+        daemon_url
+    );
+
+    loop {
+        match run_session(token, channel_id, daemon_url, prefix).await {
+            Ok(()) => {
+                eprintln!("[discord-listener] Session ended cleanly. Reconnecting in 5s...");
+            }
+            Err(e) => {
+                eprintln!(
+                    "[discord-listener] Session error: {}. Reconnecting in 5s...",
+                    e
+                );
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
+}
+
+async fn run_session(
+    token: &str,
+    channel_id: &str,
+    daemon_url: &str,
+    prefix: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (ws_stream, _) = tokio_tungstenite::connect_async(GATEWAY_URL).await?;
+    let (mut write, mut read) = ws_stream.split();
+
+    // Wait for Hello (op 10) to get heartbeat interval.
+    let hello = read.next().await.ok_or("Gateway closed before Hello")??;
+    let hello_json: serde_json::Value = serde_json::from_str(hello.to_text()?)?;
+    let heartbeat_interval = hello_json["d"]["heartbeat_interval"]
+        .as_u64()
+        .unwrap_or(41250);
+
+    eprintln!(
+        "[discord-listener] Connected. Heartbeat interval: {}ms",
+        heartbeat_interval
+    );
+
+    // Send Identify.
+    // Intents: GUILDS (1) + GUILD_MESSAGES (512) + MESSAGE_CONTENT (32768) = 33281
+    let identify = json!({
+        "op": 2,
+        "d": {
+            "token": token,
+            "intents": 33281,
+            "properties": {
+                "os": std::env::consts::OS,
+                "browser": "ta-channel-discord",
+                "device": "ta-channel-discord"
+            }
+        }
+    });
+    write.send(Message::Text(identify.to_string())).await?;
+
+    let mut sequence: Option<u64> = None;
+    let mut heartbeat_timer =
+        tokio::time::interval(std::time::Duration::from_millis(heartbeat_interval));
+    // Skip the first immediate tick.
+    heartbeat_timer.tick().await;
+
+    let http_client = reqwest::Client::new();
+    let cmd_url = format!("{}/api/cmd", daemon_url);
+
+    // Track our own user ID to ignore our own messages.
+    let mut self_user_id: Option<String> = None;
+
+    loop {
+        tokio::select! {
+            _ = heartbeat_timer.tick() => {
+                let hb = json!({ "op": 1, "d": sequence });
+                write.send(Message::Text(hb.to_string())).await?;
+            }
+            msg = read.next() => {
+                let msg = match msg {
+                    Some(Ok(m)) => m,
+                    Some(Err(e)) => return Err(e.into()),
+                    None => return Ok(()), // stream ended
+                };
+
+                if msg.is_close() {
+                    return Ok(());
+                }
+
+                let text = match msg.to_text() {
+                    Ok(t) => t,
+                    Err(_) => continue, // skip binary frames
+                };
+
+                let event: serde_json::Value = match serde_json::from_str(text) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+
+                let op = event["op"].as_u64().unwrap_or(99);
+
+                match op {
+                    OP_DISPATCH => {
+                        if let Some(s) = event["s"].as_u64() {
+                            sequence = Some(s);
+                        }
+
+                        let event_name = event["t"].as_str().unwrap_or("");
+
+                        // Capture our own user ID from READY.
+                        if event_name == "READY" {
+                            if let Some(id) = event["d"]["user"]["id"].as_str() {
+                                self_user_id = Some(id.to_string());
+                                eprintln!("[discord-listener] Ready as user {}", id);
+                            }
+                        }
+
+                        if event_name == "MESSAGE_CREATE" {
+                            let d = &event["d"];
+                            let msg_channel = d["channel_id"].as_str().unwrap_or("");
+                            let content = d["content"].as_str().unwrap_or("");
+                            let author_id = d["author"]["id"].as_str().unwrap_or("");
+                            let author_bot = d["author"]["bot"].as_bool().unwrap_or(false);
+                            let author_name = d["author"]["username"].as_str().unwrap_or("?");
+
+                            // Skip: wrong channel, bot messages, our own messages.
+                            if msg_channel != channel_id {
+                                continue;
+                            }
+                            if author_bot {
+                                continue;
+                            }
+                            if let Some(ref self_id) = self_user_id {
+                                if author_id == self_id {
+                                    continue;
+                                }
+                            }
+
+                            // Check for command prefix.
+                            let command = if let Some(cmd) = content.strip_prefix(prefix) {
+                                cmd.trim()
+                            } else {
+                                continue;
+                            };
+
+                            if command.is_empty() {
+                                continue;
+                            }
+
+                            eprintln!(
+                                "[discord-listener] Command from {}: {}",
+                                author_name, command
+                            );
+
+                            // Forward to daemon.
+                            let response = forward_command(
+                                &http_client,
+                                &cmd_url,
+                                command,
+                                channel_id,
+                                token,
+                                d["id"].as_str().unwrap_or(""),
+                            )
+                            .await;
+
+                            // Post response back to Discord.
+                            let reply = format_reply(&response);
+                            let _ = post_message(
+                                &http_client,
+                                token,
+                                channel_id,
+                                &reply,
+                            )
+                            .await;
+                        }
+                    }
+                    OP_HEARTBEAT_ACK => {
+                        // Good — server acknowledged our heartbeat.
+                    }
+                    OP_HELLO => {
+                        // Shouldn't happen after initial Hello, ignore.
+                    }
+                    _ => {}
+                }
+            }
+            _ = tokio::signal::ctrl_c() => {
+                eprintln!("[discord-listener] Shutting down...");
+                let close = Message::Close(None);
+                let _ = write.send(close).await;
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Forward a command to the TA daemon HTTP API.
+async fn forward_command(
+    client: &reqwest::Client,
+    cmd_url: &str,
+    command: &str,
+    _channel_id: &str,
+    _token: &str,
+    _message_id: &str,
+) -> CommandResult {
+    // Prepend "ta " if not already present.
+    let full_command = if command.starts_with("ta ") {
+        command.to_string()
+    } else {
+        format!("ta {}", command)
+    };
+
+    match client
+        .post(cmd_url)
+        .json(&json!({ "command": full_command }))
+        .timeout(std::time::Duration::from_secs(300))
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            let status = resp.status();
+            match resp.json::<serde_json::Value>().await {
+                Ok(json) => {
+                    if status.is_success() {
+                        let exit_code = json["exit_code"].as_i64().unwrap_or(-1);
+                        let stdout = json["stdout"].as_str().unwrap_or("").to_string();
+                        let stderr = json["stderr"].as_str().unwrap_or("").to_string();
+                        CommandResult {
+                            success: exit_code == 0,
+                            output: if stdout.is_empty() { stderr } else { stdout },
+                            error: None,
+                        }
+                    } else {
+                        let err = json["error"]
+                            .as_str()
+                            .unwrap_or("unknown error")
+                            .to_string();
+                        CommandResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some(err),
+                        }
+                    }
+                }
+                Err(e) => CommandResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!("Failed to parse daemon response: {}", e)),
+                },
+            }
+        }
+        Err(e) => CommandResult {
+            success: false,
+            output: String::new(),
+            error: Some(format!("Cannot reach daemon: {}", e)),
+        },
+    }
+}
+
+struct CommandResult {
+    success: bool,
+    output: String,
+    error: Option<String>,
+}
+
+/// Format command result as a Discord message.
+fn format_reply(result: &CommandResult) -> String {
+    if let Some(ref err) = result.error {
+        format!("**Error:** {}", err)
+    } else {
+        let status = if result.success { "ok" } else { "failed" };
+        let output = truncate_output(&result.output, 1900);
+        if output.is_empty() {
+            format!("**[{}]** (no output)", status)
+        } else {
+            format!("**[{}]**\n```\n{}\n```", status, output)
+        }
+    }
+}
+
+/// Truncate output to fit in a Discord message (2000 char limit).
+fn truncate_output(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...\n(truncated)", &s[..max])
+    }
+}
+
+/// Post a text message to a Discord channel.
+async fn post_message(
+    client: &reqwest::Client,
+    token: &str,
+    channel_id: &str,
+    content: &str,
+) -> Result<(), reqwest::Error> {
+    let url = format!(
+        "https://discord.com/api/v10/channels/{}/messages",
+        channel_id
+    );
+    client
+        .post(&url)
+        .header("Authorization", format!("Bot {}", token))
+        .json(&json!({ "content": content }))
+        .send()
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_reply_success_with_output() {
+        let result = CommandResult {
+            success: true,
+            output: "Draft list:\n  1. Fix auth bug".into(),
+            error: None,
+        };
+        let reply = format_reply(&result);
+        assert!(reply.contains("**[ok]**"));
+        assert!(reply.contains("Fix auth bug"));
+    }
+
+    #[test]
+    fn format_reply_success_no_output() {
+        let result = CommandResult {
+            success: true,
+            output: String::new(),
+            error: None,
+        };
+        let reply = format_reply(&result);
+        assert!(reply.contains("(no output)"));
+    }
+
+    #[test]
+    fn format_reply_error() {
+        let result = CommandResult {
+            success: false,
+            output: String::new(),
+            error: Some("command not permitted".into()),
+        };
+        let reply = format_reply(&result);
+        assert!(reply.contains("**Error:**"));
+        assert!(reply.contains("command not permitted"));
+    }
+
+    #[test]
+    fn format_reply_failed_command() {
+        let result = CommandResult {
+            success: false,
+            output: "error: no such goal".into(),
+            error: None,
+        };
+        let reply = format_reply(&result);
+        assert!(reply.contains("**[failed]**"));
+        assert!(reply.contains("no such goal"));
+    }
+
+    #[test]
+    fn truncate_output_short() {
+        assert_eq!(truncate_output("hello", 100), "hello");
+    }
+
+    #[test]
+    fn truncate_output_long() {
+        let long = "x".repeat(2000);
+        let result = truncate_output(&long, 100);
+        assert!(result.len() < 200);
+        assert!(result.contains("(truncated)"));
+    }
+}

--- a/plugins/ta-channel-discord/src/main.rs
+++ b/plugins/ta-channel-discord/src/main.rs
@@ -3,7 +3,13 @@
 //! External JSON-over-stdio plugin that posts agent questions as rich embeds
 //! with button components to a Discord channel.
 //!
-//! ## Protocol
+//! ## Modes
+//!
+//! **Deliver mode** (default): reads one JSON line from stdin, posts to Discord, exits.
+//! **Listen mode** (`--listen`): persistent bot that watches for commands in Discord
+//! and forwards them to the TA daemon HTTP API.
+//!
+//! ## Protocol (deliver mode)
 //!
 //! - Reads one JSON line from stdin: a `ChannelQuestion` object
 //! - Posts the question as a Discord embed with buttons to the configured channel
@@ -13,6 +19,8 @@
 //!
 //! - `TA_DISCORD_TOKEN` (or custom via `token_env`): Discord bot token
 //! - `TA_DISCORD_CHANNEL_ID`: Discord channel snowflake ID
+//! - `TA_DAEMON_URL` (listen mode): daemon URL (default: `http://127.0.0.1:7700`)
+//! - `TA_DISCORD_PREFIX` (listen mode): command prefix (default: `ta `)
 //!
 //! ## Installation
 //!
@@ -24,6 +32,7 @@ use std::io::{self, BufRead, Write};
 
 use serde::{Deserialize, Serialize};
 
+mod listener;
 mod payload;
 
 /// Input: question from TA daemon via stdin.
@@ -90,15 +99,27 @@ fn write_result(result: &DeliveryResult) {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
+    // Check for --listen mode.
+    let args: Vec<String> = std::env::args().collect();
+    let listen_mode = args.iter().any(|a| a == "--listen");
+
     // Read config from environment.
-    let token_env = std::env::var("TA_DISCORD_TOKEN_ENV").unwrap_or_else(|_| "TA_DISCORD_TOKEN".into());
+    let token_env =
+        std::env::var("TA_DISCORD_TOKEN_ENV").unwrap_or_else(|_| "TA_DISCORD_TOKEN".into());
     let token = match std::env::var(&token_env) {
         Ok(t) if !t.is_empty() => t,
         _ => {
-            write_result(&DeliveryResult::error(format!(
-                "Environment variable '{}' not set. Set it to your Discord bot token.",
-                token_env
-            )));
+            if listen_mode {
+                eprintln!(
+                    "Error: Environment variable '{}' not set. Set it to your Discord bot token.",
+                    token_env
+                );
+            } else {
+                write_result(&DeliveryResult::error(format!(
+                    "Environment variable '{}' not set. Set it to your Discord bot token.",
+                    token_env
+                )));
+            }
             std::process::exit(1);
         }
     };
@@ -106,16 +127,32 @@ async fn main() {
     let channel_id = match std::env::var("TA_DISCORD_CHANNEL_ID") {
         Ok(id) if !id.is_empty() => id,
         _ => {
-            write_result(&DeliveryResult::error(
-                "Environment variable 'TA_DISCORD_CHANNEL_ID' not set. \
-                 Set it to the Discord channel snowflake ID."
-                    .into(),
-            ));
+            if listen_mode {
+                eprintln!(
+                    "Error: Environment variable 'TA_DISCORD_CHANNEL_ID' not set. \
+                     Set it to the Discord channel snowflake ID."
+                );
+            } else {
+                write_result(&DeliveryResult::error(
+                    "Environment variable 'TA_DISCORD_CHANNEL_ID' not set. \
+                     Set it to the Discord channel snowflake ID."
+                        .into(),
+                ));
+            }
             std::process::exit(1);
         }
     };
 
-    // Read question from stdin.
+    // Listen mode: persistent bot that watches for commands.
+    if listen_mode {
+        let daemon_url =
+            std::env::var("TA_DAEMON_URL").unwrap_or_else(|_| "http://127.0.0.1:7700".into());
+        let prefix = std::env::var("TA_DISCORD_PREFIX").unwrap_or_else(|_| "ta ".into());
+        listener::run(&token, &channel_id, &daemon_url, &prefix).await;
+        return;
+    }
+
+    // Deliver mode: read question from stdin.
     let stdin = io::stdin();
     let line = match stdin.lock().lines().next() {
         Some(Ok(line)) if !line.trim().is_empty() => line,
@@ -133,7 +170,11 @@ async fn main() {
             write_result(&DeliveryResult::error(format!(
                 "Invalid JSON input: {}. Got: '{}'",
                 e,
-                if line.len() > 200 { &line[..200] } else { &line }
+                if line.len() > 200 {
+                    &line[..200]
+                } else {
+                    &line
+                }
             )));
             std::process::exit(1);
         }


### PR DESCRIPTION
## Summary
- Adds `--listen` mode to the Discord plugin for bidirectional communication
- Persistent bot connects to Discord Gateway WebSocket, watches for messages prefixed with `ta ` in the configured channel
- Forwards commands to daemon HTTP API (`POST /api/cmd`), posts responses back to Discord
- Auto-reconnects on disconnect with 5s backoff
- 7 new unit tests for response formatting

### Usage
```bash
source .envrc  # loads TA_DISCORD_TOKEN + TA_DISCORD_CHANNEL_ID
.ta/plugins/channels/discord/ta-channel-discord --listen
```

Then in Discord, type: `ta status`, `ta draft list`, `ta run "Fix auth bug"`, etc.

### Prerequisites
- **MESSAGE_CONTENT** privileged intent must be enabled in Discord Developer Portal → Bot → Privileged Gateway Intents

### Known tech debt (tracked in PLAN.md v0.12.1)
- Uses message prefix matching instead of Discord slash commands
- No interaction callback handler for button clicks from deliver_question
- Reconnects from scratch (no Gateway resume protocol)
- Must be started manually (daemon should auto-launch it)
- No rate limiting on command forwarding
- Responses posted as top-level messages (should be threaded)

## Test plan
- [x] Plugin builds and all 19 tests pass (12 existing + 7 new)
- [x] Listener connects to Discord Gateway successfully
- [x] Listener authenticates and receives READY event
- [ ] Send `ta status` in Discord → daemon responds → bot posts result
- [ ] Send `ta draft list` in Discord → correct output
- [ ] Send non-prefixed message → ignored
- [ ] Disconnect WiFi → listener reconnects after 5s