### PR TITLE
fix: bump supervisor heartbeat_stale_secs default 30s → 90s

### DIFF
--- a/apps/ta-cli/src/commands/community.rs
+++ b/apps/ta-cli/src/commands/community.rs
@@ -6,6 +6,7 @@
 //   - `ta community search <q>`  — search across resources
 //   - `ta community get <id>`    — fetch and display a document
 
+use std::cmp::Reverse;
 use std::io::Write as _;
 use std::path::Path;
 
@@ -397,7 +398,7 @@ fn cmd_search(
         );
     }
 
-    results.sort_by(|a, b| b.3.cmp(&a.3));
+    results.sort_by_key(|r| Reverse(r.3));
     results.truncate(20);
 
     if json {

--- a/apps/ta-cli/src/commands/context.rs
+++ b/apps/ta-cli/src/commands/context.rs
@@ -3,6 +3,8 @@
 // Agent-agnostic persistent memory that works across agent frameworks.
 // TA owns the memory — agents consume it through MCP tools or CLI.
 
+use std::cmp::Reverse;
+
 use clap::Subcommand;
 use ta_goal::GoalRunStore;
 use ta_mcp_gateway::GatewayConfig;
@@ -431,7 +433,7 @@ fn show_stats(config: &GatewayConfig) -> anyhow::Result<()> {
         println!();
         println!("  By category:");
         let mut cats: Vec<_> = stats.by_category.iter().collect();
-        cats.sort_by(|a, b| b.1.cmp(a.1));
+        cats.sort_by_key(|e| Reverse(*e.1));
         for (cat, count) in cats {
             println!("    {:<16} {}", cat, count);
         }
@@ -441,7 +443,7 @@ fn show_stats(config: &GatewayConfig) -> anyhow::Result<()> {
         println!();
         println!("  By source:");
         let mut srcs: Vec<_> = stats.by_source.iter().collect();
-        srcs.sort_by(|a, b| b.1.cmp(a.1));
+        srcs.sort_by_key(|e| Reverse(*e.1));
         for (src, count) in srcs {
             println!("    {:<16} {}", src, count);
         }

--- a/apps/ta-cli/src/commands/context.rs
+++ b/apps/ta-cli/src/commands/context.rs
@@ -770,11 +770,7 @@ fn context_size_report(
     } else {
         format!("{}", budget)
     };
-    let pct = if budget > 0 {
-        (total * 100) / budget
-    } else {
-        0
-    };
+    let pct = (total * 100).checked_div(budget).unwrap_or(0);
 
     println!();
     println!("Context Budget Report");
@@ -795,11 +791,7 @@ fn context_size_report(
     ];
 
     for (name, chars) in sections {
-        let section_pct = if budget > 0 {
-            (chars * 100) / budget
-        } else {
-            0
-        };
+        let section_pct = (chars * 100).checked_div(budget).unwrap_or(0);
         if verbose || *chars > 0 {
             println!(
                 "  {:<30} {:>8}  {:>5}%",

--- a/apps/ta-cli/src/commands/draft.rs
+++ b/apps/ta-cli/src/commands/draft.rs
@@ -1,5 +1,6 @@
 // draft.rs — draft package subcommands: build, list, view, approve, deny, apply.
 
+use std::cmp::Reverse;
 use std::fs;
 use std::path::Path;
 use std::sync::mpsc;
@@ -2585,7 +2586,7 @@ fn list_packages(
     let mut packages = load_all_packages(config)?;
 
     // Default ordering: newest last (chronological) for readability.
-    packages.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    packages.sort_by_key(|p| p.created_at);
 
     // Load GC config for stale threshold.
     let workflow_config = ta_submit::WorkflowConfig::load_or_default(
@@ -7861,7 +7862,7 @@ pub fn load_all_packages(config: &GatewayConfig) -> anyhow::Result<Vec<DraftPack
         }
     }
 
-    packages.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    packages.sort_by_key(|p| Reverse(p.created_at));
     Ok(packages)
 }
 
@@ -8086,7 +8087,7 @@ pub fn build_draft_inline(
     // which can be `shortref/seq` format that isn't a raw UUID).
     let latest_pkg = load_all_packages(config).ok().and_then(|mut pkgs| {
         pkgs.retain(|p| p.goal.goal_id == goal_id);
-        pkgs.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        pkgs.sort_by_key(|p| Reverse(p.created_at));
         pkgs.into_iter().next()
     });
 

--- a/apps/ta-cli/src/commands/events.rs
+++ b/apps/ta-cli/src/commands/events.rs
@@ -1,5 +1,7 @@
 // events.rs -- Event system CLI: listen, hooks, tokens, routing.
 
+use std::cmp::Reverse;
+
 use clap::Subcommand;
 use ta_events::router::{EventRouter, ResponseStrategy, RoutingConfig};
 use ta_events::store::{EventQueryFilter, FsEventStore};
@@ -135,7 +137,7 @@ fn show_stats(config: &GatewayConfig) -> anyhow::Result<()> {
         println!();
         println!("  By type:");
         let mut types: Vec<_> = by_type.iter().collect();
-        types.sort_by(|a, b| b.1.cmp(a.1));
+        types.sort_by_key(|e| Reverse(*e.1));
         for (t, count) in types {
             println!("    {:<24} {}", t, count);
         }

--- a/apps/ta-cli/src/commands/follow_up.rs
+++ b/apps/ta-cli/src/commands/follow_up.rs
@@ -4,6 +4,7 @@
 // Scans goals, drafts, plan phases, and verification failures to build a
 // ranked list of follow-up candidates the user can pick from interactively.
 
+use std::cmp::Reverse;
 use std::fmt;
 
 use chrono::{DateTime, Utc};
@@ -117,7 +118,7 @@ pub fn gather_follow_up_candidates(
     }
 
     // Sort by recency (most recent first).
-    candidates.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    candidates.sort_by_key(|c| Reverse(c.updated_at));
 
     Ok(candidates)
 }
@@ -145,7 +146,7 @@ pub fn resolve_by_phase(
                 .is_some_and(|p| p == phase_id || p == normalized || p == with_v)
         })
         .collect();
-    phase_goals.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    phase_goals.sort_by_key(|g| Reverse(g.updated_at));
 
     if let Some(goal) = phase_goals.first() {
         if let Some(candidate) = goal_to_candidate(goal, &all_drafts, now) {

--- a/apps/ta-cli/src/commands/goal.rs
+++ b/apps/ta-cli/src/commands/goal.rs
@@ -1,5 +1,6 @@
 // goal.rs — Goal subcommands: start, list, status, constitution.
 
+use std::cmp::Reverse;
 use std::path::PathBuf;
 
 use clap::Subcommand;
@@ -399,7 +400,7 @@ fn find_parent_goal(
 
             // Sort by updated_at descending.
             let mut sorted = all_goals.clone();
-            sorted.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+            sorted.sort_by_key(|g| Reverse(g.updated_at));
 
             // Prefer goals that haven't been applied yet.
             let unapplied = sorted

--- a/apps/ta-cli/src/commands/governed_workflow.rs
+++ b/apps/ta-cli/src/commands/governed_workflow.rs
@@ -7,6 +7,7 @@
 //   ta workflow run governed-goal --goal "Fix the auth bug"
 //   ta workflow status <run-id>
 
+use std::cmp::Reverse;
 use std::io::{BufRead, Write as _};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -601,7 +602,7 @@ impl GovernedWorkflowRun {
                 Some((modified, e.path()))
             })
             .collect();
-        candidates.sort_by(|a, b| b.0.cmp(&a.0));
+        candidates.sort_by_key(|c| Reverse(c.0));
         match candidates.first() {
             None => Ok(None),
             Some((_, path)) => {

--- a/apps/ta-cli/src/commands/onboard.rs
+++ b/apps/ta-cli/src/commands/onboard.rs
@@ -1416,25 +1416,23 @@ fn run_wizard_loop(
                         state.api_key_message = String::new();
                         state.message = None;
                     }
-                    KeyCode::Enter => {
-                        if !state.api_key_input.is_empty() {
-                            state.message = Some("  Validating API key...".to_string());
-                            terminal.draw(|f| render_wizard(f, state))?;
-                            match validate_anthropic_key(&state.api_key_input) {
-                                Ok(()) => {
-                                    state.api_key_validated = Some(true);
-                                    state.api_key_message = "✓ API key valid".to_string();
-                                    state.message = Some("✓ API key valid".to_string());
-                                    terminal.draw(|f| render_wizard(f, state))?;
-                                    std::thread::sleep(std::time::Duration::from_millis(800));
-                                    state.advance();
-                                    state.message = None;
-                                }
-                                Err(e) => {
-                                    state.api_key_validated = Some(false);
-                                    state.api_key_message = format!("✗ {e}");
-                                    state.message = Some(format!("✗ {e}"));
-                                }
+                    KeyCode::Enter if !state.api_key_input.is_empty() => {
+                        state.message = Some("  Validating API key...".to_string());
+                        terminal.draw(|f| render_wizard(f, state))?;
+                        match validate_anthropic_key(&state.api_key_input) {
+                            Ok(()) => {
+                                state.api_key_validated = Some(true);
+                                state.api_key_message = "✓ API key valid".to_string();
+                                state.message = Some("✓ API key valid".to_string());
+                                terminal.draw(|f| render_wizard(f, state))?;
+                                std::thread::sleep(std::time::Duration::from_millis(800));
+                                state.advance();
+                                state.message = None;
+                            }
+                            Err(e) => {
+                                state.api_key_validated = Some(false);
+                                state.api_key_message = format!("✗ {e}");
+                                state.message = Some(format!("✗ {e}"));
                             }
                         }
                     }
@@ -1446,15 +1444,11 @@ fn run_wizard_loop(
                 },
 
                 WizardStep::OllamaModel => match key.code {
-                    KeyCode::Up => {
-                        if state.ollama_model_idx > 0 {
-                            state.ollama_model_idx -= 1;
-                        }
+                    KeyCode::Up if state.ollama_model_idx > 0 => {
+                        state.ollama_model_idx -= 1;
                     }
-                    KeyCode::Down => {
-                        if state.ollama_model_idx + 1 < state.ollama_models.len() {
-                            state.ollama_model_idx += 1;
-                        }
+                    KeyCode::Down if state.ollama_model_idx + 1 < state.ollama_models.len() => {
+                        state.ollama_model_idx += 1;
                     }
                     KeyCode::Enter | KeyCode::Right => {
                         state.advance();

--- a/apps/ta-cli/src/commands/plan.rs
+++ b/apps/ta-cli/src/commands/plan.rs
@@ -20,6 +20,7 @@
 // `ta plan create` generates a new plan from a template.
 // `ta pr apply` auto-updates PLAN.md when a goal with --phase completes.
 
+use std::cmp::Reverse;
 use std::fmt;
 use std::path::Path;
 
@@ -2651,7 +2652,7 @@ fn plan_discuss(config: &GatewayConfig, topic: &str, _json: bool) -> anyhow::Res
             matches.push((p, score));
         }
     }
-    matches.sort_by(|a, b| b.1.cmp(&a.1));
+    matches.sort_by_key(|m| Reverse(m.1));
     if matches.is_empty() {
         println!("  No existing phases match this topic.");
     } else {

--- a/apps/ta-cli/src/commands/publish.rs
+++ b/apps/ta-cli/src/commands/publish.rs
@@ -8,6 +8,7 @@
 //   5. Pushes to the remote (if git is configured)
 //   6. Creates a GitHub PR (if `gh` CLI is available)
 
+use std::cmp::Reverse;
 use std::path::Path;
 use std::process::Command;
 
@@ -51,7 +52,7 @@ fn find_latest_approved(project_root: &Path) -> anyhow::Result<Option<DraftPacka
     }
 
     // Sort by created_at descending.
-    candidates.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    candidates.sort_by_key(|c| Reverse(c.created_at));
     Ok(candidates.into_iter().next())
 }
 

--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -3452,20 +3452,16 @@ fn accumulate_tokens(line: &str, tokens: &mut AgentTokens) {
                     .unwrap_or(0);
             }
         }
-        Some("system") => {
-            if tokens.model.is_empty() {
-                if let Some(model) = val.get("model").and_then(|v| v.as_str()) {
-                    tokens.model = model.to_string();
-                }
+        Some("system") if tokens.model.is_empty() => {
+            if let Some(model) = val.get("model").and_then(|v| v.as_str()) {
+                tokens.model = model.to_string();
             }
         }
-        Some("assistant") => {
+        Some("assistant") if tokens.model.is_empty() => {
             // Also extract model from assistant message metadata if present.
-            if tokens.model.is_empty() {
-                if let Some(msg) = val.get("message") {
-                    if let Some(model) = msg.get("model").and_then(|v| v.as_str()) {
-                        tokens.model = model.to_string();
-                    }
+            if let Some(msg) = val.get("message") {
+                if let Some(model) = msg.get("model").and_then(|v| v.as_str()) {
+                    tokens.model = model.to_string();
                 }
             }
         }

--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -8,6 +8,7 @@
 //
 // The user then reviews/approves/applies via `ta draft` commands.
 
+use std::cmp::Reverse;
 use std::io::IsTerminal;
 use std::path::Path;
 
@@ -3872,7 +3873,7 @@ pub(crate) fn find_latest_draft_id(config: &GatewayConfig, goal_id: &str) -> Opt
         .filter(|pkg| pkg.goal.goal_id == goal_id)
         .collect();
 
-    drafts.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    drafts.sort_by_key(|d| Reverse(d.created_at));
     // Return the canonical display ID so the emitted string resolves via `ta draft view`.
     drafts.first().map(draft_canonical_id)
 }

--- a/apps/ta-cli/src/commands/runbook.rs
+++ b/apps/ta-cli/src/commands/runbook.rs
@@ -545,7 +545,7 @@ fn load_project_runbooks(project_root: &Path) -> Vec<RunbookDefinition> {
         }
     }
 
-    runbooks.sort_by(|a, b| a.name.cmp(&b.name));
+    runbooks.sort_by_key(|r| r.name.clone());
     runbooks
 }
 

--- a/apps/ta-cli/src/commands/shell_tui.rs
+++ b/apps/ta-cli/src/commands/shell_tui.rs
@@ -1504,11 +1504,9 @@ async fn handle_terminal_event(
                         app.running = false;
                     }
                 }
-                (KeyCode::Esc, _) => {
+                (KeyCode::Esc, _) if app.pending_paste.is_some() => {
                     // Escape cancels a pending large paste (v0.11.4.5).
-                    if app.pending_paste.is_some() {
-                        app.cancel_pending_paste();
-                    }
+                    app.cancel_pending_paste();
                 }
                 (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
                     // Ctrl-D in attach mode exits attach (v0.12.0.1).
@@ -2266,22 +2264,22 @@ async fn handle_terminal_event(
                     }
                 }
                 // Scrollbar drag: update position while dragging (v0.14.7.1 item 6).
-                MouseEventKind::Drag(MouseButton::Left) if app.scrollbar_dragging => {
-                    if app.output_area_height > 0 {
-                        let h = app.output_area_height as usize;
-                        let rel_row = (mouse.row.saturating_sub(app.output_area_top)) as usize;
-                        let rel_row = rel_row.min(h.saturating_sub(1));
-                        let vl = app.cached_visual_lines.max(app.output.len());
-                        let max_scroll = vl.saturating_sub(h);
-                        if max_scroll > 0 {
-                            let pos = rel_row * max_scroll / h;
-                            app.scroll_offset = max_scroll.saturating_sub(pos);
-                            if app.scroll_offset == 0 {
-                                app.auto_scroll = true;
-                                app.unread_events = 0;
-                            } else {
-                                app.auto_scroll = false;
-                            }
+                MouseEventKind::Drag(MouseButton::Left)
+                    if app.scrollbar_dragging && app.output_area_height > 0 =>
+                {
+                    let h = app.output_area_height as usize;
+                    let rel_row = (mouse.row.saturating_sub(app.output_area_top)) as usize;
+                    let rel_row = rel_row.min(h.saturating_sub(1));
+                    let vl = app.cached_visual_lines.max(app.output.len());
+                    let max_scroll = vl.saturating_sub(h);
+                    if max_scroll > 0 {
+                        let pos = rel_row * max_scroll / h;
+                        app.scroll_offset = max_scroll.saturating_sub(pos);
+                        if app.scroll_offset == 0 {
+                            app.auto_scroll = true;
+                            app.unread_events = 0;
+                        } else {
+                            app.auto_scroll = false;
                         }
                     }
                 }

--- a/apps/ta-cli/src/commands/stats.rs
+++ b/apps/ta-cli/src/commands/stats.rs
@@ -6,6 +6,8 @@
 // v0.15.14.2: Added --phase-prefix filtering, COST column, FOLLOWUPS column,
 // auto-migrate deprecation note.
 
+use std::cmp::Reverse;
+
 use clap::Subcommand;
 use ta_goal::{GoalOutcome, VelocityHistoryStore, VelocityStore};
 use ta_mcp_gateway::GatewayConfig;
@@ -292,7 +294,7 @@ pub fn execute(cmd: &StatsCommands, config: &GatewayConfig) -> anyhow::Result<()
             }
 
             // Newest first.
-            entries.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+            entries.sort_by_key(|e| Reverse(e.started_at));
             entries.truncate(*limit);
 
             if entries.is_empty() {

--- a/apps/ta-cli/src/commands/template.rs
+++ b/apps/ta-cli/src/commands/template.rs
@@ -581,7 +581,7 @@ fn read_installed_templates(dir: &Path) -> Vec<(String, Option<TemplateManifest>
             result.push((name, manifest));
         }
     }
-    result.sort_by(|a, b| a.0.cmp(&b.0));
+    result.sort_by_key(|r| r.0.clone());
     result
 }
 

--- a/apps/ta-cli/src/commands/verify.rs
+++ b/apps/ta-cli/src/commands/verify.rs
@@ -7,6 +7,7 @@
 // v0.10.18.3: Streaming stdout/stderr, heartbeat progress, per-command
 // configurable timeouts, and enhanced timeout error messages.
 
+use std::cmp::Reverse;
 use std::io::BufRead;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -325,7 +326,7 @@ pub fn execute(config: &GatewayConfig, goal_id: Option<&str>) -> anyhow::Result<
     } else {
         // Find the most recent running or pr-ready goal.
         let mut goals = goal_store.list()?;
-        goals.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        goals.sort_by_key(|g| Reverse(g.created_at));
         goals
             .into_iter()
             .find(|g| {

--- a/crates/ta-changeset/src/interactive_session_store.rs
+++ b/crates/ta-changeset/src/interactive_session_store.rs
@@ -3,6 +3,7 @@
 // Stores interactive sessions as JSON files in .ta/interactive_sessions/<session-id>.json
 // Enables multi-invocation interactive workflows where humans can pause and resume sessions.
 
+use std::cmp::Reverse;
 use std::fs;
 use std::path::PathBuf;
 
@@ -64,7 +65,7 @@ impl InteractiveSessionStore {
             }
         }
 
-        sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        sessions.sort_by_key(|s| Reverse(s.updated_at));
         Ok(sessions)
     }
 

--- a/crates/ta-changeset/src/review_session_store.rs
+++ b/crates/ta-changeset/src/review_session_store.rs
@@ -3,6 +3,7 @@
 // Stores review sessions as JSON files in ~/.ta/review_sessions/<session-id>.json
 // Enables multi-invocation review workflows where reviewers can pause and resume.
 
+use std::cmp::Reverse;
 use std::fs;
 use std::path::PathBuf;
 
@@ -65,7 +66,7 @@ impl ReviewSessionStore {
         }
 
         // Sort by updated_at descending (most recent first).
-        sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        sessions.sort_by_key(|s| Reverse(s.updated_at));
         Ok(sessions)
     }
 

--- a/crates/ta-changeset/src/sources.rs
+++ b/crates/ta-changeset/src/sources.rs
@@ -349,7 +349,7 @@ impl SourceCache {
                 }
             }
         }
-        items.sort_by(|a, b| a.name.cmp(&b.name));
+        items.sort_by_key(|i| i.name.clone());
         items
     }
 }

--- a/crates/ta-changeset/src/supervisor_review.rs
+++ b/crates/ta-changeset/src/supervisor_review.rs
@@ -66,11 +66,14 @@ pub struct SupervisorRunConfig {
     pub constitution_path: Option<std::path::PathBuf>,
     /// Don't fail if constitution is missing.
     pub skip_if_no_constitution: bool,
-    /// Kill supervisor if no token is received for this many seconds (default 30).
+    /// Kill supervisor if no token is received for this many seconds (default 90).
     ///
     /// Replaces wall-clock `timeout_secs`: a supervisor actively streaming a large diff
     /// will never be killed as long as tokens keep arriving. Only a truly stalled process
     /// (no output for `heartbeat_stale_secs`) is terminated.
+    ///
+    /// 90s accommodates extended-thinking models and prompt-cache creation: building a
+    /// 30k+ token cache can take 30-60s at the API with no tokens emitted.
     pub heartbeat_stale_secs: u64,
     /// Deprecated: use `heartbeat_stale_secs` instead. Accepted for backward compat and
     /// mapped to `heartbeat_stale_secs` at construction time with a deprecation warning.

--- a/crates/ta-daemon/src/api/project_browser.rs
+++ b/crates/ta-daemon/src/api/project_browser.rs
@@ -5,6 +5,7 @@
 //   GET  /api/project/list   — List recent projects
 //   POST /api/project/browse — Trigger native OS directory picker
 
+use std::cmp::Reverse;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -156,7 +157,7 @@ pub async fn open_project(
 pub async fn list_projects(State(_state): State<Arc<AppState>>) -> impl IntoResponse {
     let mut projects = RecentProjectsStore::load();
     // Sort by last_opened descending (most recent first).
-    projects.sort_by(|a, b| b.last_opened.cmp(&a.last_opened));
+    projects.sort_by_key(|p| Reverse(p.last_opened.clone()));
     Json(projects).into_response()
 }
 

--- a/crates/ta-daemon/src/api/stats.rs
+++ b/crates/ta-daemon/src/api/stats.rs
@@ -7,6 +7,7 @@
 //   ?since=YYYY-MM-DD    — filter entries from this date
 //   ?phase_prefix=0.15   — filter to v0.15.x phases
 
+use std::cmp::Reverse;
 use std::sync::Arc;
 
 use axum::extract::{Query, State};
@@ -136,7 +137,7 @@ pub async fn velocity_detail(
         }
 
         // Newest first.
-        entries.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        entries.sort_by_key(|e| Reverse(e.started_at));
         let limit = params.limit.unwrap_or(50);
         entries.truncate(limit);
 

--- a/crates/ta-daemon/src/api/workflow.rs
+++ b/crates/ta-daemon/src/api/workflow.rs
@@ -102,7 +102,7 @@ pub async fn list_workflows(State(state): State<Arc<AppState>>) -> impl IntoResp
         }
     }
 
-    entries.sort_by(|a, b| a.id.cmp(&b.id));
+    entries.sort_by_key(|e| e.id.clone());
     let count = entries.len();
 
     Json(serde_json::json!({

--- a/crates/ta-daemon/src/web.rs
+++ b/crates/ta-daemon/src/web.rs
@@ -15,6 +15,7 @@
 //   POST /api/memory               → create memory entry (v0.5.7)
 //   DELETE /api/memory/:key        → delete memory entry (v0.5.7)
 
+use std::cmp::Reverse;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -373,7 +374,7 @@ fn load_all_drafts(dir: &std::path::Path) -> Result<Vec<DraftPackage>, std::io::
         }
     }
     // Most recent first.
-    drafts.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    drafts.sort_by_key(|d| Reverse(d.created_at));
     Ok(drafts)
 }
 

--- a/crates/ta-db-overlay/src/overlay.rs
+++ b/crates/ta-db-overlay/src/overlay.rs
@@ -195,7 +195,7 @@ impl DraftOverlay {
     pub fn list_mutations(&mut self) -> Result<Vec<&OverlayEntry>> {
         self.ensure_loaded()?;
         let mut entries: Vec<&OverlayEntry> = self.cache.values().collect();
-        entries.sort_by(|a, b| a.ts.cmp(&b.ts));
+        entries.sort_by_key(|e| e.ts);
         Ok(entries)
     }
 

--- a/crates/ta-events/src/tokens.rs
+++ b/crates/ta-events/src/tokens.rs
@@ -7,6 +7,7 @@
 //
 // Tokens are simple HMAC-SHA256 signatures over the scope + expiry + random nonce.
 
+use std::cmp::Reverse;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -161,7 +162,7 @@ impl TokenStore {
                 }
             }
         }
-        tokens.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        tokens.sort_by_key(|t| Reverse(t.created_at));
         Ok(tokens)
     }
 

--- a/crates/ta-extension/src/review_queue.rs
+++ b/crates/ta-extension/src/review_queue.rs
@@ -181,7 +181,7 @@ mod tests {
         q.enqueue(make_entry("d2")).await.unwrap();
 
         let mut pending = q.pending().await.unwrap();
-        pending.sort_by(|a, b| a.draft_id.cmp(&b.draft_id));
+        pending.sort_by_key(|e| e.draft_id.clone());
         assert_eq!(pending.len(), 2);
         assert_eq!(pending[0].draft_id, "d1");
     }

--- a/crates/ta-goal/src/history.rs
+++ b/crates/ta-goal/src/history.rs
@@ -4,11 +4,10 @@
 // `.ta/goal-history.jsonl`. This preserves queryable history even after
 // goal JSON files are archived or deleted.
 
+use std::cmp::Reverse;
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-
-use std::cmp::Reverse;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/crates/ta-goal/src/history.rs
+++ b/crates/ta-goal/src/history.rs
@@ -8,6 +8,8 @@ use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 
+use std::cmp::Reverse;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -140,7 +142,7 @@ impl GoalHistoryLedger {
         }
 
         // Most recent first.
-        entries.sort_by(|a, b| b.created.cmp(&a.created));
+        entries.sort_by_key(|e| Reverse(e.created));
 
         // Apply limit.
         if let Some(limit) = filter.limit {

--- a/crates/ta-goal/src/operations.rs
+++ b/crates/ta-goal/src/operations.rs
@@ -5,6 +5,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::cmp::Reverse;
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -160,7 +161,7 @@ impl OperationsLog {
             }
         }
         // Most recent first.
-        entries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        entries.sort_by_key(|e| Reverse(e.created_at));
         if let Some(limit) = limit {
             entries.truncate(limit);
         }

--- a/crates/ta-goal/src/operations.rs
+++ b/crates/ta-goal/src/operations.rs
@@ -3,9 +3,10 @@
 // The daemon watchdog emits CorrectiveAction proposals when it detects issues.
 // They are persisted to `.ta/operations.jsonl` and surfaced via `ta operations log`.
 
+use std::cmp::Reverse;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::cmp::Reverse;
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};

--- a/crates/ta-goal/src/operations.rs
+++ b/crates/ta-goal/src/operations.rs
@@ -4,12 +4,12 @@
 // They are persisted to `.ta/operations.jsonl` and surfaced via `ta operations log`.
 
 use std::cmp::Reverse;
-
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::error::GoalError;

--- a/crates/ta-goal/src/persona.rs
+++ b/crates/ta-goal/src/persona.rs
@@ -101,7 +101,7 @@ impl PersonaConfig {
             };
             summaries.push(cfg.to_summary());
         }
-        summaries.sort_by(|a, b| a.name.cmp(&b.name));
+        summaries.sort_by_key(|s| s.name.clone());
         summaries
     }
 

--- a/crates/ta-goal/src/store.rs
+++ b/crates/ta-goal/src/store.rs
@@ -5,6 +5,7 @@
 //
 // The store supports CRUD operations plus filtering by state.
 
+use std::cmp::Reverse;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -86,7 +87,7 @@ impl GoalRunStore {
         }
 
         // Sort by creation time, newest first.
-        goals.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        goals.sort_by_key(|g| Reverse(g.created_at));
         Ok(goals)
     }
 

--- a/crates/ta-goal/src/velocity.rs
+++ b/crates/ta-goal/src/velocity.rs
@@ -27,8 +27,6 @@ pub fn is_zero_u64_pub(v: &u64) -> bool {
     *v == 0
 }
 
-use std::cmp::Reverse;
-
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;

--- a/crates/ta-goal/src/velocity.rs
+++ b/crates/ta-goal/src/velocity.rs
@@ -10,6 +10,7 @@
 //
 // v0.15.14.2: Added token cost fields, phase-prefix filtering, rework tracking.
 
+use std::cmp::Reverse;
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -601,7 +602,7 @@ pub fn aggregate_by_contributor(entries: &[VelocityEntry]) -> Vec<ContributorAgg
             }
         })
         .collect();
-    result.sort_by_key(|r| Reverse(r.total_goals));
+    result.sort_by_key(|e| Reverse(e.total_goals));
     result
 }
 

