### PR TITLE
fix: include output schemas in ta-output-schema crate package

### DIFF
--- a/crates/ta-output-schema/Cargo.toml
+++ b/crates/ta-output-schema/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/trustedautonomy/ta"
 homepage = "https://github.com/trustedautonomy/ta"
 keywords = ["ai", "agent", "autonomy", "schema", "output"]
 categories = ["development-tools", "parsing"]
+include = ["src/**/*", "schemas/**/*", "Cargo.toml", "README.md"]
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/ta-output-schema/schemas/claude-code-v1.yaml
+++ b/crates/ta-output-schema/schemas/claude-code-v1.yaml
@@ -1,0 +1,67 @@
+# Output schema for Claude Code (legacy format, v1).
+#
+# Older versions of Claude Code put content at the top level:
+#   {"type":"assistant","content":[{"type":"text","text":"..."}]}
+# instead of nesting under "message".
+#
+# Use this schema if you're running an older Claude Code version.
+
+agent: claude-code-v1
+schema_version: 1
+format: stream-json
+
+model_paths:
+  - model
+
+suppress:
+  - message_start
+  - message_stop
+  - message_delta
+  - content_block_stop
+  - ping
+
+extractors:
+  # Assistant message — content at top level (legacy format).
+  - type_match: [assistant]
+    output: text
+    paths:
+      - content
+    content_type_filter: text
+
+  # Streaming text chunk.
+  - type_match: [content_block_delta]
+    output: text
+    paths:
+      - delta.text
+
+  # Final result.
+  - type_match: [result]
+    output: text
+    paths:
+      - result
+      - result.text
+    prefix: "[result] "
+
+  # Tool invocation.
+  - type_match: [tool_use]
+    output: tool_use
+    paths:
+      - name
+
+  # Tool invocation from content_block_start.
+  - type_match: [content_block_start]
+    output: tool_use
+    paths:
+      - content_block.name
+
+  # System events.
+  - type_match: [system]
+    output: text
+    paths: []
+    subtype_formats:
+      init:
+        template: "[init] model: {model}"
+        fields: [model]
+      hook_started:
+        template: "[hook] {hook_name}..."
+        fields: [hook_name]

--- a/crates/ta-output-schema/schemas/claude-code.yaml
+++ b/crates/ta-output-schema/schemas/claude-code.yaml
@@ -1,0 +1,72 @@
+# Output schema for Claude Code (current format, v2).
+#
+# Claude Code with `--output-format stream-json` emits JSON lines with a "type"
+# field. Text content is nested under message.content[].text (current format)
+# or content[].text (legacy — see claude-code-v1.yaml).
+#
+# Override per-project: .ta/agents/output-schemas/claude-code.yaml
+# Override per-user:    ~/.config/ta/agents/output-schemas/claude-code.yaml
+
+agent: claude-code
+schema_version: 2
+format: stream-json
+
+# Paths to check for model name in any JSON event.
+model_paths:
+  - message.model
+  - model
+
+# Event types that produce no displayable content.
+suppress:
+  - message_start
+  - message_stop
+  - message_delta
+  - content_block_stop
+  - ping
+
+extractors:
+  # Assistant message — text content nested under message.content[].
+  - type_match: [assistant]
+    output: text
+    paths:
+      - message.content
+      - content
+    content_type_filter: text
+
+  # Streaming text chunk.
+  - type_match: [content_block_delta]
+    output: text
+    paths:
+      - delta.text
+
+  # Final result.
+  - type_match: [result]
+    output: text
+    paths:
+      - result
+      - result.text
+    prefix: "[result] "
+
+  # Tool invocation from explicit tool_use event.
+  - type_match: [tool_use]
+    output: tool_use
+    paths:
+      - name
+
+  # Tool invocation from content_block_start.
+  - type_match: [content_block_start]
+    output: tool_use
+    paths:
+      - content_block.name
+
+  # System events with subtype-specific formatting.
+  - type_match: [system]
+    output: text
+    paths: []
+    subtype_formats:
+      init:
+        template: "[init] model: {model}"
+        fields: [model]
+      hook_started:
+        template: "[hook] {hook_name}..."
+        fields: [hook_name]

--- a/crates/ta-output-schema/schemas/codex.yaml
+++ b/crates/ta-output-schema/schemas/codex.yaml
@@ -1,0 +1,54 @@
+# Output schema for OpenAI Codex CLI.
+#
+# Codex outputs JSON lines with a simpler structure than Claude Code.
+# Text content is typically in a "content" or "message" field.
+
+agent: codex
+schema_version: 1
+format: stream-json
+
+model_paths:
+  - model
+  - message.model
+
+suppress:
+  - ping
+  - heartbeat
+
+extractors:
+  # Message with content field (primary Codex output).
+  - type_match: [message]
+    output: text
+    paths:
+      - content
+      - message
+
+  # Assistant response.
+  - type_match: [assistant]
+    output: text
+    paths:
+      - content
+      - message.content
+    content_type_filter: text
+
+  # Streaming delta.
+  - type_match: [content_block_delta, delta]
+    output: text
+    paths:
+      - delta.text
+      - delta.content
+
+  # Result.
+  - type_match: [result]
+    output: text
+    paths:
+      - result
+      - text
+    prefix: "[result] "
+
+  # Tool use.
+  - type_match: [tool_use, function_call]
+    output: tool_use
+    paths:
+      - name
+      - function.name

--- a/crates/ta-output-schema/src/loader.rs
+++ b/crates/ta-output-schema/src/loader.rs
@@ -11,11 +11,11 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 /// Embedded schema YAML files for built-in agents.
-const EMBEDDED_CLAUDE_CODE_V2: &str =
-    include_str!("../../../agents/output-schemas/claude-code.yaml");
-const EMBEDDED_CLAUDE_CODE_V1: &str =
-    include_str!("../../../agents/output-schemas/claude-code-v1.yaml");
-const EMBEDDED_CODEX: &str = include_str!("../../../agents/output-schemas/codex.yaml");
+/// Stored in `crates/ta-output-schema/schemas/` so they are included in the
+/// published crate package (workspace-relative paths are not packaged by cargo publish).
+const EMBEDDED_CLAUDE_CODE_V2: &str = include_str!("../schemas/claude-code.yaml");
+const EMBEDDED_CLAUDE_CODE_V1: &str = include_str!("../schemas/claude-code-v1.yaml");
+const EMBEDDED_CODEX: &str = include_str!("../schemas/codex.yaml");
 
 /// Schema loader with configurable search paths and embedded defaults.
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- `cargo publish` packages only files within the crate directory — workspace-relative `include_str!` paths (`../../../agents/output-schemas/*.yaml`) don't resolve when cargo verifies the published tarball
- Copies the 3 schema YAML files into `crates/ta-output-schema/schemas/`
- Updates `include_str!` paths to `../schemas/*.yaml`
- Adds `include` field to `Cargo.toml` so the schemas are explicitly listed in the package

## Test plan
- [ ] `cargo build -p ta-output-schema` passes
- [ ] `cargo test -p ta-output-schema` passes (36 tests)
- [ ] `cargo package -p ta-output-schema` includes `schemas/*.yaml` in tarball
- [ ] crates.io publish succeeds on rerun