### PR TITLE
v0.10.19 — Shell agent routing, TUI mouse fix, error surfacing

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -3110,9 +3110,9 @@ Each platform has a different mechanism for icon embedding:
 
 ---
 
-### v0.10.19 — Shell Agent Routing & TUI Copy Support
-<!-- status: pending -->
-**Goal**: Fix two immediate shell usability issues discovered in v0.10.18: (1) agent Q&A sessions fail when `default_agent` is not `claude-code`, and (2) TUI raw mode prevents text selection/copy.
+### v0.10.19 — Shell Agent Routing, TUI Mouse Fix & Agent Output Diagnostics
+<!-- status: in_progress -->
+**Goal**: Fix three immediate shell usability issues: (1) agent Q&A sessions fail when `default_agent` is not `claude-code`, (2) TUI mouse capture prevents text selection/copy, and (3) agent errors are silently swallowed.
 
 #### Problem 1: Agent Q&A routing broken for non-claude-code agents
 When `default_agent = "claude-flow"` in `daemon.toml`, natural language questions in `ta shell` hit the generic fallback in `resolve_agent_command()` (`agent.rs:384`): `claude-flow "prompt"`. Claude-flow is a framework/MCP server — it doesn't accept bare prompts as CLI arguments. The process exits immediately with no useful output, showing "agent output ended" in the shell.
@@ -3121,15 +3121,33 @@ The root issue is that `default_agent` serves two different purposes:
 - **Goal execution** (`ta run`): which agent framework to spawn for goals — claude-flow is correct here
 - **Shell Q&A** (`ask_agent`): which LLM to answer ad-hoc questions — needs a prompt-capable agent (claude-code)
 
-#### Problem 2: TUI raw mode blocks text selection/copy
-The shell TUI (`shell_tui.rs`) enables mouse capture for scroll support (`MouseEventKind::ScrollUp/Down`). This intercepts the terminal emulator's native text selection, making it impossible to copy agent output. Users need to copy command output, error messages, and goal IDs regularly.
+Ultimately each workflow should be able to specify which agent framework to use, with per-agent override options. The workflow and agent might have a recommendation but it should be stored at the project level.
+
+#### Problem 2: TUI mouse capture blocks text selection/copy
+The shell TUI (`shell_tui.rs`) calls `EnableMouseCapture` to support scroll-via-mouse (`MouseEventKind::ScrollUp/Down`). This steals the mouse from the terminal emulator, blocking native text selection. Claude Code's terminal handles this correctly — scroll and text selection both work because it doesn't capture the mouse. We already have keyboard scrolling (Shift+Up/Down, PageUp/PageDown) so mouse capture adds no value. Remove it.
+
+#### Problem 3: Agent errors silently swallowed
+When the agent process fails to start, crashes, or exits with an error, the output may be lost — especially if the stream-json parser doesn't recognize the output format. The shell should always surface what the agent said, even if it's an error or unrecognized format. Never silently ignore agent output.
 
 #### Items