--- a/crates/ta-goal/src/velocity.rs
+++ b/crates/ta-goal/src/velocity.rs
@@ -661,7 +661,7 @@ pub fn detect_phase_conflicts(committed: &[VelocityEntry]) -> Vec<PhaseConflict>
             }
         })
         .collect();
-    conflicts.sort_by(|a, b| a.phase_id.cmp(&b.phase_id));
+    conflicts.sort_by_key(|c| c.phase_id.clone());
     conflicts
 }
 

--- a/crates/ta-goal/src/velocity.rs
+++ b/crates/ta-goal/src/velocity.rs
@@ -26,6 +26,8 @@ pub fn is_zero_u64_pub(v: &u64) -> bool {
     *v == 0
 }
 
+use std::cmp::Reverse;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -540,7 +542,7 @@ pub fn merge_velocity_entries(
     }
 
     let mut merged: Vec<VelocityEntry> = by_id.into_values().collect();
-    merged.sort_by(|a, b| a.started_at.cmp(&b.started_at));
+    merged.sort_by_key(|e| e.started_at);
 
     (merged, committed_ids)
 }
@@ -599,7 +601,7 @@ pub fn aggregate_by_contributor(entries: &[VelocityEntry]) -> Vec<ContributorAgg
             }
         })
         .collect();
