### PR TITLE
Fix §4 scanner false positive and add --files filter to draft view

### DIFF
--- a/apps/ta-cli/src/commands/draft.rs
+++ b/apps/ta-cli/src/commands/draft.rs
@@ -93,6 +93,10 @@ pub enum DraftCommands {
         /// in the external application instead of showing the diff inline.
         #[arg(long)]
         file: Option<String>,
+        /// Filter to one or more files (paths relative to workspace root, comma-separated or repeated).
+        /// Example: --files config.rs,role.rs  or  --files config.rs --files role.rs
+        #[arg(long, value_delimiter = ',', num_args = 1..)]
+        files: Vec<String>,
         /// Open file in external handler.
         /// If not specified, uses workflow.toml [diff] open_external setting (default: true).
         /// Use --no-open-external to force inline diff display even if handler exists.
@@ -395,6 +399,7 @@ pub fn execute(cmd: &DraftCommands, config: &GatewayConfig) -> anyhow::Result<()
             id,
             summary,
             file,
+            files,
             open_external,
             detail,
             format,
@@ -405,11 +410,18 @@ pub fn execute(cmd: &DraftCommands, config: &GatewayConfig) -> anyhow::Result<()
             if *json {
                 view_package_json(config, &resolved)
             } else {
+                // Merge --file (single, legacy) and --files (multi) into one list.
+                let mut combined_filters: Vec<String> = files.clone();
+                if let Some(f) = file {
+                    if !combined_filters.contains(f) {
+                        combined_filters.push(f.clone());
+                    }
+                }
                 view_package(
                     config,
                     &resolved,
                     *summary,
-                    file.as_deref(),
+                    combined_filters,
                     open_external,
                     detail,
                     format,
@@ -1568,7 +1580,7 @@ fn view_package(
     config: &GatewayConfig,
     id: &str,
     summary_only: bool,
-    file_filter: Option<&str>,
+    file_filters: Vec<String>,
     open_external: &Option<bool>,
     detail_str: &str,
     format_str: &str,
@@ -1586,9 +1598,10 @@ fn view_package(
         .map_err(|e| anyhow::anyhow!(e))?;
 
     // v0.2.3: Use output adapters for rendering.
-    // Exception: If --file with --open-external, try external handler first.
-    if let Some(filter) = file_filter {
+    // Exception: If a single --file with --open-external, try external handler first.
+    if file_filters.len() == 1 {
         if let Some(true) = open_external {
+            let filter = &file_filters[0];
             // Try external handler path (legacy v0.2.2 behavior).
             if let Ok(goal_store) = GoalRunStore::new(&config.goals_dir) {
                 if let Ok(goals) = goal_store.list() {
@@ -1651,7 +1664,7 @@ fn view_package(
     let ctx = RenderContext {
         package: &pkg,
         detail_level: effective_detail,
-        file_filter: file_filter.map(String::from),
+        file_filters,
         diff_provider: diff_provider.as_ref().map(|p| p as &dyn DiffProvider),
     };
 
@@ -1951,7 +1964,7 @@ fn build_commit_message(goal: &ta_goal::GoalRun, pkg: &DraftPackage) -> String {
     let ctx = RenderContext {
         package: pkg,
         detail_level: DetailLevel::Medium,
-        file_filter: None,
+        file_filters: vec![],
         diff_provider: None,
     };
     let adapter = get_adapter(OutputFormat::Terminal, false);
@@ -4577,14 +4590,19 @@ fn count_call_sites(content: &str, prefix: &str) -> usize {
             let prev = content.as_bytes()[abs - 1];
             !prev.is_ascii_alphanumeric() && prev != b'_'
         };
-        // Must be followed by `<ident_char>(` — i.e., this is a call expression.
+        // Must be followed by `<ident_chars>(` — i.e., this is a call expression.
+        // We consume all identifier chars and verify the very next char is `(`,
+        // preventing false positives from field names like `inject_memory: bool`.
         let rest = &content[abs + prefix.len()..];
+        let ident_end = rest
+            .find(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+            .unwrap_or(rest.len());
         let followed_by_call = rest
             .chars()
             .next()
             .map(|c| c.is_ascii_alphanumeric() || c == '_')
             .unwrap_or(false)
-            && rest.contains('(');
+            && rest[ident_end..].starts_with('(');
         if preceded_ok && followed_by_call {
             count += 1;
         }
@@ -4635,6 +4653,26 @@ fn setup() {
         assert_eq!(count_call_sites(content, "inject_"), 0);
         // 'restore_value' is not a call (no '(' following ident)
         assert_eq!(count_call_sites(content, "restore_"), 0);
+    }
+
+    #[test]
+    fn count_call_sites_no_false_positive_for_field_names() {
+        // Struct field `inject_memory: bool` must NOT be counted as an inject call.
+        // This was the root cause of the §4 false positive in config.rs (v0.11.7 draft).
+        // The old check used `rest.contains('(')` which matched any `(` later in the file.
+        let content = r#"
+pub struct AgentConfig {
+    pub inject_memory: bool,
+    pub inject_memory_depth: usize,
+}
+impl AgentConfig {
+    fn apply(&self) {
+        some_fn(self.inject_memory);
+    }
+}
+"#;
+        // Field declarations: not calls — no `(` immediately after the identifier.
+        assert_eq!(count_call_sites(content, "inject_"), 0);
     }
 
     #[test]

--- a/apps/ta-cli/src/commands/pr.rs
+++ b/apps/ta-cli/src/commands/pr.rs
@@ -152,6 +152,7 @@ fn to_draft_command(cmd: &PrCommands) -> draft::DraftCommands {
             id: Some(id.clone()),
             summary: *summary,
             file: file.clone(),
+            files: vec![],
             open_external: *open_external,
             detail: detail.clone(),
             format: format.clone(),

--- a/crates/ta-changeset/src/output_adapters/html.rs
+++ b/crates/ta-changeset/src/output_adapters/html.rs
@@ -110,11 +110,15 @@ impl OutputAdapter for HtmlAdapter {
             pkg.changes.artifacts.len()
         ));
 
-        let artifacts: Vec<&Artifact> = if let Some(filter) = &ctx.file_filter {
+        let artifacts: Vec<&Artifact> = if !ctx.file_filters.is_empty() {
             pkg.changes
                 .artifacts
                 .iter()
-                .filter(|a| a.resource_uri.contains(filter))
+                .filter(|a| {
+                    ctx.file_filters
+                        .iter()
+                        .any(|f| a.resource_uri.contains(f.as_str()))
+                })
                 .collect()
         } else {
             pkg.changes.artifacts.iter().collect()
@@ -313,7 +317,7 @@ mod tests {
         let ctx = RenderContext {
             package: &pkg,
             detail_level: DetailLevel::Top,
-            file_filter: None,
+            file_filters: vec![],
             diff_provider: None,
         };
         let html = adapter.render(&ctx).unwrap();

--- a/crates/ta-changeset/src/output_adapters/json.rs
+++ b/crates/ta-changeset/src/output_adapters/json.rs
@@ -15,7 +15,7 @@ impl JsonAdapter {
 impl OutputAdapter for JsonAdapter {
     fn render(&self, ctx: &RenderContext) -> Result<String, ChangeSetError> {
         // For JSON output, we serialize the entire PRPackage
-        // The detail_level and file_filter are ignored — the consumer can filter client-side
+        // The detail_level and file_filters are ignored — the consumer can filter client-side
 
         let json = serde_json::to_string_pretty(ctx.package).map_err(|e| {
             ChangeSetError::InvalidData(format!("JSON serialization failed: {}", e))
@@ -115,7 +115,7 @@ mod tests {
         let ctx = RenderContext {
             package: &package,
             detail_level: DetailLevel::Full,
-            file_filter: None,
+            file_filters: vec![],
             diff_provider: None,
         };
 

--- a/crates/ta-changeset/src/output_adapters/markdown.rs
+++ b/crates/ta-changeset/src/output_adapters/markdown.rs
@@ -51,11 +51,15 @@ impl OutputAdapter for MarkdownAdapter {
             pkg.changes.artifacts.len()
         ));
 
-        let artifacts: Vec<&Artifact> = if let Some(filter) = &ctx.file_filter {
+        let artifacts: Vec<&Artifact> = if !ctx.file_filters.is_empty() {
             pkg.changes
                 .artifacts
                 .iter()
-                .filter(|a| a.resource_uri.contains(filter))
+                .filter(|a| {
+                    ctx.file_filters
+                        .iter()
+                        .any(|f| a.resource_uri.contains(f.as_str()))
+                })
                 .collect()
         } else {
             pkg.changes.artifacts.iter().collect()

--- a/crates/ta-changeset/src/output_adapters/mod.rs
+++ b/crates/ta-changeset/src/output_adapters/mod.rs
@@ -92,8 +92,9 @@ impl std::fmt::Display for DetailLevel {
 pub struct RenderContext<'a> {
     pub package: &'a DraftPackage,
     pub detail_level: DetailLevel,
-    /// Optional: Filter to a specific file (show only one artifact).
-    pub file_filter: Option<String>,
+    /// Optional: Filter artifacts to one or more files (matched by substring against resource_uri).
+    /// Empty vec means no filter (show all). Replaces the old single-value `file_filter`.
+    pub file_filters: Vec<String>,
     /// Optional: Diff content provider (for fetching full diffs).
     pub diff_provider: Option<&'a dyn DiffProvider>,
 }

--- a/crates/ta-changeset/src/output_adapters/terminal.rs
+++ b/crates/ta-changeset/src/output_adapters/terminal.rs
@@ -365,19 +365,23 @@ impl OutputAdapter for TerminalAdapter {
 
         // Filter artifacts
         let artifacts = &ctx.package.changes.artifacts;
-        let filtered_artifacts: Vec<&Artifact> = if let Some(filter) = &ctx.file_filter {
+        let filtered_artifacts: Vec<&Artifact> = if !ctx.file_filters.is_empty() {
             artifacts
                 .iter()
-                .filter(|a| a.resource_uri.contains(filter))
+                .filter(|a| {
+                    ctx.file_filters
+                        .iter()
+                        .any(|f| a.resource_uri.contains(f.as_str()))
+                })
                 .collect()
         } else {
             artifacts.iter().collect()
         };
 
-        if let (true, Some(filter)) = (filtered_artifacts.is_empty(), &ctx.file_filter) {
+        if filtered_artifacts.is_empty() && !ctx.file_filters.is_empty() {
             return Err(ChangeSetError::InvalidData(format!(
-                "No artifacts match filter: {}",
-                filter
+                "No artifacts match filter(s): {}",
+                ctx.file_filters.join(", ")
             )));
         }
 
@@ -528,7 +532,7 @@ mod tests {
         let ctx = RenderContext {
             package: &package,
             detail_level: DetailLevel::Top,
-            file_filter: None,
+            file_filters: vec![],
             diff_provider: None,
         };
 
@@ -549,7 +553,7 @@ mod tests {
         let ctx = RenderContext {
             package: &package,
             detail_level: DetailLevel::Top,
-            file_filter: None,
+            file_filters: vec![],
             diff_provider: None,
         };
 
@@ -566,7 +570,7 @@ mod tests {
         let ctx = RenderContext {
             package: &package,
             detail_level: DetailLevel::Medium,
-            file_filter: None,
+            file_filters: vec![],
             diff_provider: None,
         };
 
@@ -582,7 +586,7 @@ mod tests {
         let ctx = RenderContext {
             package: &package,
             detail_level: DetailLevel::Top,
-            file_filter: Some("auth.rs".to_string()),
+            file_filters: vec!["auth.rs".to_string()],
             diff_provider: None,
         };
 
@@ -597,7 +601,7 @@ mod tests {
         let ctx = RenderContext {
             package: &package,
             detail_level: DetailLevel::Top,
-            file_filter: Some("nonexistent.rs".to_string()),
+            file_filters: vec!["nonexistent.rs".to_string()],
             diff_provider: None,
         };
 
@@ -613,7 +617,7 @@ mod tests {
         let ctx = RenderContext {
             package: &package,
             detail_level: DetailLevel::Medium,
-            file_filter: None,
+            file_filters: vec![],
             diff_provider: None,
         };
         let output = adapter.render(&ctx).unwrap();
@@ -677,7 +681,7 @@ mod tests {
         let ctx = RenderContext {
             package: &package,
             detail_level: DetailLevel::Top,
-            file_filter: None,
+            file_filters: vec![],
             diff_provider: None,
         };
         let output = adapter.render(&ctx).unwrap();
@@ -709,7 +713,7 @@ mod tests {
         let ctx = RenderContext {
             package: &package,
             detail_level: DetailLevel::Top,
-            file_filter: None,
+            file_filters: vec![],
             diff_provider: None,
         };
         let output = adapter.render(&ctx).unwrap();
@@ -737,7 +741,7 @@ mod tests {
         let ctx = RenderContext {
             package: &package,
             detail_level: DetailLevel::Top,
-            file_filter: None,
+            file_filters: vec![],
             diff_provider: None,
         };
         let output = adapter.render(&ctx).unwrap();
@@ -755,7 +759,7 @@ mod tests {
         let ctx = RenderContext {
             package: &package,
             detail_level: DetailLevel::Top,
-            file_filter: None,
+            file_filters: vec![],
             diff_provider: None,
         };
         let output = adapter.render(&ctx).unwrap();
@@ -769,7 +773,7 @@ mod tests {
         let ctx = RenderContext {
             package: &package,
             detail_level: DetailLevel::Medium,
-            file_filter: None,
+            file_filters: vec![],
             diff_provider: None,
         };
         let output = adapter.render(&ctx).unwrap();


### PR DESCRIPTION
## Summary
- **§4 scanner false positive**: `count_call_sites` was using `rest.contains('(')` which matched any `(` later in the file, so struct fields like `inject_memory: bool` were counted as injection call sites. Now consumes all identifier chars and checks that `(` appears immediately after. This was the root cause of the v0.11.7 draft (fae8c7ec) getting a spurious `config.rs: 6 inject_* call(s) but only 0 restore_* call(s)` warning.
- **`--files` filter for `ta draft view`**: Changed `RenderContext.file_filter: Option<String>` → `file_filters: Vec<String>`. All three output adapters (terminal, html, markdown) updated. New `--files` arg accepts comma-separated or repeated paths; `--file` (single) still works for backward compat. Example: `ta draft view <id> --detail full --files config.rs,role.rs`

## Test plan
- [x] `count_call_sites_no_false_positive_for_field_names` — new regression test covering `inject_memory: bool` field pattern
- [x] All 3 existing `count_call_sites` tests still pass
- [x] `file_filter_works` and `file_filter_no_match_returns_error` tests updated and passing
- [x] Full workspace test suite: 0 failures
- [x] Clippy: clean
- [x] `cargo fmt --check`: clean