-1. [ ] **Separate `qa_agent` config**: Add `[agent].qa_agent` (default: `"claude-code"`) in `daemon.toml` for shell Q&A sessions. `ask_agent()` uses `qa_agent` instead of `default_agent`. The default agent for goals remains independently configurable.
-2. [ ] **Add `claude-flow` to `resolve_agent_command()`**: Add a match arm for `"claude-flow"` that invokes it correctly for agent prompts (or falls back to claude-code for Q&A).
-3. [ ] **Toggle mouse capture with keybinding**: Add a keybinding (e.g., `Shift+M` or `Ctrl+Shift+C`) that temporarily disables mouse capture so the user can select and copy text. Re-enable on next keypress. Show mode indicator in status bar.
-4. [ ] **Copy-mode**: Alternative approach — a `:copy` shell command that dumps the last N lines of output to a temp file and opens it in `$PAGER` (or `less`), where native selection works. Or copies to system clipboard via `pbcopy`/`xclip`/`xsel`.
-5. [ ] **`--classic` shell flag**: Allow launching the non-TUI shell (`shell.rs`) which uses readline and doesn't capture mouse, as a fallback for users who need unrestricted copy. Already exists as code path but may not be easily selectable.
+1. [ ] **Per-workflow agent config at project level**: Add `[agent.workflows]` in `daemon.toml` (or `project.toml`) mapping workflow types to agents:
+   ```toml
+   [agent]
+   default_agent = "claude-flow"   # fallback for goal execution
+   qa_agent = "claude-code"        # shell Q&A, diagnostic, interactive
+
+   [agent.workflows]
+   goal = "claude-flow"            # ta run
+   qa = "claude-code"              # shell natural language
+   diagnostic = "claude-code"      # daemon-spawned diagnostics (v0.12.4)
+   dev = "claude-code"             # ta dev
+   # Per-agent overrides possible per workflow
+   ```
+   `ask_agent()` uses `qa_agent`; `ta run` uses `goal` workflow agent. Each is independently configurable with project-level storage.
+2. [ ] **Add `claude-flow` match arm to `resolve_agent_command()`**: Invoke claude-flow correctly for goal execution, and ensure Q&A routing never sends prompts to a framework agent.
+3. [ ] **Remove `EnableMouseCapture` from TUI**: Delete `EnableMouseCapture`/`DisableMouseCapture` and the `MouseEventKind` handler. Terminal-native mouse scroll and text selection both work. Keyboard scrolling (Shift+Up/Down, PageUp/PageDown) remains.
+4. [ ] **Surface all agent output on error**: When the agent process exits with non-zero status, or when `parse_stream_json_text()` returns `None` (unrecognized format), display the raw output to the user instead of silently dropping it. Include exit code, stderr, and any stdout that wasn't parsed.
+5. [ ] **Agent launch failure surfacing**: If `resolve_agent_command()` produces a binary that doesn't exist or fails to spawn, show the error in the shell output stream immediately — not just in daemon logs. Include the binary name, args, and spawn error.
 
 #### Version: `0.10.19-alpha`
 

