### PR TITLE
v0.15.16 — Windows Code Signing (EV Certificate + CI Integration)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,26 @@ jobs:
             -o "artifacts\${{ env.BINARY_NAME }}-$env:TAG-x86_64-pc-windows-msvc.msi"
           Write-Host "MSI created: artifacts\${{ env.BINARY_NAME }}-$env:TAG-x86_64-pc-windows-msvc.msi"
 
+      # ── Windows code signing (v0.15.16) ──────────────────────────────────────
+      # Signs ta.exe, ta-daemon.exe, and the MSI with an EV code signing cert.
+      # Skipped automatically when WINDOWS_SIGNING_CERT_BASE64 is not set.
+      - name: Sign Windows artifacts
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        env:
+          WINDOWS_SIGNING_CERT_BASE64: ${{ secrets.WINDOWS_SIGNING_CERT_BASE64 }}
+          WINDOWS_SIGNING_PASSWORD: ${{ secrets.WINDOWS_SIGNING_PASSWORD }}
+          TAG: ${{ steps.get_version.outputs.version }}
+        run: |
+          $exeDir = "target\x86_64-pc-windows-msvc\release"
+          $msiPath = Get-ChildItem -Path artifacts -Filter '*.msi' | Select-Object -First 1 -ExpandProperty FullName
+          $filesToSign = @(
+            "$exeDir\ta.exe",
+            "$exeDir\ta-daemon.exe"
+          )
+          if ($msiPath) { $filesToSign += $msiPath }
+          & scripts\sign-windows.ps1 @filesToSign
+
       # ── macOS pkg + DMG (v0.13.11) ───────────────────────────────────────────
       # Build on ARM runner (aarch64-apple-darwin) — one DMG covers both arches.
       - name: Build macOS pkg and DMG

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ All outcomes must be **observable** (with details and logging) and **actionable*
 
 ## Current State
 
-**Current version**: `0.15.15-alpha.7`
+**Current version**: `0.15.16-alpha`
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --phase 4b`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.15.15-alpha.7"
+version = "0.15.16-alpha"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -10926,7 +10926,7 @@ Stable and nightly use different tag prefixes (`v*` vs `nightly`), so GitHub's d
 ---
 
 ### v0.15.16 — Windows Code Signing (EV Certificate + CI Integration)
-<!-- status: pending -->
+<!-- status: done -->
 **Goal**: Eliminate the Microsoft SmartScreen "Windows protected your PC" warning on the TA Windows MSI installer by signing all Windows binaries and the MSI with an Extended Validation (EV) code signing certificate. EV certs bypass SmartScreen's reputation-building period — signed EV binaries show no warning on first install regardless of download count. Ships with a fully automated signing step in the release CI workflow.
 
 **Depends on**: v0.13.11 (platform installers — WiX MSI build in release.yml)
@@ -10957,20 +10957,20 @@ Secrets required (GitHub Actions repository secrets):
 
 1. [ ] **Certificate procurement (manual, human step)**: Purchase EV code signing certificate from a Microsoft-trusted CA (DigiCert recommended). Store as `WINDOWS_SIGNING_CERT_BASE64` and `WINDOWS_SIGNING_PASSWORD` in GitHub Actions repository secrets. Document the renewal process in `docs/release-ops.md`.
 
-2. [ ] **`sign-windows.ps1` helper script** (`scripts/sign-windows.ps1`): Decode the base64 cert, write to a temp PFX, sign all `.exe` and `.msi` files passed as arguments with `signtool.exe` (SHA-256 digest, RFC 3161 timestamp via DigiCert's TSA), verify each signature, delete the temp PFX. Idempotent and safe to re-run.
+2. [x] **`sign-windows.ps1` helper script** (`scripts/sign-windows.ps1`): Decode the base64 cert, write to a temp PFX, sign all `.exe` and `.msi` files passed as arguments with `signtool.exe` (SHA-256 digest, RFC 3161 timestamp via DigiCert's TSA), verify each signature, delete the temp PFX in a `try/finally` block. Idempotent and safe to re-run.
 
-3. [ ] **Release workflow signing step** (`release.yml`): After the WiX MSI build step (`Build Windows MSI`), add a `Sign Windows artifacts` step that:
+3. [x] **Release workflow signing step** (`release.yml`): After the WiX MSI build step (`Build Windows MSI`), add a `Sign Windows artifacts` step that:
    - Calls `sign-windows.ps1` on `ta.exe`, `ta-daemon.exe`, and the `.msi` artifact
    - Verifies signatures with `signtool verify /pa`
    - Fails the build if any signature is invalid
 
 4. [ ] **Publisher display name**: The EV cert Common Name (CN) must match the intended publisher name shown in Windows UAC prompts ("Do you want to allow **Trusted Autonomy** to make changes..."). Coordinate cert purchase with the correct legal entity name.
 
-5. [ ] **Timestamp server**: Use DigiCert's RFC 3161 TSA (`http://timestamp.digicert.com`) so signatures remain valid after the cert expires. Include `--tr` (timestamp RFC 3161) and `--td sha256` flags.
+5. [x] **Timestamp server**: Use DigiCert's RFC 3161 TSA (`http://timestamp.digicert.com`) so signatures remain valid after the cert expires. Include `--tr` (timestamp RFC 3161) and `--td sha256` flags.
 
