### PR TITLE
Add v0.11.3.1 — Shell Scroll & Help

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ All outcomes must be **observable** (with details and logging) and **actionable*
 
 ## Current State
 
-- **Current version**: `0.11.2-alpha.1`
+- **Current version**: `0.11.3-alpha.1`
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --phase 4b`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "ta-build"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "chrono",
  "glob",
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "chrono",
  "rmcp",
@@ -3221,7 +3221,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "chrono",
  "glob",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "ta-output-schema"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3263,7 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "chrono",
  "glob",
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "chrono",
  "libc",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.11.3-alpha"
+version = "0.11.3-alpha.1"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -3689,6 +3689,18 @@ The core insight: a real prompt means the agent is **waiting** — it stops prod
 
 ---
 
+### v0.11.3.1 — Shell Scroll & Help
+<!-- status: done -->
+**Goal**: Fix trackpad/mouse wheel scrolling in `ta shell` and improve command discoverability.
+
+1. [x] **Mouse scroll capture**: Enable `EnableMouseCapture` so trackpad two-finger scroll and mouse wheel events are handled by the TUI instead of scrolling the terminal's main buffer. Scroll events move 3 lines per tick.
+2. [x] **Full-page PageUp/PageDown**: PageUp/PageDown now scroll `terminal_height - 4` lines (with 4-line overlap) instead of the previous fixed 10 lines.
+3. [x] **Text selection via Shift+click-drag**: With mouse capture enabled, native click-drag is captured. Users can select text with Shift+click-drag (standard behavior in terminals with mouse capture).
+4. [x] **`help` shows CLI commands**: The shell `help` command now shows both shell-specific help and a summary of all `ta` CLI commands, so users can discover available commands without leaving the shell.
+5. [x] **Help text updated**: Scroll instructions updated to reflect trackpad scroll, full-page PageUp/PageDown, and Shift+click-drag for text selection.
+
+---
+
 ### v0.11.4 — Plugin Registry & Project Manifest
 <!-- status: pending -->
 **Goal**: Unified plugin distribution system so any TA project can declare its plugin requirements and `ta setup` resolves them automatically — downloading platform-specific binaries, falling back to source builds, and verifying version compatibility. Users who clone a TA project run `ta setup` and everything works.

--- a/apps/ta-cli/src/commands/shell_tui.rs
+++ b/apps/ta-cli/src/commands/shell_tui.rs
@@ -12,7 +12,10 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
+    MouseEventKind,
+};
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
@@ -672,9 +675,10 @@ async fn run_tui(
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     stdout.execute(EnterAlternateScreen)?;
-    // Mouse capture intentionally NOT enabled — preserves native text selection
-    // (click-drag to copy). Scrolling uses PageUp/PageDown (full page) or
-    // Shift+Up/Down (1 line). Mouse wheel scrolls terminal scrollback natively.
+    // Enable mouse capture so trackpad/wheel scroll events reach the TUI.
+    // Without this, scroll events go to the terminal's main buffer and show
+    // pre-shell content. Text selection works via Shift+click-drag.
+    stdout.execute(EnableMouseCapture)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -695,6 +699,7 @@ async fn run_tui(
     // Cleanup.
     running.store(false, Ordering::Relaxed);
     disable_raw_mode()?;
+    terminal.backend_mut().execute(DisableMouseCapture)?;
     terminal.backend_mut().execute(LeaveAlternateScreen)?;
 
     // Save history.
@@ -912,6 +917,8 @@ async fn handle_terminal_event(
                             }
                             "help" | ":help" | "?" => {
                                 app.push_lines(HELP_TEXT, OutputLine::info);
+                                // Also show CLI commands for discoverability.
+                                app.push_lines(CLI_HELP_TEXT, OutputLine::info);
                                 return;
                             }
                             ":status" => {
@@ -1059,7 +1066,7 @@ async fn handle_terminal_event(
                     let page = crossterm::terminal::size()
                         .map(|(_, h)| h as usize)
                         .unwrap_or(40);
-                    app.scroll_up(page.saturating_sub(4)); // leave 4 lines overlap
+                    app.scroll_up(page.saturating_sub(4));
                 }
                 (KeyCode::PageDown, _) => {
                     let page = crossterm::terminal::size()
@@ -1073,9 +1080,11 @@ async fn handle_terminal_event(
                 _ => {}
             }
         }
-        Event::Mouse(_) => {
-            // Mouse capture not enabled — terminal handles natively.
-        }
+        Event::Mouse(mouse) => match mouse.kind {
+            MouseEventKind::ScrollUp => app.scroll_up(3),
+            MouseEventKind::ScrollDown => app.scroll_down(3),
+            _ => {} // Click/drag ignored — Shift+click-drag for text selection.
+        },
         Event::Resize(_, _) => {
             // Terminal will re-draw on next loop iteration.
         }
@@ -2601,9 +2610,11 @@ Shell commands:
   :status            Refresh the status bar
   clear              Clear the output pane
   Ctrl-L             Clear the output pane
-  PgUp / PgDn        Scroll output 10 lines
+  Scroll (trackpad)  Scroll output 3 lines per tick
+  PgUp / PgDn        Scroll output one full page
   Shift+Up / Down    Scroll output 1 line
   Shift+Home / End   Scroll to top / bottom of output
+  Shift+click-drag   Select text for copy (mouse capture is active)
   Tab                Auto-complete commands
   Ctrl-W             Toggle split pane (shell | agent side-by-side)
   Ctrl-C / exit      Exit the shell (Ctrl-C detaches when tailing)
@@ -2612,6 +2623,29 @@ Scrollback:
   Output is retained in a scrollback buffer (default: 50000 lines).
   Configure via [shell] scrollback_lines in .ta/workflow.toml (minimum: 10000).
   Status bar shows scroll position and new output indicator when scrolled up.";
+
+const CLI_HELP_TEXT: &str = "\
+CLI Commands (prefix with 'ta' or use directly):
+  goal <cmd>         Manage goal runs (start, list, status, delete, inspect, doctor, gc)
+  draft <cmd>        Review and manage draft packages (view, approve, deny, apply, list)
+  run <title>        Run an agent in a TA-mediated staging workspace
+  dev                Interactive developer loop
+  plan <cmd>         View and track the development plan (list, status, add)
+  status             Project-wide dashboard: agents, drafts, next phase
+  build              Build the project using the configured adapter
+  doctor             System-wide health check
+  daemon <cmd>       Manage daemon lifecycle (start, stop, restart, status, log)
+  plugin <cmd>       Manage channel plugins (list, install, validate)
+  workflow <cmd>     Manage multi-stage workflows
+  gc                 Unified garbage collection
+  context <cmd>      Manage persistent context memory
+  audit <cmd>        Inspect the audit trail
+  release <cmd>      Run the configurable release pipeline
+  setup              Interactive setup wizard
+  verify             Pre-draft verification checks
+  config <cmd>       Inspect and validate configuration
+
+Run 'ta <command> --help' for details on any command.";
 
 #[cfg(test)]
 mod tests {

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -2908,14 +2908,15 @@ Built-in shell commands:
 
 | Command | Description |
 |---------|-------------|
-| `help` / `?` | Show help |
+| `help` / `?` | Show shell help and CLI command summary |
 | `:tail [id] [--lines N]` | Attach to goal output stream (`--lines` overrides backfill count) |
 | `:follow-up [filter]` | List follow-up candidates (failed goals, denied drafts); filter by keyword |
 | `:status` | Refresh the status bar |
 | `clear` / `Ctrl-L` | Clear the output pane |
 | `Shift+Up` / `Shift+Down` | Scroll output 1 line |
-| `PgUp` / `PgDn` | Scroll output 10 lines |
+| `PgUp` / `PgDn` | Scroll output one full page (with 4-line overlap) |
 | Mouse wheel / touchpad scroll | Scroll output 3 lines per tick |
+| `Shift+click-drag` | Select text for copy (mouse capture is active) |
 | `Shift+Home` / `Shift+End` | Scroll to top/bottom of output |
 | `Tab` | Auto-complete commands |
 | `Ctrl-W` | Toggle split-pane mode (agent output on the right) |

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
-  "committed": "0.11.3-alpha",
-  "deployed": "0.11.3-alpha",
+  "committed": "0.11.3-alpha.1",
+  "deployed": "0.11.3-alpha.1",
   "committed_at": "2026-03-15",
   "deployed_at": "2026-03-15",
-  "deployed_tag": "v0.11.3-alpha"
+  "deployed_tag": "v0.11.3.1-alpha"
 }


### PR DESCRIPTION
## Summary
- Enable mouse capture so trackpad/wheel scroll works in ta shell TUI (3 lines per tick)
- PageUp/PageDown scroll a full page instead of 10 lines
- Text selection: Shift+click-drag (standard behavior with mouse capture)
- `help` command now shows both shell help AND a summary of all CLI commands
- Version bump to 0.11.3-alpha.1

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (481 tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Run `ta shell` → two-finger scroll on trackpad → verify output scrolls
- [ ] Run `ta shell` → type `help` → verify CLI commands listed
- [ ] Run `ta shell` → Shift+click-drag → verify text selection works
- [ ] Run `ta shell` → PageUp → verify full page scroll with overlap