-    result.sort_by(|a, b| b.total_goals.cmp(&a.total_goals));
+    result.sort_by_key(|r| Reverse(r.total_goals));
     result
 }
 

--- a/crates/ta-memory/src/conflict.rs
+++ b/crates/ta-memory/src/conflict.rs
@@ -7,6 +7,8 @@
 // - `AgentResolver`: stub — escalates to human (full LLM synthesis is a future phase)
 // - `ConflictResolverConfig`: parsed from [memory.conflict_resolution] in workflow.toml
 
+use std::cmp::Reverse;
+
 use serde::{Deserialize, Serialize};
 
 use crate::store::{ConflictPair, ConflictResolution, MemoryConflictResolver};
@@ -222,7 +224,7 @@ pub fn load_conflicts(project_memory_dir: &std::path::Path) -> Vec<ConflictPair>
             }
         }
     }
-    conflicts.sort_by(|a, b| b.detected_at.cmp(&a.detected_at));
+    conflicts.sort_by_key(|c| Reverse(c.detected_at));
     conflicts
 }
 

--- a/crates/ta-memory/src/fs_store.rs
+++ b/crates/ta-memory/src/fs_store.rs
@@ -5,6 +5,7 @@
 // Sufficient for small-to-medium projects. For large-scale semantic
 // search, the ruvector backend can be enabled via cargo feature.
 
