### PR TITLE
Add daemon auto-start and version guard to both shells

### DIFF
--- a/apps/ta-cli/src/commands/shell.rs
+++ b/apps/ta-cli/src/commands/shell.rs
@@ -124,17 +124,26 @@ async fn run_shell(
         }
     }
 
-    // Warn if the daemon version doesn't match the CLI version.
+    // Version mismatch — auto-restart the daemon to match CLI version.
     let cli_version = env!("CARGO_PKG_VERSION");
     if status.version != cli_version {
         eprintln!(
-            "Warning: daemon is v{} but this CLI is v{}",
+            "Daemon is v{} but CLI is v{} — restarting daemon...",
             status.version, cli_version
         );
-        eprintln!("  The daemon may behave differently than expected.");
-        eprintln!("  To fix: restart the daemon with the matching version:");
-        eprintln!("    ta daemon restart");
-        eprintln!();
+        match super::daemon::restart(project_root, None) {
+            Ok(_pid) => {
+                std::thread::sleep(std::time::Duration::from_secs(1));
+                status = fetch_status(&client, &base_url).await;
+                eprintln!("Daemon restarted (v{}).", status.version);
+            }
+            Err(e) => {
+                eprintln!(
+                    "Warning: daemon restart failed: {}. Continuing with v{}.",
+                    e, status.version
+                );
+            }
+        }
     }
 
     print_header(&status, &base_url);

--- a/apps/ta-cli/src/commands/shell_tui.rs
+++ b/apps/ta-cli/src/commands/shell_tui.rs
@@ -524,24 +524,53 @@ async fn run_tui(
     let client = reqwest::Client::new();
 
     // Check daemon connectivity before entering TUI mode.
-    let initial_status = super::shell::fetch_status(&client, &base_url).await;
+    let mut initial_status = super::shell::fetch_status(&client, &base_url).await;
     if initial_status.version.is_empty() || initial_status.version == "?" {
-        eprintln!("Error: Cannot reach daemon at {}", base_url);
-        eprintln!();
-        eprintln!("Start the daemon with:");
-        eprintln!("  ta daemon start                # start in background");
-        eprintln!("  ta daemon start --foreground   # start in foreground (for debugging)");
-        return Err(anyhow::anyhow!("daemon not reachable at {}", base_url));
+        // Auto-start the daemon (v0.11.2.1 — match classic shell behavior).
+        match super::daemon::ensure_running(&project_root) {
+            Ok(()) => {
+                initial_status = super::shell::fetch_status(&client, &base_url).await;
+                if initial_status.version.is_empty() || initial_status.version == "?" {
+                    eprintln!("Error: Daemon started but status fetch still failed.");
+                    eprintln!("  Check logs: ta daemon log");
+                    return Err(anyhow::anyhow!("daemon not reachable at {}", base_url));
+                }
+                eprintln!("Daemon auto-started (v{}).", initial_status.version);
+            }
+            Err(e) => {
+                eprintln!("Error: Cannot reach daemon at {}", base_url);
+                eprintln!("  Auto-start failed: {}", e);
+                eprintln!();
+                eprintln!("Start the daemon manually with:");
+                eprintln!("  ta daemon start                # start in background");
+                eprintln!("  ta daemon start --foreground   # start in foreground (for debugging)");
+                return Err(anyhow::anyhow!("daemon not reachable at {}", base_url));
+            }
+        }
     }
 
-    // Version mismatch warning.
+    // Version mismatch — auto-restart the daemon to match CLI version.
     let cli_version = env!("CARGO_PKG_VERSION");
     if initial_status.version != cli_version {
         eprintln!(
-            "Warning: daemon is v{} but this CLI is v{}",
+            "Daemon is v{} but CLI is v{} — restarting daemon...",
             initial_status.version, cli_version
         );
-        eprintln!("  Restart with matching version: pkill -f 'ta-daemon' && ta-daemon --api --project-root .");
+        match super::daemon::restart(&project_root, None) {
+            Ok(_pid) => {
+                // Wait briefly for the new daemon to be ready.
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                // Re-fetch status after restart.
+                initial_status = super::shell::fetch_status(&client, &base_url).await;
+                eprintln!("Daemon restarted (v{}).", initial_status.version);
+            }
+            Err(e) => {
+                eprintln!(
+                    "Warning: daemon restart failed: {}. Continuing with v{}.",
+                    e, initial_status.version
+                );
+            }
+        }
     }
 
     // Fetch completions.

--- a/docs/TA-CONSTITUTION.md
+++ b/docs/TA-CONSTITUTION.md
@@ -207,9 +207,12 @@ Constitution violations are always Warning or higher.
 The agent (and shell) propose actions. The daemon evaluates policy, records audit events, and mediates execution. The agent never writes directly to the source project — all changes flow through staging → diff → draft → apply.
 
 ### 9.3 Daemon Auto-Start
-If `ta shell` cannot reach the daemon, it attempts auto-start via `daemon::ensure_running()`. If the daemon is still unreachable after auto-start, shell fails with a clear error.
+If `ta shell` cannot reach the daemon, it MUST auto-start via `daemon::ensure_running()`. The user should never have to manually start the daemon to use the shell. If the daemon is still unreachable after auto-start, shell fails with a clear error.
 
-### 9.4 Agent Read-Only Inspection
+### 9.4 Daemon Version Guard
+If the running daemon version does not match the CLI version, the shell MUST auto-restart the daemon to ensure version parity. The CLI and daemon are tightly coupled — running mismatched versions leads to silent failures, missing features, and protocol incompatibilities. The restart happens automatically before entering the shell; the user sees the version transition in startup output.
+
+### 9.5 Agent Read-Only Inspection
 The agent can read daemon state (goal status, draft details, plan progress, logs) through MCP tools or daemon API. It cannot mutate state without daemon mediation and policy evaluation.
 
 ---
@@ -335,7 +338,7 @@ For pre-release review, verify each command against these rules:
 | `ta goal start` | 3.1 (staging copy), 5.1 (Created → Configured) |
 | `ta goal delete` | 7.4 (terminal audit) |
 | `ta goal gc` | 5.5 (zombie detection), 7.4 (terminal audit) |
-| `ta shell` | 9.1-9.4 (thin client, daemon mediates) |
+| `ta shell` | 9.1-9.5 (thin client, daemon mediates, auto-start, version guard) |
 | `ta plan *` | 9.4 (read-only agent inspection) |
 | `ta audit verify` | 7.2 (hash chain validation) |
 | Plugins | 11.2-11.4 (discovery, isolation, signing) |


### PR DESCRIPTION
## Summary
- TUI shell now auto-starts daemon via `ensure_running()` if unreachable (classic shell already did this)
- Both shells auto-restart daemon when CLI version != daemon version, preventing silent failures from mismatched versions
- Added Constitution sections 9.3 (Daemon Auto-Start) and 9.4 (Daemon Version Guard) as mandatory shell behaviors

## Test plan
- [ ] Run `ta shell` with daemon stopped — verify it auto-starts
- [ ] Run `ta shell --classic` with daemon stopped — verify it auto-starts
- [ ] Build a new CLI version, run `ta shell` against old daemon — verify auto-restart
- [ ] Verify `TA-CONSTITUTION.md` sections 9.3 and 9.4 are present and accurate

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)