### PR TITLE
Implement v0.11.1 —  Unification &

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3148,7 +3148,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "chrono",
  "rmcp",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3220,7 +3220,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "serde",
  "serde_json",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.11.0-alpha.1"
+version = "0.11.1-alpha"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -3256,35 +3256,34 @@ shelve_by_default = true  # shelve instead of submit
 ---
 
 ### v0.11.1 — `SourceAdapter` Unification & `ta sync`
-<!-- status: pending -->
+<!-- status: done -->
 **Goal**: Merge the current `SubmitAdapter` trait with sync operations into a unified `SourceAdapter` trait. Add `ta sync` command. The trait defines abstract VCS operations; provider-specific mechanics (rebase, fast-forward, shelving) live in each implementation.
 
 See `docs/MISSION-AND-SCOPE.md` for the full `SourceAdapter` trait design and per-provider operation mapping.
 
-#### Items
+#### Completed
 
-1. **`SourceAdapter` trait** (`crates/ta-submit/src/adapter.rs`):
-   - Rename `SubmitAdapter` → `SourceAdapter`
-   - Add `sync_upstream(&self) -> Result<SyncResult>` abstract method
-   - `SyncResult`: `{ updated: bool, conflicts: Vec<String>, new_commits: u32 }`
-   - Provider-specific config namespaced under `[source.git]`, `[source.perforce]`, etc.
+1. [x] **`SourceAdapter` trait** (`crates/ta-submit/src/adapter.rs`): Renamed `SubmitAdapter` → `SourceAdapter` with backward-compatible type alias. Added `sync_upstream(&self) -> Result<SyncResult>` with default no-op implementation. Added `SyncResult` struct with `updated`, `conflicts`, `new_commits`, `message`, and `metadata` fields. Added `SyncError` and `SyncConflict` variants to `SubmitError`. Added `SourceConfig` and `SyncConfig` to workflow config (`[source.sync]` section with `auto_sync`, `strategy`, `remote`, `branch`).
+2. [x] **Git implementation** (`crates/ta-submit/src/git.rs`): `sync_upstream()` runs `git fetch` + merge/rebase/ff-only per `source.sync.strategy` config. Counts new commits via `rev-list --count`. Conflict detection via `git diff --name-only --diff-filter=U`. Returns structured `SyncResult` with conflict file list. Added `with_full_config()` constructor accepting `SyncConfig`.
+3. [x] **SVN implementation** (`crates/ta-submit/src/svn.rs`): `sync_upstream()` runs `svn update`, parses output for conflicts ("C " lines) and updates ("U ", "A ", "D " lines).
+4. [x] **Perforce implementation** (`crates/ta-submit/src/perforce.rs`): `sync_upstream()` runs `p4 sync`, counts synced files from output.
+5. [x] **`ta sync` CLI command** (`apps/ta-cli/src/commands/sync.rs`): Calls `SourceAdapter::sync_upstream()`, emits `sync_completed` or `sync_conflict` events via `FsEventStore`, warns about active staging workspaces, shows troubleshooting on failure.
+6. [x] **`ta shell` integration**: Added `sync` and `verify` to daemon's `ta_subcommands` list so `ta> sync` routes automatically as `ta sync`.
+7. [x] **Wire into `ta draft apply`**: Optional `auto_sync = true` in `[source.sync]` config. After apply + commit + push + review, auto-syncs upstream with conflict warning if needed.
+8. [x] **Events**: Added `SyncCompleted { adapter, new_commits, message }` and `SyncConflict { adapter, conflicts, message }` variants to `SessionEvent`.
+9. [x] **Registry**: Added `select_adapter_with_sync()` for passing `SyncConfig` to adapters. Updated all registry and consumer code to use `SourceAdapter`.
+10. [x] **Backward compatibility**: `SubmitAdapter` remains as a type alias for `SourceAdapter`. All existing imports continue to work.
 
-2. **Git implementation** (`crates/ta-submit/src/git.rs`):
-   - `sync_upstream`: `git fetch origin` + merge/rebase/ff per `source.git.sync_strategy`
-   - Conflict detection: parse merge output, return structured `SyncResult`
-
-3. **`ta sync` CLI command** (`apps/ta-cli/src/commands/sync.rs`):
-   - Calls `SourceAdapter::sync_upstream()`
-   - Emits `sync_completed` or `sync_conflict` event
-   - If staging is active, warns or auto-rebases per config
-
-4. **`ta shell` integration**:
-   - `ta> sync` as shell shortcut
-   - SSE event for sync results
-
-5. **Wire into `ta draft apply`**:
-   - Optional `auto_sync = true` in `[source.sync]` config
-   - After apply + commit + push, auto-sync main if configured
+#### Tests: 9 new tests
+- `sync_result_is_clean_when_no_conflicts` (adapter.rs)
+- `sync_result_is_not_clean_with_conflicts` (adapter.rs)
+- `sync_result_serialization_roundtrip` (adapter.rs)
+- `test_git_adapter_sync_upstream_already_up_to_date` (git.rs)
+- `test_git_adapter_sync_upstream_with_local_remote` (git.rs)
+- `sync_config_defaults` (config.rs)
+- `parse_toml_with_source_sync_section` (config.rs)
+- `parse_toml_without_source_section_uses_default` (config.rs)
+- `none_adapter_sync_returns_not_updated` (sync.rs)
 
 #### Version: `0.11.1-alpha`
 
@@ -3583,7 +3582,7 @@ Alternative sources (no registry needed):
 
 #### Items
 1. [ ] **`ta new --plugins` flag**: Declare required plugins at project creation. `ta new --name my-bot --plugins discord,slack --vcs git` generates a `project.toml` with those declarations pre-filled.
-2. [ ] **`ta new --vcs` flag**: Set the VCS adapter. Defaults to `git`. `--vcs perforce` adds `ta-submit-perforce` to the plugin requirements.
+2. [ ] **`ta new --vcs` flag + interactive VCS prompt**: Set the VCS adapter explicitly via `--vcs git|svn|perforce|none`. When `--vcs` is omitted in interactive mode, `ta new` asks "Do you want version control?" with options derived from available adapters/plugins (e.g., `[git, svn, perforce, none]`). The selected adapter is written into `.ta/workflow.toml` `[submit].adapter`, and for Git, runs `git init` + initial commit automatically. `--vcs perforce` also adds `ta-submit-perforce` to the plugin requirements in `project.toml`.
 3. [ ] **Template project generator**: `ta new` produces a project with `project.toml`, `README.md` with setup instructions, `.ta/` config pre-wired for the declared plugins, and a `setup.sh` fallback for users without TA installed.
 4. [ ] **`setup.sh` bootstrap**: Standalone shell script (committed to the template repo) that installs TA if missing, runs `ta setup`, and prints next steps. Works on macOS/Linux. PowerShell equivalent for Windows.
 5. [ ] **Reference template: ta-discord-template**: Published to `Trusted-Autonomy/ta-discord-template`. Demonstrates Discord channel plugin integration with a local TA daemon. Includes project.toml, setup.sh, .env.example, test-connection script.

