### PR TITLE
fix: use || pattern for cargo publish to survive set -e

### DIFF
--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -89,8 +89,10 @@ publish_crate() {
     fi
   else
     echo "  Publishing $crate_name@$WORKSPACE_VERSION to crates.io..."
-    PUBLISH_OUTPUT=$(cargo publish -p "$crate_name" --token "$CARGO_REGISTRY_TOKEN" 2>&1)
-    PUBLISH_EXIT=$?
+    # Use || to prevent set -e from aborting on non-zero exit before we can
+    # inspect the output (e.g. "already exists" should be treated as a skip).
+    PUBLISH_EXIT=0
+    PUBLISH_OUTPUT=$(cargo publish -p "$crate_name" --token "$CARGO_REGISTRY_TOKEN" 2>&1) || PUBLISH_EXIT=$?
     echo "$PUBLISH_OUTPUT"
     if [ $PUBLISH_EXIT -eq 0 ]; then
       echo "  ✓ Published $crate_name@$WORKSPACE_VERSION"


### PR DESCRIPTION
## Summary
- Script runs under `bash -e` — `PUBLISH_OUTPUT=$(cargo publish ...)` aborts immediately on non-zero exit (before `PUBLISH_EXIT` is set or output inspected)
- Fix: `PUBLISH_EXIT=0; PUBLISH_OUTPUT=$(cmd) || PUBLISH_EXIT=$?` — the `||` makes the assignment expression succeed regardless, so `set -e` doesn't abort and the "already exists" check can run

## Test plan
- [ ] Merge and rerun release — already-published crates skip cleanly, remaining crates publish in order