-6. [ ] **Verification in CI**: After signing, run `signtool verify /pa artifacts/ta-*.msi` and fail the workflow if exit code is non-zero. This catches cert expiry or misconfigured secrets before a release ships.
+6. [x] **Verification in CI**: After signing, run `signtool verify /pa artifacts/ta-*.msi` and fail the workflow if exit code is non-zero. This catches cert expiry or misconfigured secrets before a release ships.
 
-7. [ ] **`docs/release-ops.md` section**: "Windows Code Signing" — how to renew the cert, update the GitHub secret, what to do if the cert expires mid-release cycle, how to verify a signed MSI locally (`signtool verify /pa /v ta-*.msi`).
+7. [x] **`docs/release-ops.md` section**: "Windows Code Signing" — how to renew the cert, update the GitHub secret, what to do if the cert expires mid-release cycle, how to verify a signed MSI locally (`signtool verify /pa /v ta-*.msi`).
 
 8. [ ] **macOS Gatekeeper hardening (optional, same phase)**: If time permits, add `codesign --deep --force --verify --sign "Developer ID Application: ..."` + `notarytool` notarization to the macOS DMG build step. Eliminates the equivalent "macOS cannot verify the developer" prompt. Requires an Apple Developer account ($99/yr) and App-Specific Password for notarytool.
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -42,26 +42,26 @@ which = { workspace = true }
 arboard = { workspace = true }
 
 # Internal crates — version kept in sync with workspace by bump-version.sh
