### PR TITLE
Fix .git/ leaking into staging overlay diffs

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -4028,9 +4028,7 @@ The output pipeline is: user types command → `send_input()` POST to daemon `/a
 
 #### Critical Bug Fix — `.git/` in Overlay Diff
 
-1. [ ] **Merge adapter excludes into overlay**: In `goal.rs`, after selecting the VCS adapter, call `adapter.exclude_patterns()` and merge the result into `ExcludePatterns` before calling `OverlayWorkspace::create()`. For the Git adapter this adds `".git/"`, preventing staging from capturing VCS metadata. Without this, `ta draft apply --git-commit` can overwrite `.git/HEAD`, `.git/index`, and delete local branches by restoring staging's git state.
-   - `goal.rs:490`: `let mut excludes = ExcludePatterns::load(&source_dir); excludes.merge(&adapter.exclude_patterns());`
-   - Add test: create overlay on a git repo, run a git op in staging, confirm `.git/**` not in `diff_all()`.
+1. [x] **Merge adapter excludes into overlay**: `load_excludes_with_adapter()` helper in `draft.rs` merges `adapter.exclude_patterns()` (e.g. `".git/"` for Git) into `ExcludePatterns` before creating/opening the overlay. Applied in `goal.rs` (create), `draft.rs` build (open), `draft.rs` apply (open), and snapshot rebase. Regression test added to `ta-workspace`: verifies `.git/` is not copied into staging and does not appear in `diff_all()` even if created in staging.
 
 #### Goal Progress & Tail UX
 

--- a/apps/ta-cli/src/commands/draft.rs
+++ b/apps/ta-cli/src/commands/draft.rs
@@ -29,6 +29,20 @@ use ta_workspace::{
 };
 use uuid::Uuid;
 
+/// Load exclude patterns for a source directory, merging VCS adapter patterns
+/// (e.g. ".git/" for Git) so that VCS metadata never appears in staging diffs.
+///
+/// Without merging adapter patterns, ta draft apply --git-commit can overwrite
+/// .git/HEAD and .git/index from the staging copy, resetting HEAD to main.
+pub fn load_excludes_with_adapter(source_dir: &std::path::Path) -> ExcludePatterns {
+    let mut excludes = ExcludePatterns::load(source_dir);
+    let wf_path = source_dir.join(".ta/workflow.toml");
+    let wf_config = ta_submit::WorkflowConfig::load_or_default(&wf_path);
+    let adapter = ta_submit::select_adapter(source_dir, &wf_config.submit);
+    excludes.merge(&adapter.exclude_patterns());
+    excludes
+}
+
 #[derive(Subcommand)]
 pub enum DraftCommands {
     /// Build a draft package from overlay workspace diffs.
@@ -759,8 +773,8 @@ pub(crate) fn build_package(
         .ok_or_else(|| anyhow::anyhow!("Goal has no source_dir (not an overlay-based goal)"))?;
 
     // Open the overlay workspace and compute diffs.
-    // V1 TEMPORARY: Load exclude patterns for diff filtering.
-    let excludes = ExcludePatterns::load(source_dir);
+    // V1 TEMPORARY: Load exclude patterns, merging VCS adapter patterns.
+    let excludes = load_excludes_with_adapter(source_dir);
     let overlay =
         OverlayWorkspace::open(goal_id.clone(), source_dir, &goal.workspace_path, excludes);
     let changes = overlay.diff_all().map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -2097,8 +2111,8 @@ fn apply_package(
     let applied_files: Vec<String> = if let Some(ref source_dir) = goal.source_dir {
         // Overlay-based goal: diff staging vs source, copy changed files.
         eprintln!("[apply] Opening overlay workspace...");
-        // V1 TEMPORARY: Load exclude patterns for diff filtering.
-        let excludes = ExcludePatterns::load(source_dir);
+        // V1 TEMPORARY: Load exclude patterns, merging VCS adapter patterns.
+        let excludes = load_excludes_with_adapter(source_dir);
         let mut overlay = OverlayWorkspace::open(
             goal.goal_run_id.to_string(),
             source_dir,
@@ -2129,7 +2143,7 @@ fn apply_package(
                 if has_source_changes && workflow_config.follow_up.rebase_on_apply {
                     // Rebase: re-snapshot the current source state so apply compares
                     // staging against the updated source (e.g., after a prior draft was applied).
-                    let excludes = ExcludePatterns::load(source_dir);
+                    let excludes = load_excludes_with_adapter(source_dir);
                     if let Ok(fresh_snapshot) =
                         ta_workspace::SourceSnapshot::capture(&target_dir, |p| {
                             excludes.should_exclude(p)

--- a/apps/ta-cli/src/commands/goal.rs
+++ b/apps/ta-cli/src/commands/goal.rs
@@ -8,7 +8,7 @@ use ta_mcp_gateway::GatewayConfig;
 use ta_policy::constitution::{
     AccessConstitution, ConstitutionEntry, ConstitutionStore, EnforcementMode,
 };
-use ta_workspace::{ExcludePatterns, OverlayWorkspace};
+use ta_workspace::OverlayWorkspace;
 use uuid::Uuid;
 
 /// Resolve a draft ID prefix to the goal that produced it.
@@ -486,8 +486,10 @@ fn start_goal(
         goal.parent_goal_id = parent_goal_id;
         let goal_id = goal.goal_run_id.to_string();
 
-        // V1 TEMPORARY: Load exclude patterns from .taignore or defaults.
-        let excludes = ExcludePatterns::load(&source_dir);
+        // V1 TEMPORARY: Load exclude patterns, merging VCS adapter patterns
+        // (e.g. ".git/" for Git) so VCS metadata is never captured in staging
+        // diffs or overwritten on apply.
+        let excludes = super::draft::load_excludes_with_adapter(&source_dir);
         let overlay =
             OverlayWorkspace::create(&goal_id, &source_dir, &config.staging_dir, excludes)?;
 

--- a/crates/ta-workspace/src/overlay.rs
+++ b/crates/ta-workspace/src/overlay.rs
@@ -1371,4 +1371,78 @@ mod tests {
             other => panic!("expected Modified, got {:?}", other),
         }
     }
+
+    #[test]
+    fn git_dir_excluded_from_copy_and_diff_when_merged() {
+        // Regression test: ta draft apply --git-commit was overwriting .git/HEAD
+        // and .git/index because goal.rs didn't merge adapter.exclude_patterns().
+        // Verify that when ".git/" is in ExcludePatterns, the overlay neither
+        // copies .git/ into staging nor includes it in diff_all().
+        let source = create_source_project();
+
+        // Simulate a .git directory in the source (like a real git repo).
+        fs::create_dir_all(source.path().join(".git/refs/heads")).unwrap();
+        fs::write(source.path().join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
+        fs::write(source.path().join(".git/index"), "binary git index").unwrap();
+
+        // Use ExcludePatterns with ".git/" merged in (simulates the fix in goal.rs).
+        let mut excludes = ExcludePatterns::none();
+        excludes.merge(&[".git/".to_string()]);
+
+        let staging_root = TempDir::new().unwrap();
+        let overlay = OverlayWorkspace::create(
+            "goal-git-exclude",
+            source.path(),
+            staging_root.path(),
+            excludes,
+        )
+        .unwrap();
+
+        // .git/ must NOT be copied into staging.
+        assert!(
+            !overlay.staging_dir().join(".git").exists(),
+            ".git/ should not be copied into staging"
+        );
+
+        // Even if something creates .git/ in staging (e.g. git init), diff should skip it.
+        fs::create_dir_all(overlay.staging_dir().join(".git/refs")).unwrap();
+        fs::write(
+            overlay.staging_dir().join(".git/HEAD"),
+            "ref: refs/heads/feature\n",
+        )
+        .unwrap();
+
+        // Make a real change too.
+        fs::write(
+            overlay.staging_dir().join("src/main.rs"),
+            "fn main() { println!(\"changed\"); }\n",
+        )
+        .unwrap();
+
+        let changes = overlay.diff_all().unwrap();
+
+        // Should see ONLY the main.rs change — .git/ must not appear.
+        let git_changes: Vec<_> = changes
+            .iter()
+            .filter(|c| {
+                let p = match c {
+                    OverlayChange::Modified { path, .. } => path,
+                    OverlayChange::Created { path, .. } => path,
+                    OverlayChange::Deleted { path } => path,
+                };
+                p.starts_with(".git")
+            })
+            .collect();
+        assert!(
+            git_changes.is_empty(),
+            ".git/ changes must not appear in diff: {:?}",
+            git_changes
+        );
+        assert_eq!(
+            changes.len(),
+            1,
+            "expected only src/main.rs change, got: {:?}",
+            changes
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes critical bug where `ta draft apply --git-commit` overwrote `.git/HEAD`, `.git/index`, and deleted local branches by copying staging's git state back to the real repo
- Root cause: `goal.rs` and `draft.rs` called `ExcludePatterns::load()` (build artifacts only) but never merged `adapter.exclude_patterns()` which returns `[".git/"]` for the Git adapter
- Adds `load_excludes_with_adapter()` helper that selects the VCS adapter from `.ta/workflow.toml` (or auto-detects) and merges its exclude patterns before creating/opening overlays
- Applied at all 4 call sites: `goal.rs` (overlay create), `draft.rs` build (overlay open), `draft.rs` apply (overlay open), snapshot rebase
- Regression test in `ta-workspace` verifies `.git/` is excluded from staging copy and from `diff_all()` output
- Updates PLAN.md marking v0.11.5 item 1 done

## Test plan
- [x] `cargo test --workspace` passes (including new regression test)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] Manual: run `ta goal start`, agent does git ops in staging, `ta draft build` — no `.git/**` in draft artifacts

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)