+use std::cmp::Reverse;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -79,7 +80,7 @@ impl FsMemoryStore {
         }
 
         // Sort by creation time (newest first).
-        entries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        entries.sort_by_key(|e| Reverse(e.created_at));
         Ok(entries)
     }
 }
@@ -463,7 +464,7 @@ impl ProjectMemoryStore {
                 deduplicated_project.push(versions.remove(0));
             } else {
                 // Conflict detected: write to .conflicts/ and take the newest entry.
-                versions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+                versions.sort_by_key(|v| Reverse(v.updated_at));
                 let winner = versions.remove(0);
                 let loser = versions.remove(0);
                 let conflict = crate::store::ConflictPair {
@@ -496,7 +497,7 @@ impl ProjectMemoryStore {
         }
 
         let mut result: Vec<_> = merged.into_values().collect();
-        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        result.sort_by_key(|e| Reverse(e.created_at));
         Ok(result)
     }
 }

--- a/crates/ta-memory/src/ruvector_store.rs
+++ b/crates/ta-memory/src/ruvector_store.rs
@@ -7,6 +7,7 @@
 // Storage: single `.rvf` directory at `.ta/memory.rvf`.
 // Migration: auto-imports existing `.ta/memory/*.json` on first open.
 
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -243,7 +244,7 @@ impl MemoryStore for RuVectorStore {
         }
 
         // Sort by creation time (newest first), matching FsMemoryStore behavior.