-ta-audit = { path = "../../crates/ta-audit", version = "0.15.15-alpha.7" }
-ta-credentials = { path = "../../crates/ta-credentials", version = "0.15.15-alpha.7" }
-ta-memory = { path = "../../crates/ta-memory", version = "0.15.15-alpha.7" }
-ta-changeset = { path = "../../crates/ta-changeset", version = "0.15.15-alpha.7" }
-ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.15.15-alpha.7" }
-ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.15.15-alpha.7" }
-ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.15.15-alpha.7" }
-ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.15.15-alpha.7" }
-ta-goal = { path = "../../crates/ta-goal", version = "0.15.15-alpha.7" }
-ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.15.15-alpha.7" }
-ta-policy = { path = "../../crates/ta-policy", version = "0.15.15-alpha.7" }
-ta-mediation = { path = "../../crates/ta-mediation", version = "0.15.15-alpha.7" }
-ta-session = { path = "../../crates/ta-session", version = "0.15.15-alpha.7" }
-ta-events = { path = "../../crates/ta-events", version = "0.15.15-alpha.7" }
-ta-submit = { path = "../../crates/ta-submit", version = "0.15.15-alpha.7" }
-ta-workspace = { path = "../../crates/ta-workspace", version = "0.15.15-alpha.7" }
-ta-workflow = { path = "../../crates/ta-workflow", version = "0.15.15-alpha.7" }
-ta-build = { path = "../../crates/ta-build", version = "0.15.15-alpha.7" }
-ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.15.15-alpha.7" }
-ta-runtime = { path = "../../crates/ta-runtime", version = "0.15.15-alpha.7" }
+ta-audit = { path = "../../crates/ta-audit", version = "0.15.16-alpha" }
+ta-credentials = { path = "../../crates/ta-credentials", version = "0.15.16-alpha" }
+ta-memory = { path = "../../crates/ta-memory", version = "0.15.16-alpha" }
+ta-changeset = { path = "../../crates/ta-changeset", version = "0.15.16-alpha" }
+ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.15.16-alpha" }
+ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.15.16-alpha" }
+ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.15.16-alpha" }
+ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.15.16-alpha" }
+ta-goal = { path = "../../crates/ta-goal", version = "0.15.16-alpha" }
+ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.15.16-alpha" }
+ta-policy = { path = "../../crates/ta-policy", version = "0.15.16-alpha" }
+ta-mediation = { path = "../../crates/ta-mediation", version = "0.15.16-alpha" }
+ta-session = { path = "../../crates/ta-session", version = "0.15.16-alpha" }
+ta-events = { path = "../../crates/ta-events", version = "0.15.16-alpha" }
+ta-submit = { path = "../../crates/ta-submit", version = "0.15.16-alpha" }
+ta-workspace = { path = "../../crates/ta-workspace", version = "0.15.16-alpha" }
+ta-workflow = { path = "../../crates/ta-workflow", version = "0.15.16-alpha" }
+ta-build = { path = "../../crates/ta-build", version = "0.15.16-alpha" }
+ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.15.16-alpha" }
+ta-runtime = { path = "../../crates/ta-runtime", version = "0.15.16-alpha" }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/crates/ta-connectors/comfyui/Cargo.toml
+++ b/crates/ta-connectors/comfyui/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.15.15-alpha.7" }
+ta-changeset = { path = "../../ta-changeset", version = "0.15.16-alpha" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/discord/Cargo.toml
+++ b/crates/ta-connectors/discord/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.15.15-alpha.7" }
+ta-events = { path = "../../ta-events", version = "0.15.16-alpha" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/email/Cargo.toml
+++ b/crates/ta-connectors/email/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.15.15-alpha.7" }
+ta-events = { path = "../../ta-events", version = "0.15.16-alpha" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/fs/Cargo.toml
+++ b/crates/ta-connectors/fs/Cargo.toml
@@ -16,10 +16,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.15.15-alpha.7" }
-ta-workspace = { path = "../../ta-workspace", version = "0.15.15-alpha.7" }
-ta-audit = { path = "../../ta-audit", version = "0.15.15-alpha.7" }
+ta-changeset = { path = "../../ta-changeset", version = "0.15.16-alpha" }
+ta-workspace = { path = "../../ta-workspace", version = "0.15.16-alpha" }
+ta-audit = { path = "../../ta-audit", version = "0.15.16-alpha" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-ta-policy = { path = "../../ta-policy", version = "0.15.15-alpha.7" }
+ta-policy = { path = "../../ta-policy", version = "0.15.16-alpha" }

--- a/crates/ta-connectors/slack/Cargo.toml
+++ b/crates/ta-connectors/slack/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.15.15-alpha.7" }
+ta-events = { path = "../../ta-events", version = "0.15.16-alpha" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/unreal/Cargo.toml
+++ b/crates/ta-connectors/unreal/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.15.15-alpha.7" }
+ta-changeset = { path = "../../ta-changeset", version = "0.15.16-alpha" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -31,18 +31,18 @@ async-stream = { workspace = true }
 sha2 = { workspace = true }
 
 # Internal crates
-ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.15.15-alpha.7" }
-ta-changeset = { path = "../ta-changeset", version = "0.15.15-alpha.7" }
-ta-memory = { path = "../ta-memory", version = "0.15.15-alpha.7" }
-ta-events = { path = "../ta-events", version = "0.15.15-alpha.7" }
-ta-goal = { path = "../ta-goal", version = "0.15.15-alpha.7" }
-ta-audit = { path = "../ta-audit", version = "0.15.15-alpha.7" }
-ta-policy = { path = "../ta-policy", version = "0.15.15-alpha.7" }
-ta-connector-slack = { path = "../ta-connectors/slack", version = "0.15.15-alpha.7" }
-ta-connector-email = { path = "../ta-connectors/email", version = "0.15.15-alpha.7" }
+ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.15.16-alpha" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.16-alpha" }
+ta-memory = { path = "../ta-memory", version = "0.15.16-alpha" }
+ta-events = { path = "../ta-events", version = "0.15.16-alpha" }
+ta-goal = { path = "../ta-goal", version = "0.15.16-alpha" }
+ta-audit = { path = "../ta-audit", version = "0.15.16-alpha" }
+ta-policy = { path = "../ta-policy", version = "0.15.16-alpha" }
+ta-connector-slack = { path = "../ta-connectors/slack", version = "0.15.16-alpha" }
+ta-connector-email = { path = "../ta-connectors/email", version = "0.15.16-alpha" }
 reqwest = { workspace = true }
-ta-output-schema = { path = "../ta-output-schema", version = "0.15.15-alpha.7" }
-ta-extension = { path = "../ta-extension", version = "0.15.15-alpha.7" }
+ta-output-schema = { path = "../ta-output-schema", version = "0.15.16-alpha" }
+ta-extension = { path = "../ta-extension", version = "0.15.16-alpha" }
 which = "7"
 libc = { workspace = true }
 async-trait = "0.1"

--- a/crates/ta-db-proxy-sqlite/Cargo.toml
+++ b/crates/ta-db-proxy-sqlite/Cargo.toml
@@ -18,8 +18,8 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 rusqlite = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.15.15-alpha.7" }
-ta-db-proxy = { path = "../ta-db-proxy", version = "0.15.15-alpha.7" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.15.16-alpha" }
+ta-db-proxy = { path = "../ta-db-proxy", version = "0.15.16-alpha" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-db-proxy/Cargo.toml
+++ b/crates/ta-db-proxy/Cargo.toml
@@ -17,4 +17,4 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.15.15-alpha.7" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.15.16-alpha" }

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -23,20 +23,20 @@ tokio = { workspace = true }
 regex = { workspace = true }
 
 # Internal crates
-ta-audit = { path = "../ta-audit", version = "0.15.15-alpha.7" }
-ta-events = { path = "../ta-events", version = "0.15.15-alpha.7" }
-ta-memory = { path = "../ta-memory", version = "0.15.15-alpha.7" }
-ta-changeset = { path = "../ta-changeset", version = "0.15.15-alpha.7" }
-ta-connector-fs = { path = "../ta-connectors/fs", version = "0.15.15-alpha.7" }
-ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.15.15-alpha.7" }
-ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.15.15-alpha.7" }
-ta-connector-unity = { path = "../ta-connectors/unity", version = "0.15.15-alpha.7" }
-ta-goal = { path = "../ta-goal", version = "0.15.15-alpha.7" }
-ta-policy = { path = "../ta-policy", version = "0.15.15-alpha.7" }
-ta-workspace = { path = "../ta-workspace", version = "0.15.15-alpha.7" }
-ta-workflow = { path = "../ta-workflow", version = "0.15.15-alpha.7" }
-ta-actions = { path = "../ta-actions", version = "0.15.15-alpha.7" }
-ta-submit = { path = "../ta-submit", version = "0.15.15-alpha.7" }
+ta-audit = { path = "../ta-audit", version = "0.15.16-alpha" }
+ta-events = { path = "../ta-events", version = "0.15.16-alpha" }
+ta-memory = { path = "../ta-memory", version = "0.15.16-alpha" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.16-alpha" }
+ta-connector-fs = { path = "../ta-connectors/fs", version = "0.15.16-alpha" }
+ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.15.16-alpha" }
+ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.15.16-alpha" }
+ta-connector-unity = { path = "../ta-connectors/unity", version = "0.15.16-alpha" }
+ta-goal = { path = "../ta-goal", version = "0.15.16-alpha" }
+ta-policy = { path = "../ta-policy", version = "0.15.16-alpha" }
+ta-workspace = { path = "../ta-workspace", version = "0.15.16-alpha" }
+ta-workflow = { path = "../ta-workflow", version = "0.15.16-alpha" }
+ta-actions = { path = "../ta-actions", version = "0.15.16-alpha" }
+ta-submit = { path = "../ta-submit", version = "0.15.16-alpha" }
 
 
 [dev-dependencies]

--- a/crates/ta-mediation/Cargo.toml
+++ b/crates/ta-mediation/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates for FsMediator
-ta-workspace = { path = "../ta-workspace", version = "0.15.15-alpha.7" }
-ta-changeset = { path = "../ta-changeset", version = "0.15.15-alpha.7" }
+ta-workspace = { path = "../ta-workspace", version = "0.15.16-alpha" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.16-alpha" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-runtime/Cargo.toml
+++ b/crates/ta-runtime/Cargo.toml
@@ -20,7 +20,7 @@ which = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
 
-ta-credentials = { path = "../ta-credentials", version = "0.15.15-alpha.7" }
+ta-credentials = { path = "../ta-credentials", version = "0.15.16-alpha" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }
-ta-policy = { path = "../ta-policy", version = "0.15.15-alpha.7" }
+ta-policy = { path = "../ta-policy", version = "0.15.16-alpha" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-session/Cargo.toml
+++ b/crates/ta-session/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates
-ta-goal = { path = "../ta-goal", version = "0.15.15-alpha.7" }
-ta-changeset = { path = "../ta-changeset", version = "0.15.15-alpha.7" }
+ta-goal = { path = "../ta-goal", version = "0.15.16-alpha" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.16-alpha" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -16,8 +16,8 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.15.15-alpha.7" }
-ta-goal = { path = "../ta-goal", version = "0.15.15-alpha.7" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.16-alpha" }
+ta-goal = { path = "../ta-goal", version = "0.15.16-alpha" }
 toml = "0.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/ta-workflow/Cargo.toml
+++ b/crates/ta-workflow/Cargo.toml
@@ -18,7 +18,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.15.15-alpha.7" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.16-alpha" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -17,7 +17,7 @@ uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = "0.10"
-ta-changeset = { path = "../ta-changeset", version = "0.15.15-alpha.7" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.16-alpha" }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/docs/release-ops.md
+++ b/docs/release-ops.md
@@ -1,0 +1,103 @@
+# Release Operations Guide
+
+Operational runbook for TA releases — certificate management, CI pipeline, and platform-specific installer signing.
+
+---
+
+## Windows Code Signing
+
+### Overview
+
+The TA Windows MSI and executables are signed with an Extended Validation (EV) code signing certificate. EV certificates eliminate the Microsoft SmartScreen "Windows protected your PC" warning on first install, regardless of download count. Unsigned or OV-signed binaries require hundreds of installs before SmartScreen's reputation score clears.
+
+The signing step in `release.yml` is **skip-safe**: if `WINDOWS_SIGNING_CERT_BASE64` is not set, the step exits 0 and the release continues unsigned. This allows releases to proceed before an EV cert is in place.
+
+### Certificate Procurement (one-time, human step)
+
+1. Purchase an Extended Validation (EV) Code Signing Certificate from a Microsoft-trusted CA:
+   - **DigiCert** (recommended) — https://www.digicert.com/signing/code-signing-certificates
+   - Sectigo or GlobalSign are also accepted
+   - Cost: approximately $300–500/year
+   - Lead time: 1–5 business days (identity verification required)
+
+2. The **Common Name (CN)** on the cert must match the publisher name shown in Windows UAC prompts. Use the exact legal entity name (e.g., `Trusted Autonomy, Inc.`).
+
+3. Export the certificate as a PFX/PKCS#12 file with a strong password.
+
+4. Base64-encode the PFX:
+   ```bash
+   # macOS / Linux
+   base64 -i certificate.pfx | tr -d '\n'
+
+   # PowerShell (Windows)
+   [Convert]::ToBase64String([IO.File]::ReadAllBytes('certificate.pfx'))
+   ```
+
+5. Add the values as GitHub Actions repository secrets:
+   - `WINDOWS_SIGNING_CERT_BASE64` — the base64-encoded PFX
+   - `WINDOWS_SIGNING_PASSWORD` — the PFX password
+
+### Renewing the Certificate
+
+EV certificates typically expire after 1–3 years. To renew:
+
+1. Order a new EV cert from the same CA (or a different Microsoft-trusted CA).
+2. Export the renewed cert as a PFX file.
+3. Base64-encode it (see above).
+4. Update the `WINDOWS_SIGNING_CERT_BASE64` and `WINDOWS_SIGNING_PASSWORD` secrets in GitHub → Settings → Secrets and variables → Actions.
+5. No code changes are required — the release workflow reads the secrets at build time.
+
+**Note**: Signed artifacts remain valid after the cert expires because the timestamp server (DigiCert RFC 3161 TSA at `http://timestamp.digicert.com`) countersigns the timestamp at signing time. The timestamp chain is valid independently of the cert's validity period.
+
+### What to Do if the Cert Expires Mid-Release Cycle
+
+1. **Binaries already signed** before expiry remain valid — the RFC 3161 timestamp proves they were signed while the cert was active.
+2. **New builds** after expiry will produce unsigned binaries (the signing step skips gracefully).
+3. **Renew immediately** following the steps above, then retrigger the release workflow via `workflow_dispatch` with the tag input.
+4. If a release shipped with unsigned binaries, users will see the SmartScreen warning. Communicate via release notes and retrigger the release once the renewed cert is in place.
+
+### Verifying a Signed MSI Locally
+
+```powershell
+# Verify Authenticode signature
+signtool verify /pa /v ta-*.msi
+
+# Or using PowerShell's built-in cmdlet
+Get-AuthenticodeSignature ta-*.msi | Select-Object Status, SignerCertificate
+
+# Expected output: Status = Valid
+```
+
+On Linux/macOS, use `osslsigncode verify`:
+```bash
+osslsigncode verify -in ta-*.msi
+```
+
+### CI Signing Details
+
+The `Sign Windows artifacts` step in `release.yml` runs `scripts/sign-windows.ps1` with:
+
+| Parameter | Value |
+|-----------|-------|
+| Binary targets | `ta.exe`, `ta-daemon.exe` |
+| Installer target | `ta-<version>-x86_64-pc-windows-msvc.msi` |
+| Digest algorithm | SHA-256 (`/fd sha256`) |
+| Timestamp server | `http://timestamp.digicert.com` (RFC 3161) |
+| Timestamp digest | SHA-256 (`/td sha256`) |
+| Verification | `signtool verify /pa` after each file |
+
+The step fails the build if any signature or verification returns a non-zero exit code.
+
+---
+
+## macOS Code Signing (planned)
+
+macOS Gatekeeper hardening (`codesign --deep` + `notarytool` notarization) is tracked in the plan and will eliminate the "macOS cannot verify the developer" prompt. It requires an Apple Developer account ($99/year). See PLAN.md Phase v0.15.16 item 8.
+
+---
+
+## See Also
+
+- `scripts/sign-windows.ps1` — signing helper script
+- `.github/workflows/release.yml` — full release pipeline
+- `docs/USAGE.md` — end-user installation guide

--- a/scripts/sign-windows.ps1
+++ b/scripts/sign-windows.ps1
@@ -1,0 +1,138 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Sign Windows binaries and MSI with an EV code signing certificate.
+
+.DESCRIPTION
+    Decodes the base64-encoded PFX from WINDOWS_SIGNING_CERT_BASE64, writes it
+    to a temp file, signs all supplied .exe/.msi files with signtool.exe using
+    SHA-256 digest and an RFC 3161 timestamp, verifies each signature, then
+    removes the temp PFX. If the signing secrets are absent the script exits 0
+    (skip mode) so the release workflow continues without signing.
+
+    The temp PFX is always removed in a finally block — even if signing or
+    verification throws a terminating error.
+
+.PARAMETER Artifacts
+    One or more paths to .exe or .msi files to sign. Accepts pipeline input and
+    wildcards resolved before being passed (e.g. artifacts\*.msi).
+
+.EXAMPLE
+    .\sign-windows.ps1 artifacts\ta.exe artifacts\ta-daemon.exe artifacts\ta-v1.0.0-x86_64-pc-windows-msvc.msi
+
+.NOTES
+    Required environment variables (set as GitHub Actions secrets):
+      WINDOWS_SIGNING_CERT_BASE64  — base64-encoded PFX file
+      WINDOWS_SIGNING_PASSWORD     — PFX password
+
+    Timestamp server: http://timestamp.digicert.com (RFC 3161, SHA-256 digest).
+    Signatures remain valid after cert expiry.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, ValueFromRemainingArguments = $true)]
+    [string[]]$Artifacts
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ── 1. Check secrets ──────────────────────────────────────────────────────────
+$certBase64  = $env:WINDOWS_SIGNING_CERT_BASE64
+$certPassword = $env:WINDOWS_SIGNING_PASSWORD
+
+if ([string]::IsNullOrEmpty($certBase64)) {
+    Write-Host "WINDOWS_SIGNING_CERT_BASE64 is not set — skipping code signing."
+    Write-Host "To enable signing, add WINDOWS_SIGNING_CERT_BASE64 and WINDOWS_SIGNING_PASSWORD"
+    Write-Host "as GitHub Actions repository secrets."
+    exit 0
+}
+
+# ── 2. Locate signtool.exe ────────────────────────────────────────────────────
+$signtool = $null
+
+# Prefer the path advertised by the runner environment (GitHub Actions sets this).
+if ($env:SIGNTOOL_PATH -and (Test-Path $env:SIGNTOOL_PATH)) {
+    $signtool = $env:SIGNTOOL_PATH
+}
+
+if (-not $signtool) {
+    # Search Windows SDK installations (newest first).
+    $sdkBases = @(
+        "${env:ProgramFiles(x86)}\Windows Kits\10\bin",
+        "${env:ProgramFiles}\Windows Kits\10\bin"
+    )
+    foreach ($base in $sdkBases) {
+        if (Test-Path $base) {
+            $candidate = Get-ChildItem -Path $base -Recurse -Filter 'signtool.exe' -ErrorAction SilentlyContinue |
+                         Sort-Object FullName -Descending |
+                         Select-Object -First 1
+            if ($candidate) {
+                $signtool = $candidate.FullName
+                break
+            }
+        }
+    }
+}
+
+if (-not $signtool) {
+    Write-Error "signtool.exe not found. Install the Windows SDK or set SIGNTOOL_PATH."
+    exit 1
+}
+Write-Host "Using signtool: $signtool"
+
+# ── 3. Decode PFX to a temp file ──────────────────────────────────────────────
+$tempPfx = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName() + '.pfx')
+Write-Host "Writing temp PFX to: $tempPfx"
+
+try {
+    [System.IO.File]::WriteAllBytes($tempPfx, [System.Convert]::FromBase64String($certBase64))
+
+    # ── 4. Sign each artifact ─────────────────────────────────────────────────
+    foreach ($artifact in $Artifacts) {
+        if (-not (Test-Path $artifact)) {
+            Write-Error "Artifact not found: $artifact"
+            exit 1
+        }
+
+        Write-Host "Signing: $artifact"
+
+        $signArgs = @(
+            'sign',
+            '/fd',  'sha256',           # file digest algorithm
+            '/tr',  'http://timestamp.digicert.com',  # RFC 3161 TSA
+            '/td',  'sha256',           # timestamp digest algorithm
+            '/f',   $tempPfx
+        )
+        if (-not [string]::IsNullOrEmpty($certPassword)) {
+            $signArgs += '/p'
+            $signArgs += $certPassword
+        }
+        $signArgs += $artifact
+
+        & $signtool @signArgs
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "signtool sign failed for '$artifact' (exit $LASTEXITCODE)."
+            exit 1
+        }
+        Write-Host "  signed OK"
+
+        # ── 5. Verify ─────────────────────────────────────────────────────────
+        Write-Host "Verifying: $artifact"
+        & $signtool verify /pa $artifact
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "signtool verify failed for '$artifact' (exit $LASTEXITCODE)."
+            exit 1
+        }
+        Write-Host "  verified OK"
+    }
+
+    Write-Host "All $($Artifacts.Count) artifact(s) signed and verified successfully."
+
+} finally {
+    # Always remove the temp PFX — even if signing or verification threw.
+    if (Test-Path $tempPfx) {
+        Remove-Item -Force $tempPfx
+        Write-Host "Temp PFX removed."
+    }
+}


### PR DESCRIPTION
## Summary

- Add `scripts/sign-windows.ps1`: decodes PFX from WINDOWS_SIGNING_CERT_BASE64 secret, signs .exe/.msi artifacts with signtool.exe (SHA-256 + DigiCert RFC 3161 timestamp), verifies each signature, deletes temp PFX in try/finally block to ensure cleanup on error
- Add signing step to `.github/workflows/release.yml` after Windows MSI build — gracefully skips if secret absent, fails on signing failure
- Add `docs/release-ops.md`: cert procurement runbook, secret setup, annual renewal, local MSI verification
- Bump version to 0.15.16-alpha
- Phase v0.15.16 items 2,3,5,6,7 complete; items 1 (cert procurement, human step), 4 (legal entity name), 8 (macOS notarization, deferred), 9 (MSI smoke test, deferred)

Fixes: reviewer-flagged PLAN.md regression and resource leak (GetTempFileName → GetRandomFileName)

## Test plan

- [ ] CI passes (version consistency, lint, tests, Windows build)
- [ ] sign-windows.ps1 script has correct try/finally PFX cleanup
- [ ] release.yml signing step is after MSI build, before checksum generation
- [ ] docs/release-ops.md covers cert procurement and renewal steps

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)