### PR TITLE
Implement v0.12.7 — Shell UX: Working Indicator Clearance & Scroll Reliability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "ta-build"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3040,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3071,7 +3071,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3089,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "chrono",
  "rmcp",
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3237,7 +3237,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "ta-output-schema"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "serde",
  "serde_json",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "chrono",
  "glob",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "serde",
  "serde_json",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "chrono",
  "libc",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "chrono",
  "serde",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 dependencies = [
  "chrono",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.12.6-alpha"
+version = "0.12.7-alpha"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -90,6 +90,7 @@ External users (working on their own projects, not TA itself) need these phases 
 | **v0.12.1** | Discord Channel Polish — slash commands, rate limiting, goal progress streaming |
 | **v0.12.2** | Shell Paste-at-End UX fix |
 | **v0.12.6** | Goal lifecycle observability + Discord/Slack SSE notification reliability |
+| **v0.12.7** | Shell UX: "Agent is working" clearance on goal completion + scroll reliability |
 | ⬇ **PUBLIC BETA (v0.13.x)** | Runtime flexibility, enterprise governance, community ecosystem, goal workflow automation |
 
 ### Pre-Alpha Bugs to Fix (must resolve before external release)
@@ -4542,6 +4543,35 @@ The daemon already exposes `POST /api/goals/{id}/input` which writes directly to
 #### Completed: 2026-03-19 — 13/13 items done, 10 new tests added
 
 #### Version: `0.12.6-alpha`
+
+---
+
+### v0.12.7 — Shell UX: Working Indicator Clearance & Scroll Reliability
+<!-- status: pending -->
+**Goal**: Fix two persistent shell regressions that surfaced after v0.12.4.1:
+1. The "Agent is working..." line pushed when a goal is dispatched is not cleared when the goal completes (draft ready, failed, or any terminal state). The heartbeat lines from the tail stream are correctly replaced by `[agent exited]`, but the initial "Agent is working..." line is a non-heartbeat `CommandResponse` that `AgentOutputDone` never finds.
+2. The output pane intermittently does not stay scrolled to the bottom when new output arrives, even when the user has not scrolled up.
+
+**Root cause — working indicator**:
+`AgentOutputDone` searches for `is_heartbeat = true` lines to replace. The "Agent is working..." line is pushed via `TuiMessage::CommandResponse` → `OutputLine::command` which has `is_heartbeat = false`. It is never replaced.
+
+**Fix approach — working indicator**:
+Add `TuiMessage::WorkingIndicator(String)` variant (or change the `CommandResponse` at line 1950 to push via a new path) that calls `app.push_heartbeat()`, marking the line `is_heartbeat = true`. `AgentOutputDone` then finds and replaces it as part of its existing heartbeat replacement logic. Alternatively, extend `AgentOutputDone` to also scan for lines containing "Agent is working" by text.
+
+**Fix approach — scroll reliability**:
+Audit all `push_output`, `push_heartbeat`, and `agent_output.push` call sites to ensure `scroll_to_bottom()` or `auto_scroll_if_near_bottom()` is called consistently. Add a dedicated `push_and_scroll()` helper that combines the two. Identify the specific interaction (e.g., SSE event burst, split-pane toggle) that causes the pane to stop following.
+
+#### Items
+1. [x] **Fix working indicator clearance**: Added `TuiMessage::WorkingIndicator(String)` variant; changed "Agent is working..." emission to use it; handler calls `app.push_heartbeat()` so the line gets `is_heartbeat = true` and `AgentOutputDone` clears it on any terminal goal state. 2 new tests.
+2. [x] **Verify clearance for all terminal goal states**: `working_indicator_pushed_as_heartbeat` and `agent_output_done_clears_working_indicator` tests cover the full cycle; `AgentOutputDone` logic was already terminal-state-agnostic (searches by `is_heartbeat` flag).
+3. [x] **Fix intermittent scroll-to-bottom**: Root cause identified — heartbeat handling paths returned early without calling `auto_scroll_if_near_bottom()`. Fixed: non-split heartbeat now calls `auto_scroll_if_near_bottom()` after `push_heartbeat`; split-pane in-place update and push both reset `agent_scroll_offset` when within `AGENT_NEAR_BOTTOM_LINES`. 3 new tests.
+4. [x] **Regression test**: `scroll_stays_bottom_through_burst_of_output` — delivers 100 `AgentOutput` messages, asserts `scroll_offset` stays 0.
+5. [x] Update CLAUDE.md version to `0.12.7-alpha`
+
+#### Completed
+- 6 new tests in `apps/ta-cli/src/commands/shell_tui.rs` covering all items above.
+
+#### Version: `0.12.7-alpha`
 
 ---
 

--- a/apps/ta-cli/src/commands/shell_tui.rs
+++ b/apps/ta-cli/src/commands/shell_tui.rs
@@ -229,6 +229,8 @@ pub enum TuiMessage {
     GoalStarted { goal_id: String, title: String },
     /// Agent output stream ended (goal process exited).
     AgentOutputDone(String),
+    /// "Agent is working..." indicator — pushed as a heartbeat so AgentOutputDone clears it (v0.12.7).
+    WorkingIndicator(String),
     /// A draft is ready for review (v0.10.11).
     DraftReady {
         #[allow(dead_code)]
@@ -1947,7 +1949,9 @@ async fn handle_terminal_event(
                                     if let Some(request_id) = output.strip_prefix("__streaming__:")
                                     {
                                         let request_id = request_id.trim().to_string();
-                                        let _ = tx.send(TuiMessage::CommandResponse(
+                                        // Use WorkingIndicator so AgentOutputDone can clear it
+                                        // (it's pushed as a heartbeat line — v0.12.7 item 1).
+                                        let _ = tx.send(TuiMessage::WorkingIndicator(
                                             "Agent is working...".to_string(),
                                         ));
                                         // Subscribe to the agent output stream.
@@ -2103,6 +2107,14 @@ fn handle_tui_message(app: &mut App, msg: TuiMessage) {
             }
             app.push_lines(&text, OutputLine::command);
         }
+        TuiMessage::WorkingIndicator(text) => {
+            // Push "Agent is working..." as a heartbeat-flagged line so that
+            // AgentOutputDone can find and replace it on any terminal goal state
+            // (v0.12.7 item 1). Using push_heartbeat ensures at most one such
+            // indicator is visible at a time.
+            app.push_heartbeat(text);
+            app.scroll_to_bottom();
+        }
         TuiMessage::DaemonDown => {
             if app.daemon_connected {
                 app.daemon_connected = false;
@@ -2214,6 +2226,8 @@ fn handle_tui_message(app: &mut App, msg: TuiMessage) {
 
             // Heartbeat coalescing: detect [heartbeat] lines and update in-place
             // instead of appending (v0.11.4.1 items 9-10).
+            // Auto-scroll after heartbeat so a user pinned near the bottom stays
+            // at the bottom even when only the heartbeat ticker changes (v0.12.7 item 3).
             if line.line.starts_with("[heartbeat]") {
                 let heartbeat_text = line.line.clone();
                 if app.split_pane {
@@ -2221,12 +2235,24 @@ fn handle_tui_message(app: &mut App, msg: TuiMessage) {
                     if let Some(last) = app.agent_output.last_mut() {
                         if last.is_heartbeat {
                             last.text = heartbeat_text;
+                            // Still auto-scroll agent pane when near bottom (v0.12.7 item 3).
+                            const AGENT_NEAR_BOTTOM_LINES: usize = 5;
+                            if app.agent_scroll_offset <= AGENT_NEAR_BOTTOM_LINES {
+                                app.agent_scroll_offset = 0;
+                            }
                             return;
                         }
                     }
                     app.agent_output.push(OutputLine::heartbeat(heartbeat_text));
+                    // Auto-scroll agent pane when near bottom.
+                    const AGENT_NEAR_BOTTOM_LINES: usize = 5;
+                    if app.agent_scroll_offset <= AGENT_NEAR_BOTTOM_LINES {
+                        app.agent_scroll_offset = 0;
+                    }
                 } else {
                     app.push_heartbeat(heartbeat_text);
+                    // Auto-scroll main pane when near bottom (v0.12.7 item 3).
+                    app.auto_scroll_if_near_bottom();
                 }
                 return;
             }
@@ -6395,6 +6421,170 @@ mod tests {
         // agent_scroll_offset should remain 0 (pinned to bottom).
         assert_eq!(app.agent_scroll_offset, 0);
         assert!(!app.agent_output.is_empty());
+    }
+
+    // ── v0.12.7 working indicator & scroll reliability tests ─────────────────
+
+    #[test]
+    fn working_indicator_pushed_as_heartbeat() {
+        // Item 1: WorkingIndicator must push a heartbeat-flagged line so
+        // AgentOutputDone can find and replace it.
+        let mut app = App::new(
+            "http://localhost".into(),
+            None,
+            std::path::PathBuf::from("/tmp"),
+        );
+        handle_tui_message(
+            &mut app,
+            TuiMessage::WorkingIndicator("Agent is working...".into()),
+        );
+        let last = app.output.last().expect("should have output");
+        assert!(
+            last.is_heartbeat,
+            "WorkingIndicator must be a heartbeat line"
+        );
+        assert!(last.text.contains("Agent is working"));
+    }
+
+    #[test]
+    fn agent_output_done_clears_working_indicator() {
+        // Item 1: AgentOutputDone must clear the working indicator pushed by
+        // WorkingIndicator (which is a heartbeat-flagged line).
+        let mut app = App::new(
+            "http://localhost".into(),
+            None,
+            std::path::PathBuf::from("/tmp"),
+        );
+        app.tailing_goal = Some("goal-wi".into());
+        handle_tui_message(
+            &mut app,
+            TuiMessage::WorkingIndicator("Agent is working...".into()),
+        );
+        // Confirm it's there as a heartbeat.
+        assert!(app.output.iter().any(|l| l.is_heartbeat));
+
+        // Now simulate goal completion.
+        handle_tui_message(&mut app, TuiMessage::AgentOutputDone("goal-wi".into()));
+
+        // No heartbeat lines should remain.
+        let remaining: Vec<_> = app.output.iter().filter(|l| l.is_heartbeat).collect();
+        assert!(
+            remaining.is_empty(),
+            "AgentOutputDone must clear the working indicator heartbeat"
+        );
+        assert!(app.output.iter().any(|l| l.text.contains("agent exited")));
+    }
+
+    #[test]
+    fn heartbeat_auto_scrolls_main_pane_near_bottom() {
+        // Item 3: heartbeat lines in main pane must auto-scroll when scroll_offset
+        // is within NEAR_BOTTOM_LINES (intermittent scroll regression fix).
+        let mut app = App::new(
+            "http://localhost".into(),
+            None,
+            std::path::PathBuf::from("/tmp"),
+        );
+        // Simulate user near-bottom (3 lines up — within NEAR_BOTTOM_LINES=5).
+        app.scroll_offset = 3;
+
+        handle_tui_message(
+            &mut app,
+            TuiMessage::AgentOutput(AgentOutputLine {
+                stream: "stdout".into(),
+                line: "[heartbeat] still running... 5s elapsed".into(),
+                goal_id: None,
+            }),
+        );
+
+        // Should have snapped back to bottom.
+        assert_eq!(
+            app.scroll_offset, 0,
+            "near-bottom scroll_offset must be reset to 0 after heartbeat"
+        );
+    }
+
+    #[test]
+    fn heartbeat_preserves_scroll_when_far_up_main_pane() {
+        // Item 3: if user has scrolled far up, heartbeat must NOT auto-scroll.
+        let mut app = App::new(
+            "http://localhost".into(),
+            None,
+            std::path::PathBuf::from("/tmp"),
+        );
+        app.scroll_offset = 50;
+
+        handle_tui_message(
+            &mut app,
+            TuiMessage::AgentOutput(AgentOutputLine {
+                stream: "stdout".into(),
+                line: "[heartbeat] still running... 5s elapsed".into(),
+                goal_id: None,
+            }),
+        );
+
+        assert_eq!(
+            app.scroll_offset, 50,
+            "far-up scroll must not be reset by heartbeat"
+        );
+    }
+
+    #[test]
+    fn heartbeat_auto_scrolls_agent_pane_near_bottom() {
+        // Item 3: heartbeat in split-pane agent pane must auto-scroll when
+        // agent_scroll_offset is within AGENT_NEAR_BOTTOM_LINES.
+        let mut app = App::new(
+            "http://localhost".into(),
+            None,
+            std::path::PathBuf::from("/tmp"),
+        );
+        app.split_pane = true;
+        // Simulate user near-bottom in agent pane (3 lines up).
+        app.agent_scroll_offset = 3;
+        // First push a heartbeat line so the in-place update path is exercised.
+        app.agent_output
+            .push(OutputLine::heartbeat("[heartbeat] running".into()));
+
+        handle_tui_message(
+            &mut app,
+            TuiMessage::AgentOutput(AgentOutputLine {
+                stream: "stdout".into(),
+                line: "[heartbeat] still running... 10s elapsed".into(),
+                goal_id: None,
+            }),
+        );
+
+        assert_eq!(
+            app.agent_scroll_offset, 0,
+            "near-bottom agent_scroll_offset must be reset to 0 after heartbeat"
+        );
+    }
+
+    #[test]
+    fn scroll_stays_bottom_through_burst_of_output() {
+        // Item 4: verify scroll stays at 0 through a burst of 100 output lines
+        // with no user scroll interaction.
+        let mut app = App::new(
+            "http://localhost".into(),
+            None,
+            std::path::PathBuf::from("/tmp"),
+        );
+        assert_eq!(app.scroll_offset, 0);
+
+        for i in 0..100 {
+            handle_tui_message(
+                &mut app,
+                TuiMessage::AgentOutput(AgentOutputLine {
+                    stream: "stdout".into(),
+                    line: format!("output line {}", i),
+                    goal_id: None,
+                }),
+            );
+        }
+
+        assert_eq!(
+            app.scroll_offset, 0,
+            "scroll_offset must stay at 0 through a burst of 100 output lines"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix \"Agent is working...\" indicator not clearing on goal completion: changed from `CommandResponse` (non-heartbeat) to `WorkingIndicator` (heartbeat-flagged), so `AgentOutputDone` can find and replace it for any terminal goal state
- Fix intermittent scroll-not-following: add `auto_scroll_if_near_bottom()` after heartbeat handling; add agent pane auto-scroll in both split and non-split heartbeat paths
- Add 6 new unit tests covering the working indicator and scroll reliability behaviors
- Bump workspace version to `0.12.7-alpha`

## Test plan
- [ ] All workspace tests pass (0 failures)
- [ ] Clippy clean (0 warnings/errors)
- [ ] fmt check passes
- [ ] `ta run <goal>` in TUI: "Agent is working..." clears when goal reaches pr_ready, completed, or error state
- [ ] Scroll stays at bottom during output bursts when view is near bottom

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)