-        entries.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        entries.sort_by_key(|e| Reverse(e.created_at));
 
         match limit {
             Some(n) => Ok(entries.into_iter().take(n).collect()),

--- a/crates/ta-session/src/manager.rs
+++ b/crates/ta-session/src/manager.rs
@@ -2,6 +2,7 @@
 //
 // Stores sessions as JSON files in .ta/sessions/<session-id>.json.
 
+use std::cmp::Reverse;
 use std::fs;
 use std::path::PathBuf;
 
@@ -92,7 +93,7 @@ impl SessionManager {
             }
         }
 
-        sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        sessions.sort_by_key(|s| Reverse(s.updated_at));
         Ok(sessions)
     }
 

--- a/crates/ta-session/src/workflow_manager.rs
+++ b/crates/ta-session/src/workflow_manager.rs
@@ -4,6 +4,7 @@
 // convention `workflow-<session-id>.json` to distinguish them from
 // `TaSession` records (which use `<session-id>.json`).
 
+use std::cmp::Reverse;
 use std::fs;
 use std::path::PathBuf;
 
@@ -83,7 +84,7 @@ impl WorkflowSessionManager {
             }
         }
 
-        sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        sessions.sort_by_key(|s| Reverse(s.updated_at));
         Ok(sessions)
     }
 

