### PR TITLE
Fix release pipeline error messages — show goal title and call to action

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -5375,11 +5375,12 @@ These are addressed across v0.14.4–v0.14.5.
 
 #### Items
 
-1. [ ] **Attestation backend trait**: `AttestationBackend` with `sign(payload) → attestation`, `verify(payload, attestation) → bool`. Backends: TPM 2.0 (Linux/Windows), Apple Secure Enclave (macOS), software fallback (Ed25519 key in `.ta/keys/`).
-2. [ ] **TPM 2.0 integration**: Use `tss2-rs` or `tpm2-tools` to obtain PCR quote and sign audit entries on Linux/Windows.
-3. [ ] **Apple Secure Enclave integration**: macOS Keychain + CryptoKit `SecureEnclave.P256` to sign audit entries.
-4. [ ] **Attestation fields in AuditEntry**: `attestation: Option<AttestationRecord>` with backend, public key fingerprint, and signature.
-5. [ ] **`ta audit verify-attestation <id>`**: Verify the hardware signature on an audit entry. Useful for compliance review and post-incident investigation.
+1. [ ] **`AttestationBackend` trait**: `sign(payload) → attestation`, `verify(payload, attestation) → bool`. Plugin registry loads backends from `~/.config/ta/plugins/attestation/`.
+2. [ ] **Software fallback backend**: Ed25519 key in `.ta/keys/` — ships in TA, works on any machine without hardware TPM.
+3. [ ] **TPM 2.0 backend plugin**: `tss2-rs` / `tpm2-tools` PCR quote and signing. Linux/Windows.
+4. [ ] **Apple Secure Enclave backend plugin**: macOS Keychain + CryptoKit `SecureEnclave.P256`.
+5. [ ] **Attestation fields in `AuditEntry`**: `attestation: Option<AttestationRecord>` with backend name, public key fingerprint, and signature.
+6. [ ] **`ta audit verify-attestation <id>`**: Verify the attestation signature on an audit entry using the stored public key.
 
 #### Version: `0.14.1-alpha`
 
@@ -5540,6 +5541,13 @@ If the decision is to keep TUI, the original v0.13.6 items (survey Rust TUI apps
 
 > These are NOT part of TA core. They are independent projects that consume TA's extension points.
 > See `docs/ADR-product-concept-model.md` for how they integrate.
+
+### SecureTA *(future separate project)*
+> Planned enterprise security layer built on TA's extension points.
+
+Adds OCI/gVisor container isolation, hardware-bound audit trail signing (TPM 2.0, Apple Secure Enclave), and kernel-level network policy — for regulated deployments and environments running untrusted agent code. Depends on TA v0.13.3 (RuntimeAdapter) and v0.14.1 (AttestationBackend). Not yet started.
+
+---
 
 ### TA Web UI *(separate project)*
 > Lightweight web frontend for non-engineers to use TA without the CLI.

--- a/apps/ta-cli/src/commands/draft.rs
+++ b/apps/ta-cli/src/commands/draft.rs
@@ -2837,11 +2837,20 @@ fn apply_package(
     // This ensures the apply is atomic — either everything succeeds or we
     // fail fast without leaving files in a half-applied state.
     if !goal.state.can_transition_to(&GoalRunState::Applied) {
+        let short_id = &goal.goal_run_id.to_string()[..8];
         anyhow::bail!(
-            "Cannot apply: goal {} is in state '{}', which cannot transition to 'applied'.\n\
-             Valid source states: pr_ready, under_review, approved.",
-            &goal.goal_run_id.to_string()[..8],
-            goal.state
+            "Cannot apply draft — the agent task \"{title}\" ({short_id}) did not complete successfully.\n\
+             \n\
+             The task is in state '{state}', but applying a draft requires the task to be in\n\
+             'pr_ready', 'under_review', or 'approved'.\n\
+             \n\
+             What to do:\n\
+             1. Check what went wrong:  ta goal status {short_id}\n\
+             2. Clean up the failed task: ta goal delete {short_id}\n\
+             3. Re-run from the beginning (e.g. ta release run <version>)",
+            title = goal.title,
+            short_id = short_id,
+            state = goal.state,
         );
     }
 

--- a/apps/ta-cli/src/commands/release.rs
+++ b/apps/ta-cli/src/commands/release.rs
@@ -600,9 +600,13 @@ fn execute_agent_step(
             .status()?;
         if !approve_status.success() {
             anyhow::bail!(
-                "Failed to auto-approve draft {} for agent step '{}'",
-                id_str,
-                step.name
+                "Release pipeline stopped at step '{}': could not approve the agent draft (see error above).\n\
+                 \n\
+                 Fix the underlying issue, then re-run:\n\
+                 \n\
+                 ta release run {}",
+                step.name,
+                version
             );
         }
 
@@ -613,9 +617,13 @@ fn execute_agent_step(
             .status()?;
         if !apply_status.success() {
             anyhow::bail!(
-                "Failed to auto-apply draft {} for agent step '{}'",
-                id_str,
-                step.name
+                "Release pipeline stopped at step '{}' (see error above).\n\
+                 \n\
+                 Fix the underlying issue, then re-run:\n\
+                 \n\
+                 ta release run {}",
+                step.name,
+                version
             );
         }
         println!("  Draft {} applied to working directory.", id_str);


### PR DESCRIPTION
## Summary
- Error messages from `ta draft apply` now show the goal title alongside the short ID, so users know which task failed
- Plain-English explanation replaces internal state machine terminology
- Numbered steps tell the user exactly what to do: check status, clean up, re-run
- Release pipeline wrappers now say "see error above" and give the exact `ta release run <version>` retry command
- PLAN.md: SecureTA scope notes — v0.14 callouts cleaned up (no links to unshipped product), `SecureTA` entry in Projects On Top simplified to a one-liner

## Before / After

**Before:**
```
Error: Cannot apply: goal 465f4842 is in state 'failed', which cannot transition to 'applied'.
Valid source states: pr_ready, under_review, approved.
Error: Failed to auto-apply draft f8c634d0-8ae5-4045-9548-6e0452f38d3b for agent step 'Generate release notes'
```

**After:**
```
Error: Cannot apply draft — the agent task "fix RenderContext build errors" (465f4842) did not complete successfully.

The task is in state 'failed', but applying a draft requires the task to be in
'pr_ready', 'under_review', or 'approved'.

What to do:
1. Check what went wrong:  ta goal status 465f4842
2. Clean up the failed task: ta goal delete 465f4842
3. Re-run from the beginning (e.g. ta release run <version>)

Error: Release pipeline stopped at step 'Generate release notes' (see error above).

Fix the underlying issue, then re-run:

ta release run <version>
```

## Test plan
- [ ] `cargo build -p ta-cli` passes
- [ ] `cargo clippy -p ta-cli` clean
- [ ] `cargo fmt --check` clean
- [ ] CI green