### PR TITLE
Add --verbose to ta run headless_args for claude-code

### DIFF
--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -184,7 +184,7 @@ fn builtin_agent_config(agent_id: &str) -> AgentLaunchConfig {
             description: Some("Anthropic's Claude Code CLI".to_string()),
             interactive: None,
             alignment: Some(ta_policy::AlignmentProfile::default_developer()),
-            headless_args: vec!["--output-format".to_string(), "stream-json".to_string()],
+            headless_args: vec!["--verbose".to_string(), "--output-format".to_string(), "stream-json".to_string()],
             non_interactive_env: Default::default(),
             auto_answers: Vec::new(),
         },


### PR DESCRIPTION
## Summary
- Same `--verbose` fix as PR #159, but for the `ta run` code path in `run.rs`
- `ta run` has its own `headless_args` for claude-code that was missed

## Test plan
- [ ] `ta run <phase>` launches agent without stream-json error

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)