--- a/crates/ta-submit/src/config.rs
+++ b/crates/ta-submit/src/config.rs
@@ -741,11 +741,15 @@ pub struct SupervisorConfig {
     #[serde(default = "default_supervisor_skip_no_constitution")]
     pub skip_if_no_constitution: bool,
 
-    /// Kill supervisor if no token is received for this many seconds (default 30).
+    /// Kill supervisor if no token is received for this many seconds (default 90).
     ///
     /// Replaces the wall-clock `timeout_secs`: a supervisor actively streaming a large diff
     /// will never be killed — only one that stops producing output for `heartbeat_stale_secs`
-    /// is terminated. Set higher (e.g. 60) if your supervisor uses a slow model.
+    /// is terminated.
+    ///
+    /// 90s is the default to accommodate extended-thinking models and prompt-cache creation
+    /// (building a 30k+ token cache can take 30-60s at the API with no tokens emitted).
+    /// Lower this (e.g. 30) for fast models where genuine stalls are caught quickly.
     #[serde(default = "default_supervisor_heartbeat_stale_secs")]
     pub heartbeat_stale_secs: u64,
 
@@ -788,7 +792,7 @@ fn default_verdict_on_block() -> String {
     "warn".to_string()
 }
 fn default_supervisor_heartbeat_stale_secs() -> u64 {
-    30
+    90
 }
 fn default_supervisor_skip_no_constitution() -> bool {
     true

--- a/crates/ta-workspace/src/conflict.rs
+++ b/crates/ta-workspace/src/conflict.rs
@@ -288,7 +288,7 @@ impl SourceSnapshot {
             }
         }
 
-        conflicts.sort_by(|a, b| a.path.cmp(&b.path));
+        conflicts.sort_by_key(|c| c.path.clone());
         Ok(conflicts)
     }
 