--- a/apps/ta-cli/src/commands/draft.rs
+++ b/apps/ta-cli/src/commands/draft.rs
@@ -2198,14 +2198,14 @@ fn apply_package(
 
     // Submit workflow integration (VCS-agnostic: git, svn, perforce, etc.).
     if git_commit {
-        use ta_submit::{select_adapter, SubmitAdapter, WorkflowConfig};
+        use ta_submit::{select_adapter, SourceAdapter, WorkflowConfig};
 
         // Load workflow config if it exists.
         let workflow_config_path = target_dir.join(".ta/workflow.toml");
         let workflow_config = WorkflowConfig::load_or_default(&workflow_config_path);
 
         // Select adapter via registry (auto-detects VCS if config is default "none").
-        let adapter: Box<dyn SubmitAdapter> = select_adapter(&target_dir, &workflow_config.submit);
+        let adapter: Box<dyn SourceAdapter> = select_adapter(&target_dir, &workflow_config.submit);
 
         if adapter.name() == "none" && !dry_run {
             eprintln!(
@@ -2336,6 +2336,32 @@ fn apply_package(
                             eprintln!(
                                 "  You can manually create a review from the submitted branch."
                             );
+                        }
+                    }
+                }
+
+                // Auto-sync upstream if configured (v0.11.1).
+                if workflow_config.source.sync.auto_sync {
+                    println!("\nAuto-syncing upstream (source.sync.auto_sync = true)...");
+                    match adapter.sync_upstream() {
+                        Ok(result) if result.is_clean() && result.updated => {
+                            println!(
+                                "[ok] Synced {} new commit(s) from upstream.",
+                                result.new_commits
+                            );
+                        }
+                        Ok(result) if !result.is_clean() => {
+                            eprintln!(
+                                "Warning: auto-sync found {} conflict(s). \
+                                 Resolve manually with `ta sync`.",
+                                result.conflicts.len()
+                            );
+                        }
+                        Ok(_) => {
+                            println!("[ok] Already up to date.");
+                        }
+                        Err(e) => {
+                            eprintln!("Warning: auto-sync failed: {}. Run `ta sync` manually.", e);
                         }
                     }
                 }

--- a/apps/ta-cli/src/commands/mod.rs
+++ b/apps/ta-cli/src/commands/mod.rs
@@ -31,6 +31,7 @@ pub mod setup;
 pub mod shell;
 pub mod shell_tui;
 pub mod status;
+pub mod sync;
 pub mod terms;
 pub mod token;
 pub mod verify;

--- a/apps/ta-cli/src/commands/sync.rs
+++ b/apps/ta-cli/src/commands/sync.rs
@@ -1,0 +1,162 @@
+//! `ta sync` — Pull upstream changes into the local workspace.
+//!
+//! Calls the configured `SourceAdapter::sync_upstream()` to make the local
+//! workspace current with its upstream. Emits `sync_completed` or
+//! `sync_conflict` events through the TA event system.
+
+use ta_mcp_gateway::GatewayConfig;
+use ta_submit::{select_adapter_with_sync, SourceAdapter, WorkflowConfig};
+
+/// Execute `ta sync`.
+///
+/// Resolves the VCS adapter from `.ta/workflow.toml`, calls `sync_upstream()`,
+/// and reports the result. Warns if staging workspaces are active.
+pub fn execute(config: &GatewayConfig) -> anyhow::Result<()> {
+    let project_root = &config.workspace_root;
+
+    // Load workflow config.
+    let workflow_config_path = project_root.join(".ta/workflow.toml");
+    let workflow_config = WorkflowConfig::load_or_default(&workflow_config_path);
+
+    // Select adapter with sync config.
+    let adapter: Box<dyn SourceAdapter> = select_adapter_with_sync(
+        project_root,
+        &workflow_config.submit,
+        &workflow_config.source.sync,
+    );
+
+    if adapter.name() == "none" {
+        eprintln!(
+            "No VCS adapter detected. Configure [submit].adapter in .ta/workflow.toml \
+             or run from a Git/SVN/Perforce working directory."
+        );
+        return Err(anyhow::anyhow!(
+            "No VCS adapter available for sync. \
+             Configure [submit].adapter in .ta/workflow.toml."
+        ));
+    }
+
+    println!("Syncing upstream using {} adapter...", adapter.name());
+    println!(
+        "  Strategy: {}, Remote: {}, Branch: {}",
+        workflow_config.source.sync.strategy,
+        workflow_config.source.sync.remote,
+        workflow_config.source.sync.branch,
+    );
+
+    // Warn about active staging workspaces.
+    let staging_dir = project_root.join(".ta/staging");
+    if staging_dir.exists() {
+        let active_count = std::fs::read_dir(&staging_dir)
+            .map(|entries| entries.filter_map(|e| e.ok()).count())
+            .unwrap_or(0);
+        if active_count > 0 {
+            eprintln!(
+                "\nWarning: {} active staging workspace(s) detected.\n  \
+                 Syncing the source project may cause staging workspaces to \
+                 diverge from the source. Consider completing or discarding \
+                 active goals before syncing, or use `ta run --follow-up` \
+                 to rebase after sync.",
+                active_count
+            );
+        }
+    }
+
+    // Run the sync.
+    match adapter.sync_upstream() {
+        Ok(result) => {
+            if result.is_clean() {
+                if result.updated {
+                    println!("\n[ok] {}", result.message);
+                    println!("  {} new commit(s) incorporated.", result.new_commits);
+
+                    // Emit sync_completed event.
+                    emit_sync_event(config, &*adapter, &result);
+                } else {
+                    println!("\n[ok] Already up to date.");
+                }
+            } else {
+                // Conflicts detected.
+                eprintln!("\n[conflict] {}", result.message);
+                eprintln!("\nConflicting files:");
+                for f in &result.conflicts {
+                    eprintln!("  C  {}", f);
+                }
+                eprintln!("\nResolve conflicts, then `git add <files>` and `git commit`.");
+
+                // Emit sync_conflict event.
+                emit_conflict_event(config, &*adapter, &result);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("\nSync failed: {}", e);
+            eprintln!(
+                "\nTroubleshooting:\n  \
+                 - Check network connectivity\n  \
+                 - Verify remote '{}' exists: `git remote -v`\n  \
+                 - Verify branch '{}' exists on remote\n  \
+                 - Check [source.sync] in .ta/workflow.toml",
+                workflow_config.source.sync.remote, workflow_config.source.sync.branch,
+            );
+            Err(anyhow::anyhow!("Sync failed: {}", e))
+        }
+    }
+}
+
+/// Emit a `sync_completed` event through the TA event store.
+fn emit_sync_event(
+    config: &GatewayConfig,
+    adapter: &dyn SourceAdapter,
+    result: &ta_submit::SyncResult,
+) {
+    use ta_events::schema::{EventEnvelope, SessionEvent};
+    use ta_events::store::{EventStore, FsEventStore};
+
+    let event = SessionEvent::SyncCompleted {
+        adapter: adapter.name().to_string(),
+        new_commits: result.new_commits,
+        message: result.message.clone(),
+    };
+
+    let events_dir = config.workspace_root.join(".ta").join("events");
+    let store = FsEventStore::new(&events_dir);
+    if let Err(e) = store.append(&EventEnvelope::new(event)) {
+        tracing::warn!(error = %e, "Failed to store sync_completed event");
+    }
+}
+
+/// Emit a `sync_conflict` event through the TA event store.
+fn emit_conflict_event(
+    config: &GatewayConfig,
+    adapter: &dyn SourceAdapter,
+    result: &ta_submit::SyncResult,
+) {
+    use ta_events::schema::{EventEnvelope, SessionEvent};
+    use ta_events::store::{EventStore, FsEventStore};
+
+    let event = SessionEvent::SyncConflict {
+        adapter: adapter.name().to_string(),
+        conflicts: result.conflicts.clone(),
+        message: result.message.clone(),
+    };
+
+    let events_dir = config.workspace_root.join(".ta").join("events");
+    let store = FsEventStore::new(&events_dir);
+    if let Err(e) = store.append(&EventEnvelope::new(event)) {
+        tracing::warn!(error = %e, "Failed to store sync_conflict event");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ta_submit::{NoneAdapter, SourceAdapter};
+
+    #[test]
+    fn none_adapter_sync_returns_not_updated() {
+        let adapter = NoneAdapter::new();
+        let result = adapter.sync_upstream().unwrap();
+        assert!(!result.updated);
+        assert!(result.is_clean());
+    }
+}

--- a/apps/ta-cli/src/main.rs
+++ b/apps/ta-cli/src/main.rs
@@ -277,6 +277,12 @@ enum Commands {
         /// Agent ID (required for show/accept, optional for status).
         agent: Option<String>,
     },
+    /// Sync the local workspace with upstream changes.
+    ///
+    /// Calls the configured VCS adapter's sync operation (e.g., git fetch + merge/rebase).
+    /// Emits `sync_completed` or `sync_conflict` events. Configure sync behavior
+    /// in `[source.sync]` in `.ta/workflow.toml`.
+    Sync,
     /// Run pre-draft verification checks against a staging workspace.
     ///
     /// Runs the [verify] commands from .ta/workflow.toml in the staging
@@ -535,6 +541,7 @@ fn main() -> anyhow::Result<()> {
         } => commands::gc::execute(&config, *dry_run, *threshold_days, *all, *archive),
         Commands::Status => commands::status::execute(&config),
         Commands::Serve => commands::serve::execute(&project_root),
+        Commands::Sync => commands::sync::execute(&config),
         Commands::Verify { goal_id } => commands::verify::execute(&config, goal_id.as_deref()),
         Commands::Conversation { goal_id, json } => {
             commands::conversation::execute(&config, goal_id, *json)

--- a/crates/ta-daemon/src/config.rs
+++ b/crates/ta-daemon/src/config.rs
@@ -240,6 +240,8 @@ fn default_ta_subcommands() -> Vec<String> {
         "gc",
         "status",
         "serve",
+        "sync",
+        "verify",
         "conversation",
     ]
     .iter()

--- a/crates/ta-events/src/schema.rs
+++ b/crates/ta-events/src/schema.rs
@@ -222,6 +222,20 @@ pub enum SessionEvent {
         exit_code: i32,
         stderr: String,
     },
+
+    /// Upstream sync completed successfully (v0.11.1).
+    SyncCompleted {
+        adapter: String,
+        new_commits: u32,
+        message: String,
+    },
+
+    /// Upstream sync detected conflicts (v0.11.1).
+    SyncConflict {
+        adapter: String,
+        conflicts: Vec<String>,
+        message: String,
+    },
 }
 
 fn default_response_hint() -> String {
@@ -252,6 +266,8 @@ impl SessionEvent {
             Self::InteractiveSessionStarted { .. } => "interactive_session_started",
             Self::InteractiveSessionCompleted { .. } => "interactive_session_completed",
             Self::CommandFailed { .. } => "command_failed",
+            Self::SyncCompleted { .. } => "sync_completed",
+            Self::SyncConflict { .. } => "sync_conflict",
         }
     }
 
@@ -578,11 +594,21 @@ mod tests {
                 turn_count: 3,
                 outcome: "completed".into(),
             },
+            SessionEvent::SyncCompleted {
+                adapter: "git".into(),
+                new_commits: 3,
+                message: "ok".into(),
+            },
+            SessionEvent::SyncConflict {
+                adapter: "git".into(),
+                conflicts: vec!["a.rs".into()],
+                message: "conflict".into(),
+            },
         ];
         for e in &events {
             assert!(!e.event_type().is_empty());
         }
-        assert_eq!(events.len(), 19);
+        assert_eq!(events.len(), 21);
     }
 
     #[test]

--- a/crates/ta-submit/src/adapter.rs
+++ b/crates/ta-submit/src/adapter.rs
@@ -1,4 +1,8 @@
-//! Core SubmitAdapter trait and result types
+//! Core SourceAdapter trait and result types
+//!
+//! The `SourceAdapter` trait (formerly `SubmitAdapter`) is the unified abstraction
+//! for VCS operations. It combines submit operations (commit, push, open review)
+//! with sync operations (fetch upstream, detect conflicts).
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -9,7 +13,7 @@ use thiserror::Error;
 
 use crate::config::SubmitConfig;
 
-/// Errors that can occur during submit operations
+/// Errors that can occur during source operations
 #[derive(Debug, Error)]
 pub enum SubmitError {
     #[error("Adapter not configured: {0}")]
@@ -29,6 +33,12 @@ pub enum SubmitError {
 
     #[error("Invalid state: {0}")]
     InvalidState(String),
+
+    #[error("Sync failed: {0}")]
+    SyncError(String),
+
+    #[error("Sync conflict: {conflicts} file(s) in conflict")]
+    SyncConflict { conflicts: usize },
 }
 
 pub type Result<T> = std::result::Result<T, SubmitError>;
@@ -78,6 +88,33 @@ pub struct ReviewResult {
     pub metadata: HashMap<String, String>,
 }
 
+/// Result of a sync operation — pulling upstream changes into the local workspace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncResult {
+    /// Whether upstream had new changes that were incorporated.
+    pub updated: bool,
+
+    /// Files with merge conflicts (empty if none).
+    pub conflicts: Vec<String>,
+
+    /// Number of new upstream commits incorporated.
+    pub new_commits: u32,
+
+    /// Human-readable summary of what happened.
+    pub message: String,
+
+    /// Adapter-specific metadata.
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+impl SyncResult {
+    /// Whether the sync completed without conflicts.
+    pub fn is_clean(&self) -> bool {
+        self.conflicts.is_empty()
+    }
+}
+
 /// Opaque saved VCS state for save/restore around apply operations.
 ///
 /// Each adapter stores its own state (e.g., Git saves the current branch name,
@@ -90,11 +127,14 @@ pub struct SavedVcsState {
     pub data: Box<dyn std::any::Any + Send>,
 }
 
-/// Pluggable adapter for submitting changes through different VCS workflows
+/// Pluggable adapter for source control operations (submit + sync).
 ///
 /// The staging->review->apply loop is VCS-agnostic. This trait allows
 /// different implementations for Git, Perforce, SVN, or custom workflows.
-pub trait SubmitAdapter: Send + Sync {
+///
+/// Renamed from `SubmitAdapter` in v0.11.1 to reflect the unified scope
+/// (submit + sync). The old name is available as a type alias.
+pub trait SourceAdapter: Send + Sync {
     /// Create a working branch/changelist/workspace for this goal
     ///
     /// For Git: creates a feature branch
@@ -122,6 +162,27 @@ pub trait SubmitAdapter: Send + Sync {
     /// For Perforce: create Swarm review
     /// For "none": no-op
     fn open_review(&self, goal: &GoalRun, pr: &DraftPackage) -> Result<ReviewResult>;
+
+    /// Sync the local workspace with upstream changes.
+    ///
+    /// For Git: `git fetch` + merge/rebase/ff per `source.git.sync_strategy`
+    /// For SVN: `svn update`
+    /// For Perforce: `p4 sync`
+    /// For "none": no-op (always returns updated=false)
+    ///
+    /// Returns a `SyncResult` describing what happened. If conflicts are
+    /// detected, `SyncResult.conflicts` is non-empty but the method still
+    /// returns `Ok` — the caller decides how to handle conflicts. Only
+    /// returns `Err` for infrastructure failures (network, permissions).
+    fn sync_upstream(&self) -> Result<SyncResult> {
+        Ok(SyncResult {
+            updated: false,
+            conflicts: vec![],
+            new_commits: 0,
+            message: "No sync operation (default implementation)".to_string(),
+            metadata: HashMap::new(),
+        })
+    }
 
     /// Adapter display name (for CLI output)
     fn name(&self) -> &str;
@@ -174,5 +235,57 @@ pub trait SubmitAdapter: Send + Sync {
     {
         let _ = project_root;
         false
+    }
+}
+
+/// Backward-compatible alias: `SubmitAdapter` is the old name for `SourceAdapter`.
+///
+/// Deprecated in v0.11.1. Use `SourceAdapter` instead.
+pub use SourceAdapter as SubmitAdapter;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_result_is_clean_when_no_conflicts() {
+        let result = SyncResult {
+            updated: true,
+            conflicts: vec![],
+            new_commits: 3,
+            message: "ok".to_string(),
+            metadata: HashMap::new(),
+        };
+        assert!(result.is_clean());
+    }
+
+    #[test]
+    fn sync_result_is_not_clean_with_conflicts() {
+        let result = SyncResult {
+            updated: true,
+            conflicts: vec!["src/main.rs".to_string()],
+            new_commits: 3,
+            message: "conflict".to_string(),
+            metadata: HashMap::new(),
+        };
+        assert!(!result.is_clean());
+    }
+
+    #[test]
+    fn sync_result_serialization_roundtrip() {
+        let result = SyncResult {
+            updated: true,
+            conflicts: vec!["a.rs".to_string()],
+            new_commits: 5,
+            message: "synced".to_string(),
+            metadata: [("branch".to_string(), "main".to_string())]
+                .into_iter()
+                .collect(),
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let restored: SyncResult = serde_json::from_str(&json).unwrap();
+        assert!(restored.updated);
+        assert_eq!(restored.conflicts, vec!["a.rs"]);
+        assert_eq!(restored.new_commits, 5);
     }
 }

--- a/crates/ta-submit/src/config.rs
+++ b/crates/ta-submit/src/config.rs
@@ -10,6 +10,10 @@ pub struct WorkflowConfig {
     #[serde(default)]
     pub submit: SubmitConfig,
 
+    /// Source sync configuration (v0.11.1)
+    #[serde(default)]
+    pub source: SourceConfig,
+
     /// Diff viewing configuration
     #[serde(default)]
     pub diff: DiffConfig,
@@ -159,6 +163,58 @@ fn default_shelve() -> bool {
 pub struct SvnConfig {
     /// SVN repository URL (for commit messages / metadata)
     pub repo_url: Option<String>,
+}
+
+/// Source-level configuration section (`[source]` in workflow.toml).
+///
+/// Groups adapter-agnostic sync settings. Provider-specific options
+/// live in `[submit.git]`, `[submit.svn]`, etc.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SourceConfig {
+    /// Sync behavior configuration.
+    #[serde(default)]
+    pub sync: SyncConfig,
+}
+
+/// Sync upstream configuration (`[source.sync]` in workflow.toml).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncConfig {
+    /// Automatically sync upstream after `ta draft apply` succeeds.
+    /// Default: false.
+    #[serde(default)]
+    pub auto_sync: bool,
+
+    /// Git sync strategy: "merge" (default), "rebase", or "ff-only".
+    /// Other adapters ignore this field.
+    #[serde(default = "default_sync_strategy")]
+    pub strategy: String,
+
+    /// Remote name to sync from. Default: "origin".
+    #[serde(default = "default_remote")]
+    pub remote: String,
+
+    /// Branch to sync from. Default: "main".
+    #[serde(default = "default_sync_branch")]
+    pub branch: String,
+}
+
+impl Default for SyncConfig {
+    fn default() -> Self {
+        Self {
+            auto_sync: false,
+            strategy: default_sync_strategy(),
+            remote: default_remote(),
+            branch: default_sync_branch(),
+        }
+    }
+}
+
+fn default_sync_strategy() -> String {
+    "merge".to_string()
+}
+
+fn default_sync_branch() -> String {
+    "main".to_string()
 }
 
 /// Git adapter configuration
@@ -946,6 +1002,42 @@ auto_review = true
         // auto_review was a bool before; now Option<bool>. Explicit true in TOML
         // should be parsed as Some(true).
         assert!(config.submit.effective_auto_review());
+    }
+
+    #[test]
+    fn sync_config_defaults() {
+        let config = SyncConfig::default();
+        assert!(!config.auto_sync);
+        assert_eq!(config.strategy, "merge");
+        assert_eq!(config.remote, "origin");
+        assert_eq!(config.branch, "main");
+    }
+
+    #[test]
+    fn parse_toml_with_source_sync_section() {
+        let toml = r#"
+[source.sync]
+auto_sync = true
+strategy = "rebase"
+remote = "upstream"
+branch = "develop"
+"#;
+        let config: WorkflowConfig = toml::from_str(toml).unwrap();
+        assert!(config.source.sync.auto_sync);
+        assert_eq!(config.source.sync.strategy, "rebase");
+        assert_eq!(config.source.sync.remote, "upstream");
+        assert_eq!(config.source.sync.branch, "develop");
+    }
+
+    #[test]
+    fn parse_toml_without_source_section_uses_default() {
+        let toml = r#"
+[submit]
+adapter = "git"
+"#;
+        let config: WorkflowConfig = toml::from_str(toml).unwrap();
+        assert!(!config.source.sync.auto_sync);
+        assert_eq!(config.source.sync.strategy, "merge");
     }
 
     #[test]

--- a/crates/ta-submit/src/git.rs
+++ b/crates/ta-submit/src/git.rs
@@ -6,9 +6,11 @@ use ta_changeset::DraftPackage;
 use ta_goal::GoalRun;
 
 use crate::adapter::{
-    CommitResult, PushResult, Result, ReviewResult, SavedVcsState, SubmitAdapter, SubmitError,
+    CommitResult, PushResult, Result, ReviewResult, SavedVcsState, SourceAdapter, SubmitError,
+    SyncResult,
 };
 use crate::config::SubmitConfig;
+use crate::config::SyncConfig;
 
 /// Git adapter implementing branch-based workflow
 ///
@@ -22,6 +24,8 @@ pub struct GitAdapter {
     work_dir: std::path::PathBuf,
     /// Submit configuration (co-author, branch prefix, etc.)
     config: SubmitConfig,
+    /// Sync configuration (strategy, remote, branch)
+    sync_config: SyncConfig,
 }
 
 impl GitAdapter {
@@ -30,6 +34,7 @@ impl GitAdapter {
         Self {
             work_dir: work_dir.into(),
             config: SubmitConfig::default(),
+            sync_config: SyncConfig::default(),
         }
     }
 
@@ -38,6 +43,20 @@ impl GitAdapter {
         Self {
             work_dir: work_dir.into(),
             config,
+            sync_config: SyncConfig::default(),
+        }
+    }
+
+    /// Create a new GitAdapter with submit and sync configuration
+    pub fn with_full_config(
+        work_dir: impl Into<std::path::PathBuf>,
+        config: SubmitConfig,
+        sync_config: SyncConfig,
+    ) -> Self {
+        Self {
+            work_dir: work_dir.into(),
+            config,
+            sync_config,
         }
     }
 
@@ -106,7 +125,7 @@ impl GitAdapter {
     }
 }
 
-impl SubmitAdapter for GitAdapter {
+impl SourceAdapter for GitAdapter {
     fn prepare(&self, goal: &GoalRun, config: &SubmitConfig) -> Result<()> {
         let branch_name = self.branch_name(goal, config);
 
@@ -250,6 +269,112 @@ impl SubmitAdapter for GitAdapter {
 
     fn exclude_patterns(&self) -> Vec<String> {
         vec![".git/".to_string()]
+    }
+
+    fn sync_upstream(&self) -> Result<SyncResult> {
+        let remote = &self.sync_config.remote;
+        let branch = &self.sync_config.branch;
+        let strategy = &self.sync_config.strategy;
+
+        tracing::info!(
+            remote = %remote,
+            branch = %branch,
+            strategy = %strategy,
+            "GitAdapter: syncing upstream"
+        );
+
+        // Fetch from remote.
+        self.git_cmd(&["fetch", remote])?;
+
+        // Count new commits on remote that we don't have locally.
+        let remote_ref = format!("{}/{}", remote, branch);
+        let count_output = self
+            .git_cmd(&["rev-list", "--count", &format!("HEAD..{}", remote_ref)])
+            .unwrap_or_else(|_| "0".to_string());
+        let new_commits: u32 = count_output.trim().parse().unwrap_or(0);
+
+        if new_commits == 0 {
+            return Ok(SyncResult {
+                updated: false,
+                conflicts: vec![],
+                new_commits: 0,
+                message: format!("Already up to date with {}/{}.", remote, branch),
+                metadata: [
+                    ("remote".to_string(), remote.clone()),
+                    ("branch".to_string(), branch.clone()),
+                ]
+                .into_iter()
+                .collect(),
+            });
+        }
+
+        // Apply the upstream changes using the configured strategy.
+        let merge_result = match strategy.as_str() {
+            "rebase" => self.git_cmd(&["rebase", &remote_ref]),
+            "ff-only" => self.git_cmd(&["merge", "--ff-only", &remote_ref]),
+            _ => self.git_cmd(&["merge", &remote_ref]),
+        };
+
+        match merge_result {
+            Ok(output) => Ok(SyncResult {
+                updated: true,
+                conflicts: vec![],
+                new_commits,
+                message: format!(
+                    "Synced {} new commit(s) from {}/{} (strategy: {}). {}",
+                    new_commits, remote, branch, strategy, output
+                ),
+                metadata: [
+                    ("remote".to_string(), remote.clone()),
+                    ("branch".to_string(), branch.clone()),
+                    ("strategy".to_string(), strategy.clone()),
+                ]
+                .into_iter()
+                .collect(),
+            }),
+            Err(e) => {
+                // Check for merge conflicts.
+                let conflict_output = self
+                    .git_cmd(&["diff", "--name-only", "--diff-filter=U"])
+                    .unwrap_or_default();
+                let conflicts: Vec<String> = conflict_output
+                    .lines()
+                    .filter(|l| !l.is_empty())
+                    .map(|l| l.to_string())
+                    .collect();
+
+                if conflicts.is_empty() {
+                    // Not a conflict — infrastructure failure.
+                    Err(SubmitError::SyncError(format!(
+                        "Failed to sync {}/{} using strategy '{}': {}",
+                        remote, branch, strategy, e
+                    )))
+                } else {
+                    // Conflicts detected — return Ok with conflict info.
+                    // The caller decides whether to abort the merge.
+                    Ok(SyncResult {
+                        updated: true,
+                        conflicts: conflicts.clone(),
+                        new_commits,
+                        message: format!(
+                            "Synced {} new commit(s) from {}/{} but {} file(s) have conflicts. \
+                             Resolve conflicts manually, then `git add` and `git commit`.",
+                            new_commits,
+                            remote,
+                            branch,
+                            conflicts.len()
+                        ),
+                        metadata: [
+                            ("remote".to_string(), remote.clone()),
+                            ("branch".to_string(), branch.clone()),
+                            ("strategy".to_string(), strategy.clone()),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    })
+                }
+            }
+        }
     }
 
     fn save_state(&self) -> Result<Option<SavedVcsState>> {
@@ -568,6 +693,80 @@ mod tests {
         adapter.restore_state(state).unwrap();
         let restored = adapter.current_branch().unwrap();
         assert_eq!(restored, original_branch);
+    }
+
+    #[test]
+    fn test_git_adapter_sync_upstream_already_up_to_date() {
+        let dir = tempdir().unwrap();
+        init_git_repo(dir.path()).unwrap();
+
+        let adapter = GitAdapter::new(dir.path());
+        // No remote configured, so sync should fail gracefully or show up-to-date.
+        // Since there's no remote "origin", fetch will fail.
+        let result = adapter.sync_upstream();
+        // Without a remote, this will return an error (VCS operation failed).
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_git_adapter_sync_upstream_with_local_remote() {
+        // Create a "remote" repo and a "local" clone to test sync.
+        let remote_dir = tempdir().unwrap();
+        init_git_repo(remote_dir.path()).unwrap();
+
+        // Clone it to create a local repo with origin pointing to remote.
+        let local_dir = tempdir().unwrap();
+        Command::new("git")
+            .args(["clone", &remote_dir.path().to_string_lossy(), "."])
+            .current_dir(local_dir.path())
+            .output()
+            .unwrap();
+
+        // Detect the actual default branch name (may be "main" or "master").
+        let branch_output = Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .current_dir(local_dir.path())
+            .output()
+            .unwrap();
+        let branch_name = String::from_utf8_lossy(&branch_output.stdout)
+            .trim()
+            .to_string();
+
+        // Configure the sync adapter with the correct branch.
+        let sync_config = crate::config::SyncConfig {
+            branch: branch_name,
+            ..Default::default()
+        };
+        let adapter =
+            GitAdapter::with_full_config(local_dir.path(), SubmitConfig::default(), sync_config);
+
+        // At this point local is up to date with remote.
+        let result = adapter.sync_upstream().unwrap();
+        assert!(!result.updated);
+        assert_eq!(result.new_commits, 0);
+        assert!(result.is_clean());
+
+        // Now add a commit to the remote.
+        std::fs::write(remote_dir.path().join("new_file.txt"), "hello\n").unwrap();
+        Command::new("git")
+            .args(["add", "."])
+            .current_dir(remote_dir.path())
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "Remote commit"])
+            .current_dir(remote_dir.path())
+            .output()
+            .unwrap();
+
+        // Sync should pick up the new commit.
+        let result = adapter.sync_upstream().unwrap();
+        assert!(result.updated);
+        assert_eq!(result.new_commits, 1);
+        assert!(result.is_clean());
+
+        // Verify the file is now present locally.
+        assert!(local_dir.path().join("new_file.txt").exists());
     }
 
     #[test]

--- a/crates/ta-submit/src/lib.rs
+++ b/crates/ta-submit/src/lib.rs
@@ -1,8 +1,9 @@
-//! Submit adapters for VCS integration
+//! Source adapters for VCS integration
 //!
-//! This crate provides pluggable adapters for submitting changes through different
-//! version control systems and workflows. The core abstraction is the `SubmitAdapter`
-//! trait, with built-in implementations for Git, SVN (stub), Perforce (stub),
+//! This crate provides pluggable adapters for source control operations through
+//! different version control systems and workflows. The core abstraction is the
+//! `SourceAdapter` trait (unified from the former `SubmitAdapter` in v0.11.1),
+//! with built-in implementations for Git, SVN (stub), Perforce (stub),
 //! and a "none" fallback.
 
 pub mod adapter;
@@ -13,13 +14,20 @@ pub mod perforce;
 pub mod registry;
 pub mod svn;
 
-pub use adapter::{CommitResult, PushResult, ReviewResult, SavedVcsState, SubmitAdapter};
+// Primary exports (v0.11.1+)
+pub use adapter::{
+    CommitResult, PushResult, ReviewResult, SavedVcsState, SourceAdapter, SyncResult,
+};
+
+// Backward-compatible re-export: SubmitAdapter is a type alias for SourceAdapter.
+pub use adapter::SubmitAdapter;
+
 pub use config::{
     BuildConfig, DiffConfig, GitConfig, PerforceConfig, ShellConfig, SubmitConfig, SvnConfig,
-    VerifyCommand, VerifyConfig, VerifyOnFailure, WorkflowConfig,
+    SyncConfig, VerifyCommand, VerifyConfig, VerifyOnFailure, WorkflowConfig,
 };
 pub use git::GitAdapter;
 pub use none::NoneAdapter;
 pub use perforce::PerforceAdapter;
-pub use registry::{detect_adapter, known_adapters, select_adapter};
+pub use registry::{detect_adapter, known_adapters, select_adapter, select_adapter_with_sync};
 pub use svn::SvnAdapter;

--- a/crates/ta-submit/src/none.rs
+++ b/crates/ta-submit/src/none.rs
@@ -3,7 +3,7 @@
 use ta_changeset::DraftPackage;
 use ta_goal::GoalRun;
 
-use crate::adapter::{CommitResult, PushResult, Result, ReviewResult, SubmitAdapter};
+use crate::adapter::{CommitResult, PushResult, Result, ReviewResult, SourceAdapter};
 use crate::config::SubmitConfig;
 
 /// Fallback adapter that performs no VCS operations
@@ -25,7 +25,7 @@ impl Default for NoneAdapter {
     }
 }
 
-impl SubmitAdapter for NoneAdapter {
+impl SourceAdapter for NoneAdapter {
     fn prepare(&self, _goal: &GoalRun, _config: &SubmitConfig) -> Result<()> {
         // No-op: no workspace preparation needed
         tracing::debug!("NoneAdapter: prepare() - no-op");

--- a/crates/ta-submit/src/perforce.rs
+++ b/crates/ta-submit/src/perforce.rs
@@ -15,7 +15,8 @@ use ta_changeset::DraftPackage;
 use ta_goal::GoalRun;
 
 use crate::adapter::{
-    CommitResult, PushResult, Result, ReviewResult, SavedVcsState, SubmitAdapter, SubmitError,
+    CommitResult, PushResult, Result, ReviewResult, SavedVcsState, SourceAdapter, SubmitError,
+    SyncResult,
 };
 use crate::config::SubmitConfig;
 
@@ -69,7 +70,7 @@ impl PerforceAdapter {
     }
 }
 
-impl SubmitAdapter for PerforceAdapter {
+impl SourceAdapter for PerforceAdapter {
     fn prepare(&self, goal: &GoalRun, _config: &SubmitConfig) -> Result<()> {
         tracing::info!(
             "PerforceAdapter: creating pending changelist for goal {}",
@@ -174,6 +175,26 @@ impl SubmitAdapter for PerforceAdapter {
             message: "Changes shelved. If Helix Swarm is configured, the review is available in the Swarm web UI.".to_string(),
             metadata: Default::default(),
         })
+    }
+
+    fn sync_upstream(&self) -> Result<SyncResult> {
+        tracing::info!("PerforceAdapter: running p4 sync");
+
+        match self.p4_cmd(&["sync"]) {
+            Ok(output) => {
+                // Count synced files from p4 sync output.
+                let file_count = output.lines().count();
+
+                Ok(SyncResult {
+                    updated: file_count > 0,
+                    conflicts: vec![],
+                    new_commits: file_count as u32,
+                    message: format!("p4 sync completed: {} file(s) updated.", file_count),
+                    metadata: Default::default(),
+                })
+            }
+            Err(e) => Err(SubmitError::SyncError(format!("p4 sync failed: {}", e))),
+        }
     }
 
     fn name(&self) -> &str {

--- a/crates/ta-submit/src/registry.rs
+++ b/crates/ta-submit/src/registry.rs
@@ -6,8 +6,8 @@
 
 use std::path::Path;
 
-use crate::adapter::SubmitAdapter;
-use crate::config::SubmitConfig;
+use crate::adapter::SourceAdapter;
+use crate::config::{SubmitConfig, SyncConfig};
 use crate::git::GitAdapter;
 use crate::none::NoneAdapter;
 use crate::perforce::PerforceAdapter;
@@ -18,7 +18,7 @@ use crate::svn::SvnAdapter;
 /// Detection order: Git -> SVN -> Perforce -> None.
 /// First match wins.
 /// Auto-detect the appropriate VCS adapter with default config.
-pub fn detect_adapter(project_root: &Path) -> Box<dyn SubmitAdapter> {
+pub fn detect_adapter(project_root: &Path) -> Box<dyn SourceAdapter> {
     detect_adapter_with_config(project_root, &SubmitConfig::default())
 }
 
@@ -27,7 +27,7 @@ pub fn detect_adapter(project_root: &Path) -> Box<dyn SubmitAdapter> {
 pub fn detect_adapter_with_config(
     project_root: &Path,
     config: &SubmitConfig,
-) -> Box<dyn SubmitAdapter> {
+) -> Box<dyn SourceAdapter> {
     if GitAdapter::detect(project_root) {
         tracing::info!(adapter = "git", "Auto-detected Git repository");
         return Box::new(GitAdapter::with_config(project_root, config.clone()));
@@ -55,7 +55,7 @@ pub fn detect_adapter_with_config(
 /// 3. If auto-detection fails, fall back to NoneAdapter.
 ///
 /// This replaces the raw `.git/` existence check that was previously in `draft.rs`.
-pub fn select_adapter(project_root: &Path, config: &SubmitConfig) -> Box<dyn SubmitAdapter> {
+pub fn select_adapter(project_root: &Path, config: &SubmitConfig) -> Box<dyn SourceAdapter> {
     match config.adapter.as_str() {
         "git" => {
             tracing::info!(adapter = "git", "Using configured Git adapter");
@@ -83,6 +83,32 @@ pub fn select_adapter(project_root: &Path, config: &SubmitConfig) -> Box<dyn Sub
             );
             detect_adapter_with_config(project_root, config)
         }
+    }
+}
+
+/// Select an adapter with full configuration including sync settings.
+///
+/// Same as `select_adapter` but passes `SyncConfig` to adapters that support it
+/// (currently Git). Other adapters ignore sync config.
+pub fn select_adapter_with_sync(
+    project_root: &Path,
+    config: &SubmitConfig,
+    sync_config: &SyncConfig,
+) -> Box<dyn SourceAdapter> {
+    match config.adapter.as_str() {
+        "git" => {
+            tracing::info!(
+                adapter = "git",
+                "Using configured Git adapter (with sync config)"
+            );
+            Box::new(GitAdapter::with_full_config(
+                project_root,
+                config.clone(),
+                sync_config.clone(),
+            ))
+        }
+        // Other adapters don't use sync config — delegate to select_adapter.
+        _ => select_adapter(project_root, config),
     }
 }
 

--- a/crates/ta-submit/src/svn.rs
+++ b/crates/ta-submit/src/svn.rs
@@ -13,7 +13,9 @@ use std::process::Command;
 use ta_changeset::DraftPackage;
 use ta_goal::GoalRun;
 
-use crate::adapter::{CommitResult, PushResult, Result, ReviewResult, SubmitAdapter, SubmitError};
+use crate::adapter::{
+    CommitResult, PushResult, Result, ReviewResult, SourceAdapter, SubmitError, SyncResult,
+};
 use crate::config::SubmitConfig;
 
 /// SVN adapter implementing Subversion workflow.
@@ -54,7 +56,7 @@ impl SvnAdapter {
     }
 }
 
-impl SubmitAdapter for SvnAdapter {
+impl SourceAdapter for SvnAdapter {
     fn prepare(&self, _goal: &GoalRun, _config: &SubmitConfig) -> Result<()> {
         // SVN doesn't use branches the same way as Git.
         // No-op: the working copy is already pointing at the correct location.
@@ -113,6 +115,39 @@ impl SubmitAdapter for SvnAdapter {
             message: "SVN has no built-in review workflow. Consider using a code review tool like Crucible or ReviewBoard.".to_string(),
             metadata: Default::default(),
         })
+    }
+
+    fn sync_upstream(&self) -> Result<SyncResult> {
+        tracing::info!("SvnAdapter: running svn update");
+
+        match self.svn_cmd(&["update"]) {
+            Ok(output) => {
+                // Try to detect conflicts from "C " prefix lines in svn update output.
+                let conflicts: Vec<String> = output
+                    .lines()
+                    .filter(|l| l.starts_with("C ") || l.starts_with("C\t"))
+                    .map(|l| l[2..].trim().to_string())
+                    .collect();
+
+                // Try to count updated files from "U " prefix lines.
+                let updated_count = output
+                    .lines()
+                    .filter(|l| l.starts_with("U ") || l.starts_with("A ") || l.starts_with("D "))
+                    .count();
+
+                Ok(SyncResult {
+                    updated: updated_count > 0 || !conflicts.is_empty(),
+                    conflicts,
+                    new_commits: updated_count as u32,
+                    message: format!(
+                        "svn update completed. {}",
+                        output.lines().last().unwrap_or("")
+                    ),
+                    metadata: Default::default(),
+                })
+            }
+            Err(e) => Err(SubmitError::SyncError(format!("svn update failed: {}", e))),
+        }
     }
 
     fn name(&self) -> &str {

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1138,6 +1138,7 @@ Each adapter contributes VCS-specific exclude patterns that are merged with your
 | `commit()` | `git add` + `git commit` | `svn add` + `svn commit` | `p4 reconcile` + `p4 shelve` |
 | `push()` | `git push` | No-op (commit is remote) | `p4 submit` |
 | `open_review()` | `gh pr create` | No-op | Helix Swarm (if configured) |
+| `sync_upstream()` | `git fetch` + merge/rebase/ff | `svn update` | `p4 sync` |
 | `save_state()` | Save current branch | No-op | Save client/changelist |
 | `restore_state()` | Switch back to original branch | No-op | Log restore |
 
@@ -1152,6 +1153,32 @@ adapter = "perforce"
 ```
 
 **Build-time VCS revision**: The `ta` binary embeds a VCS revision at build time. Set `TA_REVISION` environment variable to override auto-detection (useful in CI for non-Git builds).
+
+### Syncing Upstream (`ta sync`)
+
+After a PR merges, your local branch is stale. `ta sync` pulls upstream changes through the configured VCS adapter:
+
+```bash
+ta sync
+```
+
+For Git, this runs `git fetch` followed by merge, rebase, or fast-forward depending on your configuration. If conflicts are detected, `ta sync` reports them without aborting — you resolve conflicts manually.
+
+Configure sync behavior in `.ta/workflow.toml`:
+
+```toml
+[source.sync]
+auto_sync = false    # auto-sync after ta draft apply (default: false)
+strategy = "merge"   # "merge" (default), "rebase", or "ff-only"
+remote = "origin"    # remote to sync from (default: "origin")
+branch = "main"      # branch to sync from (default: "main")
+```
+
+**Auto-sync after apply**: Set `auto_sync = true` to automatically sync upstream after `ta draft apply` completes the submit workflow. If conflicts are found during auto-sync, a warning is printed and you can run `ta sync` manually to resolve.
+
+**Shell shortcut**: In `ta shell`, type `sync` to run `ta sync` directly.
+
+**Events**: `ta sync` emits `sync_completed` or `sync_conflict` events, which flow through channels and event routing like all other TA events.
 
 ### Agent Configuration
 
@@ -4587,6 +4614,8 @@ TA has a working end-to-end workflow: staging isolation, agent wrapping, draft r
 | v0.10.18.6 | `ta daemon` subcommand (start/stop/restart/status/log) | Done |
 | v0.10.18.7 | Per-platform icon packaging | Done |
 | v0.11.0 | Event-driven agent routing | Done |
+| v0.11.0.1 | Draft apply defaults & CLI flag cleanup | Done |
+| v0.11.1 | `SourceAdapter` unification & `ta sync` | Done |
 
 See [PLAN.md](../PLAN.md) for full details on each phase.
 


### PR DESCRIPTION
## Summary

Changes from goal: Implement v0.11.1 —  Unification & `ta sync`

**Why**: Merge the current `SubmitAdapter` trait with sync operations into a unified `SourceAdapter` trait. Add `ta sync` command. The trait defines abstract VCS operations; provider-specific mechanics (rebase, fast-forward, shelving) live in each implementation.

**Impact**: 19 file(s) changed

## Changes (19 file(s))

- `~` `fs://workspace/.git/index`
- `~` `fs://workspace/Cargo.lock`
- `~` `fs://workspace/Cargo.toml` — Bumped workspace version from 0.11.0-alpha.1 to 0.11.1-alpha.
  - Version management policy requires version bump per phase.
- `~` `fs://workspace/PLAN.md` — Replaced v0.11.1 Items section with Completed section. Marked all 10 items as completed with descriptions. Listed 9 new tests with names and locations.
  - Plan tracks implementation progress. All items are done.
- `~` `fs://workspace/apps/ta-cli/src/commands/draft.rs` — Updated SubmitAdapter import to SourceAdapter. Added auto-sync block after review step in ta draft apply: when source.sync.auto_sync is true, calls adapter.sync_upstream() with clean/conflict/error handling.
  - Auto-sync after apply keeps the local workspace current without requiring a separate ta sync invocation.
- `~` `fs://workspace/apps/ta-cli/src/commands/mod.rs` — Added pub mod sync to register the new sync command module.
  - Rust module system requires explicit registration.
- `+` `fs://workspace/apps/ta-cli/src/commands/sync.rs` — New ta sync CLI command. Resolves VCS adapter with sync config from workflow.toml. Calls sync_upstream(). Emits sync_completed/sync_conflict events via FsEventStore. Warns about active staging workspaces. Includes troubleshooting on failure. 1 new test.
  - ta sync is the user-facing command for pulling upstream changes through TA's governed workflow.
- `~` `fs://workspace/apps/ta-cli/src/main.rs` — Added Commands::Sync variant with help text. Added match arm routing to commands::sync::execute.
  - Wiring the new command into the CLI's argument parser and dispatch.
- `~` `fs://workspace/crates/ta-daemon/src/config.rs` — Added 'sync' and 'verify' to default_ta_subcommands() list.
  - Shell TUI routes bare words matching ta_subcommands as ta <word>. Adding sync enables 'ta> sync' as a shell shortcut.
- `~` `fs://workspace/crates/ta-events/src/schema.rs` — Added SyncCompleted { adapter, new_commits, message } and SyncConflict { adapter, conflicts, message } variants to SessionEvent enum. Added event_type() match arms. Updated all_event_types_have_names test (19 → 21 events).
  - Sync results need to flow through the TA event system for channels, routing agents, and audit.
- `~` `fs://workspace/crates/ta-submit/src/adapter.rs` — Renamed SubmitAdapter trait to SourceAdapter with backward-compat type alias. Added SyncResult struct (updated, conflicts, new_commits, message, metadata) with is_clean() helper. Added sync_upstream() default method (no-op). Added SyncError and SyncConflict variants to SubmitError. Added 3 new tests for SyncResult.
  - Unifying submit and sync operations into one trait per the MISSION-AND-SCOPE.md SourceAdapter design. Backward-compat alias prevents breaking existing consumers.
- `~` `fs://workspace/crates/ta-submit/src/config.rs` — Added SourceConfig and SyncConfig structs ([source.sync] section with auto_sync, strategy, remote, branch fields). Added source field to WorkflowConfig. Added 3 new config tests.
  - The sync operation needs per-project configuration for strategy (merge/rebase/ff-only), remote, and branch. The [source.sync] namespace follows the MISSION-AND-SCOPE design.
- `~` `fs://workspace/crates/ta-submit/src/git.rs` — Renamed SubmitAdapter impl to SourceAdapter. Added sync_config field to GitAdapter. Added with_full_config() constructor. Implemented sync_upstream(): git fetch + merge/rebase/ff-only per config, commit counting via rev-list, conflict detection via diff --name-only --diff-filter=U. Added 2 new tests (up-to-date and local remote sync).
  - Git is the primary adapter — its sync_upstream() is the most complete implementation, supporting all three merge strategies and structured conflict detection.
- `~` `fs://workspace/crates/ta-submit/src/lib.rs` — Updated public re-exports: added SourceAdapter, SyncResult, SyncConfig, select_adapter_with_sync. Kept SubmitAdapter re-export for backward compat. Updated module doc comment.
  - Consumers import through lib.rs — all new types need to be re-exported here.
- `~` `fs://workspace/crates/ta-submit/src/none.rs` — Renamed SubmitAdapter impl to SourceAdapter. sync_upstream() uses the default no-op from the trait.
  - NoneAdapter inherits the default no-op implementation — no explicit sync code needed.
- `~` `fs://workspace/crates/ta-submit/src/perforce.rs` — Renamed SubmitAdapter impl to SourceAdapter. Implemented sync_upstream(): p4 sync with file count from output.
  - Perforce sync is p4 sync — maps cleanly to the abstract operation.
- `~` `fs://workspace/crates/ta-submit/src/registry.rs` — Updated all references from SubmitAdapter to SourceAdapter. Added select_adapter_with_sync() function that passes SyncConfig to Git adapter. Added SyncConfig import.
  - The registry is the adapter factory — it needs to pass sync config to adapters that support it (currently Git).
- `~` `fs://workspace/crates/ta-submit/src/svn.rs` — Renamed SubmitAdapter impl to SourceAdapter. Implemented sync_upstream(): svn update with conflict detection (C prefix lines) and update counting (U/A/D prefix lines).
  - SVN sync is straightforward — svn update is the only strategy.
- `~` `fs://workspace/docs/USAGE.md` — Added sync_upstream() row to VCS adapter operations table. Added 'Syncing Upstream (ta sync)' section with usage, config example, auto-sync, shell shortcut, and events documentation. Added v0.11.0.1 and v0.11.1 to roadmap table.
  - USAGE.md is the user onboarding guide — new user-facing features must be documented.

## Goal Context

- **Title**: Implement v0.11.1 —  Unification &
- **Objective**: Implement v0.11.1 —  Unification &
- **Goal ID**: `3ace3ee5-1ce0-47ae-b1e5-e713419c99db`
- **PR ID**: `74379eee-871a-4df9-a1af-11a164db7847`
- **Plan Phase**: `0.11.1`

---

Generated by [Trusted Autonomy](https://github.com/trustedautonomy/ta)
