### PR TITLE
fix: re-apply truncate() char-boundary fix (lost to staging drift)

### DIFF
--- a/apps/ta-cli/src/commands/plan.rs
+++ b/apps/ta-cli/src/commands/plan.rs
@@ -1872,8 +1872,9 @@ fn plan_create(
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() > max {
-        format!("{}...", &s[..max - 3])
+    if s.chars().count() > max {
+        let cut: String = s.chars().take(max - 3).collect();
+        format!("{}...", cut)
     } else {
         s.to_string()
     }


### PR DESCRIPTION
## Summary
- `truncate()` in `plan.rs` was reverted to the byte-indexing version when the v0.15.19.4.3 draft applied changes from staging that predated PR #406
- Re-applies the char-aware fix: `chars().take(max - 3).collect()` instead of `&s[..max - 3]`
- Without this, `ta plan list` panics on any phase title containing multi-byte characters (e.g. `§` in v0.11.6, `–` in v0.11.6)

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `ta plan list` completes without panic

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)