### PR TITLE
fix: release pipeline skips already-approved drafts in find_latest_draft fallback

### DIFF
--- a/apps/ta-cli/src/commands/release.rs
+++ b/apps/ta-cli/src/commands/release.rs
@@ -661,11 +661,14 @@ fn find_latest_draft(config: &GatewayConfig) -> anyhow::Result<Option<uuid::Uuid
             if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
                 if let Ok(id) = uuid::Uuid::parse_str(stem) {
                     // Only consider drafts that can still be approved.
+                    // "approved" is excluded too — already-approved drafts
+                    // would fail re-approval with "Cannot approve in Approved state".
                     if let Ok(contents) = std::fs::read_to_string(&path) {
                         let dominated_by_terminal = contents.contains("\"applied\"")
                             || contents.contains("\"denied\"")
                             || contents.contains("\"superseded\"")
-                            || contents.contains("\"closed\"");
+                            || contents.contains("\"closed\"")
+                            || contents.contains("\"approved\"");
                         if dominated_by_terminal {
                             continue;
                         }


### PR DESCRIPTION
## Summary
- `find_latest_draft` fallback in `execute_agent_step` filtered terminal states (`applied/denied/superseded/closed`) but not `approved`
- An already-approved draft (e.g., the v0.12.8 implementation draft approved via web UI) was being picked up and re-approved, causing: `Cannot approve package in Approved state (must be PendingReview)`
- Fix: add `"approved"` to the non-eligible filter — fallback only returns `Draft` or `PendingReview` drafts

## Test plan
- [ ] All tests pass
- [ ] Re-run `ta release run 0.12.8-alpha` — no longer trips on the already-approved v0.12.8 draft

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)