--- a/apps/ta-cli/src/commands/shell_tui.rs
+++ b/apps/ta-cli/src/commands/shell_tui.rs
@@ -12,8 +12,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEventKind};
-use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
@@ -610,7 +609,9 @@ async fn run_tui(
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     stdout.execute(EnterAlternateScreen)?;
-    stdout.execute(EnableMouseCapture)?;
+    // NOTE: Mouse capture intentionally NOT enabled. Terminal-native mouse
+    // handles both scroll and text selection. Keyboard scrolling works via
+    // Shift+Up/Down and PageUp/PageDown. See v0.10.19 item 3.
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -631,7 +632,7 @@ async fn run_tui(
     // Cleanup.
     running.store(false, Ordering::Relaxed);
     disable_raw_mode()?;
-    terminal.backend_mut().execute(DisableMouseCapture)?;
+    // Mouse capture was never enabled — no need to disable.
     terminal.backend_mut().execute(LeaveAlternateScreen)?;
 
     // Save history.
@@ -1000,11 +1001,9 @@ async fn handle_terminal_event(
                 _ => {}
             }
         }
-        Event::Mouse(mouse_event) => match mouse_event.kind {
-            MouseEventKind::ScrollUp => app.scroll_up(3),
-            MouseEventKind::ScrollDown => app.scroll_down(3),
-            _ => {}
-        },
+        Event::Mouse(_) => {
+            // Mouse events not captured — terminal handles natively.
+        }
         Event::Resize(_, _) => {
             // Terminal will re-draw on next loop iteration.
         }

--- a/crates/ta-daemon/src/api/agent.rs
+++ b/crates/ta-daemon/src/api/agent.rs
@@ -266,6 +266,7 @@ pub async fn ask_agent(
                         let stdout = child.stdout.take();
                         let stderr = child.stderr.take();
                         let tx2 = tx.clone();
+                        let tx_err = tx.clone();
 
                         let stdout_task = tokio::spawn(async move {
                             if let Some(out) = stdout {
@@ -298,15 +299,29 @@ pub async fn ask_agent(
 
                         match status {
                             Ok(Ok(s)) if !s.success() => {
+                                let exit_code = s.code().unwrap_or(-1);
                                 tracing::warn!(
                                     "Agent ask failed (exit {}): session={}, request={}",
-                                    s.code().unwrap_or(-1),
+                                    exit_code,
                                     session_id,
                                     req_id,
                                 );
+                                // Surface error to the shell output stream (v0.10.19 item 4).
+                                let _ = tx_err.send(OutputLine {
+                                    stream: "stderr",
+                                    line: format!(
+                                        "[agent error] {} exited with code {}. \
+                                         Check agent binary and args.",
+                                        agent, exit_code
+                                    ),
+                                });
                             }
                             Ok(Err(e)) => {
                                 tracing::error!("Agent wait error: {}", e);
+                                let _ = tx_err.send(OutputLine {
+                                    stream: "stderr",
+                                    line: format!("[agent error] Process wait failed: {}", e),
+                                });
                             }
                             Err(_) => {
                                 let _ = child.kill().await;
@@ -315,6 +330,14 @@ pub async fn ask_agent(
                                     timeout.as_secs(),
                                     req_id,
                                 );
+                                let _ = tx_err.send(OutputLine {
+                                    stream: "stderr",
+                                    line: format!(
+                                        "[agent error] Timed out after {}s. \
+                                         Configure timeout in daemon.toml [agent].timeout_secs.",
+                                        timeout.as_secs()
+                                    ),
+                                });
                             }
                             _ => {}
                         }
@@ -326,6 +349,15 @@ pub async fn ask_agent(
                             binary,
                             e
                         );
+                        // Surface launch failure to the shell output stream.
+                        let _ = tx.send(OutputLine {
+                            stream: "stderr",
+                            line: format!(
+                                "[agent error] Failed to start '{}' (binary: '{}'): {}. \
+                                 Check that the agent is installed and in PATH.",
+                                agent, binary, e
+                            ),
+                        });
                     }
                 }
 

--- a/crates/ta-daemon/src/api/input.rs
+++ b/crates/ta-daemon/src/api/input.rs
@@ -76,10 +76,12 @@ pub async fn handle_input(
             let session_id = if let Some(id) = body.session_id.filter(|s| !s.is_empty()) {
                 id
             } else {
-                // Get or create a default session.
+                // Get or create a Q&A session using the qa_agent (not default_agent).
+                // qa_agent is for interactive prompts (claude-code); default_agent is
+                // for goal execution frameworks (claude-flow). See v0.10.19 item 1.
                 match state
                     .agent_sessions
-                    .get_or_create_default(&state.daemon_config.agent.default_agent)
+                    .get_or_create_default(&state.daemon_config.agent.qa_agent)
                     .await
                 {
                     Ok(session) => session.session_id,

--- a/crates/ta-daemon/src/config.rs
+++ b/crates/ta-daemon/src/config.rs
@@ -165,6 +165,11 @@ pub struct AgentConfig {
     pub max_sessions: usize,
     pub idle_timeout_secs: u64,
     pub default_agent: String,
+    /// Agent for shell Q&A sessions (natural language questions in `ta shell`).
+    /// Defaults to `"claude-code"` — must be a prompt-capable agent, not a framework.
+    /// Separate from `default_agent` which is used for goal execution (`ta run`).
+    #[serde(default = "default_qa_agent")]
+    pub qa_agent: String,
     /// Timeout for agent prompt responses (default: 300s / 5 minutes).
     /// Agent LLM calls can take minutes — this is separate from the command timeout.
     pub timeout_secs: u64,
@@ -174,12 +179,17 @@ pub struct AgentConfig {
     pub tool_access: AgentToolAccess,
 }
 
+fn default_qa_agent() -> String {
+    "claude-code".to_string()
+}
+
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
             max_sessions: 3,
             idle_timeout_secs: 3600,
             default_agent: "claude-code".to_string(),
+            qa_agent: "claude-code".to_string(),
             timeout_secs: 300,
             tool_access: AgentToolAccess::default(),
         }


### PR DESCRIPTION
## Summary
- Add `qa_agent` config (default: `claude-code`) for shell Q&A sessions, separate from `default_agent` used for goal execution. Fixes agent Q&A when `default_agent = "claude-flow"`.
- Remove `EnableMouseCapture` from TUI so terminal handles mouse natively — scroll and text selection both work, matching Claude Code behavior.
- Surface agent errors (spawn failure, non-zero exit, timeout) to shell output stream instead of silently logging to tracing only.

## Test plan
- [ ] Rebuild daemon, restart, verify `ta shell` Q&A works with `default_agent = "claude-flow"` in `daemon.toml`
- [ ] Verify text selection/copy works in `ta shell` TUI
- [ ] Verify keyboard scrolling (Shift+Up/Down, PageUp/PageDown) still works
- [ ] Verify agent errors are visible in shell output (test with non-existent agent binary)
- [ ] CI passes (build, test, clippy, fmt)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)