--- a/plugins/ta-community-hub/src/cache.rs
+++ b/plugins/ta-community-hub/src/cache.rs
@@ -3,6 +3,7 @@
 //! Remote resources (github:) are synced to `.ta/community-cache/<name>/`.
 //! Local resources (local:) are read directly — no caching needed.
 
+use std::cmp::Reverse;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
@@ -156,7 +157,7 @@ impl ResourceCache {
         }
 
         // Sort by relevance score descending.
-        results.sort_by(|a, b| b.score.cmp(&a.score));
+        results.sort_by_key(|r| Reverse(r.score));
 
         // Enforce token budget (rough: 4 chars ≈ 1 token).
         let mut total_chars = 0usize;


### PR DESCRIPTION
## Summary
- Extended-thinking models and prompt-cache creation can take 30-60s with no tokens emitted
- The 30s stall default fired mid-cache-build (35k token cache ≈ 35s at API), killing the supervisor before any findings were produced
- Observed: `ta draft view` returned instantly with \"Supervisor stalled — no tokens received for 30s\" and `cache_creation_input_tokens: 34931, output_tokens: 0`
- Bumped default to 90s in both `ta-submit/src/config.rs` (workflow.toml default) and `ta-changeset/src/supervisor_review.rs` (doc comment)
- Users can still lower it in `workflow.toml` with `heartbeat_stale_secs = 30` if desired

## Test plan
- [ ] `cargo test -p ta-changeset -p ta-submit` passes
- [ ] `ta draft view <id>` with a large diff no longer times out during cache creation