### PR TITLE
fix: thread phase_filter param into governed workflow; fix 79 missing PLAN.md markers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -136,6 +136,7 @@ Hardening for security-conscious single-node deployments. Multi-user and enterpr
 ## v0.9 — Distribution & Packaging *(release: tag v0.9.0-beta)*
 ---
 ### v0.9.0 — Distribution & Packaging
+<!-- status: done -->
 ---
 ---
 - Developer: `cargo run` + local config + Nix
@@ -152,6 +153,7 @@ Hardening for security-conscious single-node deployments. Multi-user and enterpr
 - [x] Version bump to 0.9.0-alpha
 ---
 ### v0.9.1 — Native Windows Support
+<!-- status: done -->
 ---
 ---
 **Goal**: First-class Windows experience without requiring WSL.
@@ -178,6 +180,7 @@ Hardening for security-conscious single-node deployments. Multi-user and enterpr
 - `ctrlc` crate → dropped (tokio::signal in v0.10.16 supersedes this)
 ---
 ### v0.9.2 — Sandbox Runner (optional hardening, Layer 2)
+<!-- status: done -->
 ---
 ---
 > Optional for users who need kernel-level isolation. Not a prerequisite for v1.0.
@@ -205,6 +208,7 @@ Hardening for security-conscious single-node deployments. Multi-user and enterpr
 - Enterprise state intercept → v0.11.5 (Runtime Adapter Trait)
 ---
 ### v0.9.3 — Dev Loop Access Hardening
+<!-- status: done -->
 ---
 ---
 **Goal**: Severely limit what the `ta dev` orchestrator agent can do — read-only project access, only TA MCP tools, no filesystem writes.
@@ -224,6 +228,7 @@ Hardening for security-conscious single-node deployments. Multi-user and enterpr
 - Full tool-call audit logging → completed in v0.10.15 (per-tool-call audit via `audit_tool_call()`)
 ---
 ### v0.9.4 — Orchestrator Event Wiring & Gateway Refactor
+<!-- status: done -->
 ---
 ---
 **Goal**: Wire the `ta dev` orchestrator to actually launch implementation agents, handle failures, and receive events — plus refactor the growing MCP gateway.
@@ -250,6 +255,7 @@ Hardening for security-conscious single-node deployments. Multi-user and enterpr
 ---
 ---                                                                                                                                                                                                                                                             
 ### v0.9.4.1 — Event Emission Plumbing Fix                       
+<!-- status: done -->
 ---
 ---
 **Goal**: Wire event emission into all goal lifecycle paths so `ta_event_subscribe` actually receives events. Currently only `GoalFailed` on spawn failure emits to FsEventStore — `GoalStarted`, `GoalCompleted`, and `DraftBuilt` are never written, making
@@ -270,6 +276,7 @@ wired into the MCP goal start path.
 #### Version: `0.9.4-alpha.1`
 ---
 ### v0.9.5 — Enhanced Draft View Output
+<!-- status: done -->
 ---
 ---
 **Goal**: Make `ta draft view` output clear and actionable for reviewers — structured "what changed" summaries, design alternatives considered, and grouped visual sections.
@@ -286,6 +293,7 @@ wired into the MCP goal start path.
 ---
 ---                                                  
 ### v0.9.5.1 — Goal Lifecycle Hygiene & Orchestrator Fixes                                                                                                                                                                                                      
+<!-- status: done -->
 ---
 ---
 **Goal**: Fix the bugs discovered during v0.9.5 goal lifecycle monitoring — duplicate goal creation, zombie goal cleanup, event timer accuracy, draft discoverability via MCP, and cursor-based event polling semantics.                                        
@@ -339,6 +347,7 @@ passing the cursor from the previous response returns only *new* events. Add a t
 ---
 ---
 ### v0.9.6 — Orchestrator API & Goal-Scoped Agent Tracking
+<!-- status: done -->
 ---
 ---
 **Goal**: Make MCP tools work without a `goal_run_id` for read-only project-wide operations, and track which agents are working on which goals for observability.
@@ -420,6 +429,7 @@ passing the cursor from the previous response returns only *new* events. Add a t
 ---
 ---
 ### v0.9.7 — Daemon API Expansion
+<!-- status: done -->
 ---
 ---
 **Goal**: Promote the TA daemon from a draft-review web UI to a full API server that any interface (terminal, web, Discord, Slack, email) can connect to for commands, agent conversations, and event streams.
@@ -649,6 +659,7 @@ passing the cursor from the previous response returns only *new* events. Add a t
 ---
 ---
 ### v0.9.8 — Interactive TA Shell (`ta shell`)
+<!-- status: done -->
 ---
 ---
 **Goal**: A thin terminal REPL client for the TA daemon — providing a single-terminal interactive experience for commands, agent conversation, and event notifications. The shell is a daemon client, not a standalone tool.
@@ -789,6 +800,7 @@ All complexity lives in the daemon (v0.9.7). The shell is deliberately thin — 
 ---
 ---
 ### v0.9.8.1 — Auto-Approval, Lifecycle Hygiene & Operational Polish
+<!-- status: done -->
 ---
 ---
 **Goal**: Three themes that make TA reliable for sustained multi-phase use:
@@ -1040,6 +1052,7 @@ agents:
 ---
 ---
 ### v0.9.8.1.1 — Unified Allow/Deny List Pattern
+<!-- status: done -->
 ---
 ---
 **Goal**: Standardize all allowlist/blocklist patterns across TA to support both allow and deny lists with consistent semantics: deny takes precedence over allow, empty allow = allow all, empty deny = deny nothing.
@@ -1108,6 +1121,7 @@ impl AccessFilter {
 ---
 ---
 ### v0.9.8.2 — Pluggable Workflow Engine & Framework Integration
+<!-- status: done -->
 ---
 ---
 **Goal**: Add a `WorkflowEngine` trait to TA core so multi-stage, multi-role, multi-framework workflows can be orchestrated with pluggable engines — built-in YAML for simple cases, framework adapters (LangGraph, CrewAI) for power users, or custom implementations.
@@ -1366,6 +1380,7 @@ WorkflowFailed { workflow_id, name, reason, timestamp }
 ---
 ---
 ### v0.9.8.3 — Full TUI Shell (`ratatui`)
+<!-- status: done -->
 ---
 ---
 **Goal**: Replace the line-mode rustyline shell with a full terminal UI modeled on Claude Code / claude-flow — persistent status bar, scrolling output, and input area, all in one screen.
@@ -1428,6 +1443,7 @@ WorkflowFailed { workflow_id, name, reason, timestamp }
 ---
 ---
 ### v0.9.8.4 — VCS Adapter Abstraction & Plugin Architecture
+<!-- status: done -->
 ---
 **Goal**: Move all version control operations behind the `SubmitAdapter` trait so TA is fully VCS-agnostic. Add adapter-contributed exclude patterns for staging, implement stub adapters for SVN and Perforce, and design the external plugin loading mechanism.
 ---
@@ -1580,6 +1596,7 @@ This pattern extends beyond VCS to any adapter type:
 ---
 ---
 ### v0.9.9 — Conversational Project Bootstrapping (`ta new`) *(design only)*
+<!-- status: done -->
 ---
 ---
 ---
@@ -1977,6 +1994,7 @@ Human sees question in ta shell / Slack / web UI
 ---
 ---
 ### v0.9.10 — Multi-Project Daemon & Office Configuration
+<!-- status: done -->
 ---
 **Goal**: Extend the TA daemon to manage multiple projects simultaneously, with channel-to-project routing so a single Discord bot, Slack app, or email address can serve as the interface for several independent TA workspaces.
 ---
@@ -2094,6 +2112,7 @@ Each `ProjectContext` holds:
 ---
 ---
 ### v0.10.0 — Gateway Channel Wiring & Multi-Channel Routing
+<!-- status: done -->
 ---
 ---
 ---
@@ -2114,6 +2133,7 @@ Each `ProjectContext` holds:
 #### Version: `0.10.0-alpha`
 ---
 ### v0.10.1 — Native Discord Channel
+<!-- status: done -->
 ---
 **Goal**: `DiscordChannelFactory` implementing `ChannelFactory` with direct Discord REST API connection, eliminating the need for the bridge service.
 ---
@@ -2148,6 +2168,7 @@ This is built as an in-process Rust crate (the existing pattern). When v0.10.2 (
 ---
 ---
 ### v0.10.2 — Channel Plugin Loading (Multi-Language)
+<!-- status: done -->
 ---
 **Goal**: Allow third-party channel plugins without modifying TA source or writing Rust, enabling community-built integrations (Teams, PagerDuty, ServiceNow, etc.) in any language.
 ---
@@ -2286,6 +2307,7 @@ Slack (v0.10.3) and email (v0.10.4) are built as external plugins from the start
 ---
 ---
 ### v0.10.2.1 — Refactor Discord Channel to External Plugin
+<!-- status: done -->
 ---
 ---
 ---
@@ -2344,6 +2366,7 @@ ta plugin build --all
 ---
 ---
 ### v0.10.3 — Slack Channel Plugin
+<!-- status: done -->
 ---
 ---
 ---
@@ -2761,6 +2784,7 @@ After `./install_local.sh` rebuilds and installs new `ta` and `ta-daemon` binari
 ---
 ---
 ### v0.10.12 — Streaming Agent Q&A & Status Bar Enhancements
+<!-- status: done -->
 ---
 **Goal**: Eliminate 60s+ latency in `ta shell` Q&A by streaming agent responses instead of blocking, and add daemon version + agent name to the TUI status bar.
 ---
@@ -2826,6 +2850,7 @@ Agent: Added v0.10.14 — Agent Model Discovery & Status Display
 ---
 ---
 ### v0.10.14 — Deferred Items: Shell & Agent UX
+<!-- status: done -->
 ---
 #### Tests
 ---
@@ -2854,6 +2879,7 @@ Agent: Added v0.10.14 — Agent Model Discovery & Status Display
 ---
 ---
 ### v0.10.15 — Deferred Items: Observability & Audit
+<!-- status: done -->
 ---
 ---
 ---
@@ -2874,6 +2900,7 @@ Agent: Added v0.10.14 — Agent Model Discovery & Status Display
 ---
 ---
 ### v0.10.15.1 — TUI Output & Responsiveness Fixes
+<!-- status: done -->
 ---
 ---
 ---
@@ -2886,6 +2913,7 @@ Agent: Added v0.10.14 — Agent Model Discovery & Status Display
 ---
 ---
 ### v0.10.16 — Deferred Items: Platform & Channel Hardening
+<!-- status: done -->
 ---
 **Goal**: Address deferred platform and channel items for production readiness.
 ---
@@ -2916,6 +2944,7 @@ Agent: Added v0.10.14 — Agent Model Discovery & Status Display
 ---
 ---
 ### v0.10.17 — `ta new` — Conversational Project Bootstrapping
+<!-- status: done -->
 ---
 ---
 ---
@@ -2956,6 +2985,7 @@ See v0.9.9 design section above for the full architecture and user flow.
 ---
 ---
 ### v0.10.18 — Deferred Items: Workflow & Multi-Project
+<!-- status: done -->
 ---
 ---
 ---
@@ -3011,6 +3041,7 @@ When an agent or command produces output longer than the visible terminal area i
 ---
 ---
 ### v0.10.18.3 — Verification Streaming, Heartbeat & Configurable Timeout
+<!-- status: done -->
 ---
 **Goal**: Replace the silent, fire-and-forget verification model with streaming output, explicit progress heartbeats, and per-command configurable timeouts so the user always knows what is happening and never hits an opaque timeout.
 ---
@@ -3076,6 +3107,7 @@ The daemon passes `--accept-terms` when spawning `ta run` (cmd.rs line 123), sil
 ---
 ---
 ### v0.10.18.5 — Agent Stdin Relay & Interactive Prompt Handling
+<!-- status: done -->
 ---
 ---
 ---
@@ -3119,6 +3151,7 @@ Layer 1 handles most cases. Layer 3 is the general solution for unknown/new agen
 ---
 ---
 ### v0.10.18.6 — `ta daemon` Subcommand
+<!-- status: done -->
 ---
 ---
 ---
@@ -3268,6 +3301,7 @@ Event routing handles *reactive* responses to things that already happened. It d
 ---
 ---
 ### v0.11.0.1 — Draft Apply Defaults & CLI Flag Cleanup
+<!-- status: done -->
 ---
 ---
 - `crates/ta-events/src/strategies/agent.rs`: 4 tests (context building, event JSON inclusion, attempt propagation, missing agent error)
@@ -3626,6 +3660,7 @@ example: shell-routing-01, fix-auth-03, v0.11.2.1-01
 ---
 ---
 ### v0.11.2.5 — Prompt Detection Hardening & Version Housekeeping
+<!-- status: done -->
 ---
 **Goal**: Fix false-positive stdin prompt detection that makes `ta shell` unusable during goal runs, and update stale version tracking.
 ---
@@ -3677,6 +3712,7 @@ example: shell-routing-01, fix-auth-03, v0.11.2.1-01
 ---
 ---
 ### v0.11.3 — Self-Service Operations, Draft Amend & Plan Intelligence
+<!-- status: done -->
 ---
 ---
 ---
@@ -3765,6 +3801,7 @@ example: shell-routing-01, fix-auth-03, v0.11.2.1-01
 ---
 ---
 ### v0.11.3.1 — Shell Scroll & Help
+<!-- status: done -->
 ---
 ---
 ---
@@ -3777,6 +3814,7 @@ example: shell-routing-01, fix-auth-03, v0.11.2.1-01
 ---
 #### Tests added (12 total)
 ### v0.11.4 — Plugin Registry & Project Manifest
+<!-- status: done -->
 ---
 ---
 ---
@@ -3881,6 +3919,7 @@ Alternative sources (no registry needed):
 ---
 ---
 ### v0.11.4.1 — Shell Reliability: Command Output, Text Selection & Heartbeat
+<!-- status: done -->
 ---
 **Goal**: Make `ta shell` command output reliable and complete. Today, commands like `draft apply` produce no visible output in the shell — the daemon runs them, returns output, but it never appears. This blocks the release workflow. Also fix text selection (broken by mouse capture) and polish heartbeat display.
 ---
@@ -3917,6 +3956,7 @@ The output pipeline is: user types command → `send_input()` POST to daemon `/a
 ---
 ---
 ### v0.11.4.2 — Shell Mouse & Agent Session Fix
+<!-- status: done -->
 ---
 **Goal**: Fix two critical `ta shell` usability issues: (1) mouse scroll and text selection must both work simultaneously (like Claude Code), and (2) agent Q&A must reuse a persistent session instead of spawning a new subprocess per question.
 ---
@@ -3991,6 +4031,7 @@ The output pipeline is: user types command → `send_input()` POST to daemon `/a
 ---
 ---
 ### v0.11.4.3 — Smart Input Routing & Intent Disambiguation
+<!-- status: done -->
 ---
 **Goal**: Stop mis-routing natural language as commands when the first word happens to match a keyword. Add intent-aware disambiguation so the shell either routes correctly or presents "Did you mean..." options.
 7. [x] **User-extensible schemas**: Users add `.yaml` files to `.ta/agents/output-schemas/` (project-local) or `~/.config/ta/agents/output-schemas/` (global). Documented in USAGE.md.
@@ -4023,6 +4064,7 @@ The output pipeline is: user types command → `send_input()` POST to daemon `/a
 ---
 ---
 ### v0.11.4.4 — Constitution Compliance Remediation
+<!-- status: done -->
 ---
 **Goal**: Fix all violations found by the 7-agent constitution compliance audit against `docs/TA-CONSTITUTION.md`. Prioritize High-severity items (data loss on error paths) before Medium-severity (stale injection on follow-up).
 ---
@@ -4134,12 +4176,14 @@ The output pipeline is: user types command → `send_input()` POST to daemon `/a
 ---
 16. [x] **Session lifecycle**: Parallel sessions auto-close after idle timeout. User can `/close <tag>` to end a session explicitly. Max concurrent sessions configurable in `daemon.toml`.
 ### v0.11.5 — Web Shell UX, Agent Transparency & Parallel Sessions
+<!-- status: done -->
 ---
 #### Version: `0.11.5-alpha`
 ---
 ---
 ---
 ### v0.11.6 — Constitution Audit Completion (§5–§14)
+<!-- status: done -->
 ---
 ---
 ---
@@ -4169,6 +4213,7 @@ format: <slug>-<seq>
 ---
 ---
 ### v0.11.7 — Web Shell Stream UX Polish
+<!-- status: done -->
 ---
 #### Plugin Version Control
 **Goal**: Clean up the tail/stream output UX in the web shell so live goal output is comfortable to read and the connection state is always clear.
@@ -4220,6 +4265,7 @@ format: <slug>-<seq>
 ---
 ---
 ### v0.12.0 — Template Projects & Bootstrap Flow
+<!-- status: done -->
 ---
 **Goal**: `ta new` generates projects with `project.toml` plugin declarations so downstream users get a complete, working setup from `ta setup` alone. Template projects in the Trusted-Autonomy org serve as reference implementations. Also: replace the quick-fix Discord command listener with a proper slash-command-based bidirectional integration.
 ---
@@ -4273,6 +4319,7 @@ The current `--listen` mode on `ta-channel-discord` is a quick integration that 
 ---
 ---
 ### v0.12.0.1 — PR Merge & Main Sync Completion
+<!-- status: done -->
 ---
 **Goal**: Complete the post-apply workflow so that after `ta draft apply --submit` creates a PR, the user can merge it and sync their main branch without leaving TA. This is the final step in the "run → draft → apply → merge → next phase" loop that makes TA a smooth development substrate.
 ---
@@ -4307,6 +4354,7 @@ Known issue from v0.10.18: Discord-dispatched `ta run` created a goal record (st
 ---
 ---
 ### v0.12.0.2 — VCS Adapter Externalization
+<!-- status: done -->
 ---
 **Goal**: Migrate VCS adapters from built-in compiled code to external plugins using the same JSON-over-stdio protocol as channel plugins. Git remains built-in as the zero-dependency fallback. Perforce, SVN, and any future VCS adapters become external plugins that users install when needed.
 ---
@@ -4341,6 +4389,7 @@ Today git, perforce, and svn adapters are compiled into the `ta` binary. This me
 ---
 ---
 ### v0.12.1 — Discord Channel Polish
+<!-- status: done -->
 ---
 ---
 ---
@@ -4370,6 +4419,7 @@ Today git, perforce, and svn adapters are compiled into the `ta` binary. This me
 ---
 ---
 ### v0.12.2 — Shell Paste-at-End UX
+<!-- status: done -->
 ---
 **Goal**: Fix the `ta shell` paste behavior so that pasting (⌘V / Ctrl+V / middle-click) always appends at the end of the current `ta>` prompt text, regardless of where the visual cursor is positioned. Users naturally click or scroll around while reading output and forget where the cursor is — paste should always go to the input buffer end, not a random insertion point.
 ---
@@ -4405,6 +4455,7 @@ Today git, perforce, and svn adapters are compiled into the `ta` binary. This me
 ---
 ---
 ### v0.12.2.2 — Draft Apply: Transactional Rollback on Validation Failure
+<!-- status: done -->
 ---
 **Goal**: Make `ta draft apply` safe to run on `main`. If pre-submit verification fails (fmt, clippy, tests), all files written to the working tree must be restored to their pre-apply state. Currently the apply is not atomic — files land on disk but the commit never happens, leaving the working tree dirty and requiring manual `git checkout HEAD -- <files>` to recover.
 ---
@@ -4421,6 +4472,7 @@ Today git, perforce, and svn adapters are compiled into the `ta` binary. This me
 ---
 10. [x] **Structured progress parsing**: Parse stderr for known patterns (`Reading `, `Searching `, `Running `, `Writing `) and render them as distinct "thinking" lines with a spinner or activity indicator.
 ### v0.12.2.3 — Follow-Up Draft Completeness & Injection Cleanup
+<!-- status: done -->
 ---
 The submit workflow has three abstract stages, each mapped by the adapter:
 **Goal**: Fix two follow-up bugs exposed by v0.12.2.2: (1) follow-up drafts only capture per-session writes rather than the full staging-vs-source delta, silently dropping parent-session changes (version bumps, etc.) from the child PR; (2) a crashed/frozen session leaves CLAUDE.md with the TA injection still prepended, which then leaks into the diff and ends up in the GitHub PR.
@@ -4479,6 +4531,7 @@ The submit workflow has three abstract stages, each mapped by the adapter:
 ---
 ---
 ### v0.12.4.1 — Shell: Clear Working Indicator & Auto-Scroll Fix + Channel Goal Input
+<!-- status: done -->
 ---
 **Goal**: Fix two shell regressions confirmed in the v0.12.3 build: (1) "Agent is working ⚠" persists after `ta run` completes; (2) the output pane does not stay scrolled to the latest line when new agent output arrives. Also wire Discord (and Slack) to the existing `POST /api/goals/{id}/input` endpoint so users can inject mid-run corrections from a channel.
 ---
@@ -4513,6 +4566,7 @@ The submit workflow has three abstract stages, each mapped by the adapter:
 ---
 ---
 ### v0.12.5 — Semantic Memory: RuVector Backing Store & Context Injection
+<!-- status: done -->
 ---
 ---
 ---
@@ -4542,6 +4596,7 @@ The submit workflow has three abstract stages, each mapped by the adapter:
 ---
 ---
 ### v0.12.6 — Goal Lifecycle Observability & Channel Notification Reliability
+<!-- status: done -->
 ---
 5. [x] **Require positive signal**: Only match `:` endings if the line looks conversational — no parentheses, no code formatting, not prefixed with `[`. Keep `?`, `[y/N]`, `[Y/n]`, numbered choice patterns as strong positive signals.
 **Goal**: Two related gaps that surfaced during v0.12.5 operations: (1) the daemon and CLI emit almost no structured logs for goal lifecycle — making it impossible to diagnose stuck agents, missed state transitions, or slow draft builds from logs alone; (2) the Discord/Slack SSE progress streamers replay all historical events on every reconnect, flooding channels with old notifications and missing new ones if a reconnect races with an event.
@@ -4572,6 +4627,7 @@ The submit workflow has three abstract stages, each mapped by the adapter:
 ---
 ---
 ### v0.12.7 — Shell UX: Working Indicator Clearance & Scroll Reliability
+<!-- status: done -->
 ---
 **Goal**: Fix two persistent shell regressions that surfaced after v0.12.4.1:
 ---
@@ -4601,6 +4657,7 @@ The submit workflow has three abstract stages, each mapped by the adapter:
 ---
 2. [x] **Follow-up context injection**: Inject PR review comments, CI failure logs, and the original draft summary into CLAUDE.md so the agent knows exactly what to fix.
 ### v0.12.8 — Alpha Bug-Fixes: Discord Notification Flood Hardening & Draft CLI Disconnect
+<!-- status: done -->
 ---
 [plugins.discord]
 ---
@@ -4762,6 +4819,7 @@ The trust model stays the same: daemon detects and diagnoses, agent proposes cor
 ---
 ---
 ### v0.13.1.1 — Power & Sleep Management
+<!-- status: done -->
 ---
 **Goal**: Make the daemon behave correctly when the host machine sleeps or enters low-power mode. Prevents idle sleep during active goals, detects wake events, suppresses false heartbeat alerts in the grace window, and checks API connectivity after waking.
 ---
@@ -4780,6 +4838,7 @@ The trust model stays the same: daemon detects and diagnoses, agent proposes cor
 ---
 ---
 ### v0.13.1.2 — Release Completeness & Cross-Platform Launch Fix
+<!-- status: done -->
 ---
 **Goal**: Fix two classes of critical bugs: (1) release binaries non-functional out of the box because `ta-daemon` is missing, and (2) `ta draft apply` silently succeeds when PR creation fails, leaving the user with a pushed branch and no PR and no clear recovery path.
 ---
@@ -4819,6 +4878,7 @@ The trust model stays the same: daemon detects and diagnoses, agent proposes cor
 ---
    - `fn protected_submit_targets(&self) -> Vec<String>` — adapter declares its protected refs. Default: `vec![]`.
 ### v0.13.1.3 — Shell Help & UX Polish
+<!-- status: done -->
 ---
 ---
    - `fn verify_not_on_protected_target(&self) -> Result<()>` — asserts post-`prepare()` invariant. Default impl: if `protected_submit_targets()` is non-empty, query the adapter's current position and return `Err` if it matches. Adapters may override.
@@ -4835,6 +4895,7 @@ The trust model stays the same: daemon detects and diagnoses, agent proposes cor
 ---
 ---
 ### v0.13.1.4 — Game Engine Project Templates
+<!-- status: done -->
 ---
 ---
 ---
@@ -4867,6 +4928,7 @@ The trust model stays the same: daemon detects and diagnoses, agent proposes cor
 ---
 ---
 ### v0.13.1.5 — Shell Regression Fixes
+<!-- status: done -->
 ---
 ---
 ---
@@ -4894,6 +4956,7 @@ The trust model stays the same: daemon detects and diagnoses, agent proposes cor
 ---
 3. **No process health in goal status**: `ta goal list` and `ta goal status` show lifecycle state but not process health. A goal in `running` state whose process exited 30 minutes ago looks identical to one actively producing output.
 ### v0.13.1.6 — Intelligent Surface & Operational Runbooks
+<!-- status: done -->
 ---
 ---
 ---
@@ -4933,6 +4996,7 @@ The trust model stays the same: daemon detects and diagnoses, agent proposes cor
 **Goal**: Close two remaining rough edges discovered during public-alpha testing that are annoying enough to fix before beta.
 **Tests added**: 1 new integration test (`apply_with_plan_phase_does_not_dirty_tree_before_branch_checkout` in `draft.rs`). All 589 ta-cli tests pass.
 ### v0.13.1 — Autonomous Operations & Self-Healing Daemon
+<!-- status: done -->
 
 #### Known issue discovered post-merge
 **Goal**: Shift from "user runs commands to inspect and fix problems" to "daemon detects, diagnoses, and proposes fixes — user approves." The v0.11.3 observability commands become the foundation, but instead of the user running `ta goal inspect` and `ta doctor` manually, the daemon runs them continuously and surfaces issues proactively. The user's primary interaction becomes reviewing and approving corrective actions, not discovering and diagnosing problems.
@@ -4943,6 +5007,7 @@ Audit all `push_output`, `push_heartbeat`, and `agent_output.push` call sites to
 ---
 ---
 ### v0.13.2 — MCP Transport Abstraction (TCP/Unix Socket)
+<!-- status: done -->
 ---
 <!-- beta: yes — enables container isolation and remote agent execution for team deployments -->
 **Goal**: Abstract MCP transport so agents can communicate with TA over TCP or Unix sockets, not just stdio pipes. Critical enabler for container-based isolation (Secure Autonomy) and remote agent execution.
@@ -4980,6 +5045,7 @@ These items integrate with the per-project validation commands defined in `const
 ---
 ---
 ### v0.13.3 — Runtime Adapter Trait
+<!-- status: done -->
 ---
 <!-- beta: yes — prerequisite for local model support (v0.13.8) -->
 **Goal**: Abstract how TA spawns and manages agent processes. Today it's hardcoded as a bare child process. A `RuntimeAdapter` trait enables container, VM, and remote execution backends — TA provides BareProcess, Secure Autonomy provides OCI/VM.
@@ -5056,6 +5122,7 @@ auto_approve_reads = true  # SELECT is fine, INSERT/UPDATE/DELETE needs review
 ---
 ---
 ### v0.13.5 — Database Proxy Plugins
+<!-- status: done -->
 
 **Goal**: Plugin-based database proxies that intercept agent DB operations. The agent connects to a local proxy thinking it's a real database; TA captures every query, enforces read/write policies, and logs mutations for review. Plugins provide wire protocol implementations; TA provides the governance framework (v0.13.4).
 ---
@@ -5243,6 +5310,7 @@ on_failure = "block"
 ---
 ---
 ### v0.13.7 — Goal Workflows: Serial Chains, Parallel Swarms & Office Routing
+<!-- status: done -->
 ---
 #### Critical: Command Output Reliability
 **Goal**: Connect goals to workflows so that *how* a goal executes is configurable per-project, per-department, or per-invocation — not hardcoded into `ta run`. Today every goal is a single agent in a single staging directory. This phase introduces workflow-driven execution: serial phase chains, parallel agent swarms, and a routing layer that maps goals to the right workflow based on project config, department, or explicit flag.
@@ -5335,6 +5403,7 @@ Map departments, project types, or goal categories to default workflows.
 ---
 ---
 ### v0.13.8 — Agent Framework: Pluggable Agent Backends with Shared Memory
+<!-- status: done -->
 ---
 1. [x] **`ta-submit-*` plugin protocol**: Define the JSON-over-stdio protocol for VCS plugins. Messages: `detect` (auto-detect from project), `exclude_patterns`, `save_state`, `restore_state`, `commit`, `push`, `open_review`, `revision_id`. Same request/response structure as channel plugins. → `crates/ta-submit/src/vcs_plugin_protocol.rs`
 <!-- beta: yes — foundational for local models, multi-agent workflows, and community sharing -->
@@ -5484,6 +5553,7 @@ ta run "fix the login bug" --agent qwen-coder   # goal-level override
 ---
 ---
 ### v0.13.9 — Product Constitution Framework
+<!-- status: done -->
 ---
 <!-- beta: yes — project-level behavioral contracts and release governance -->
 **Goal**: Make the constitution a first-class, configurable artifact that downstream projects declare, extend, and enforce — not a TA-internal concept hard-wired to `docs/TA-CONSTITUTION.md`. A project using TA can define its own invariants (what functions inject, what functions restore, what the rules are), and TA's draft-build scan and release checklist gate read from that config.
@@ -5584,8 +5654,10 @@ on_failure = "ask_follow_up"  # propose a follow-up goal (pairs with v0.13.1 aut
 ---
 ---
 ### v0.12.3 — Shell Multi-Agent UX & Resilience
+<!-- status: done -->
 ---
 ### v0.13.10 — Feature Velocity Stats & Outcome Telemetry
+<!-- status: done -->
 ---
 <!-- beta: yes — enterprise observability -->
 ---
@@ -5676,6 +5748,7 @@ Today's TA workflow requires the user to be the monitoring layer: notice somethi
 ---
 15. [-] **`ta status` as the one command**: → Moved to v0.13.1.6 (item 1, done).
 ### v0.13.11 — Platform Installers (macOS DMG, Windows MSI)
+<!-- status: done -->
 ---
 <!-- beta: yes — first-class installation experience for non-developer users -->
 **Goal**: Replace bare `.tar.gz`/`.zip` downloads with proper platform installers. macOS gets a signed pkg/DMG. Windows gets an MSI with PATH registration. Eliminates the "extract and manually place binary" step for non-developer users and team rollouts.
@@ -5749,9 +5822,11 @@ allowed_domains = ["api.stripe.com", "api.github.com"]
 #### Version: `0.13.4-alpha`
 #### Version: `0.13.11-alpha`
 ### v0.13.6 — Community Knowledge Hub Plugin (Context Hub Integration)
+<!-- status: done -->
 ---
 2. [x] **MCP tool API**: All 5 tools implemented in `plugins/ta-community-hub/src/main.rs`:
 ### v0.13.12 — Beta Bug Bash & Polish
+<!-- status: done -->
 ---
 **Goal**: Catch and fix accumulated polish debt, false positives, and deferred UX items from the v0.13.1.x sub-phases before advancing to the deeper v0.13.2+ infrastructure phases. No new features — only fixes, observability improvements, and cleanup.
    - `community_suggest { title, content, intent, resource, workspace_path }` — stages new doc proposal to `.ta/community-staging/<resource>/suggestions/`.
@@ -5818,6 +5893,7 @@ allowed_domains = ["api.stripe.com", "api.github.com"]
 ---
 #### Deferred items resolved
 ### v0.13.13 — VCS-Aware Team Setup, Project Sharing & Large-Workspace Staging
+<!-- status: done -->
 
 <!-- beta: yes — foundational for team adoption and game/media project support -->
 **Goal**: Make TA a first-class citizen in any VCS-managed project by (1) formalising which `.ta/` files are shared configuration vs local runtime state, (2) generating correct VCS ignore rules automatically for Git and Perforce, and (3) making staging fast enough for large game and media projects by replacing full copies with symlink-based partial staging and ReFS CoW cloning on Windows.
@@ -5878,6 +5954,7 @@ allowed_domains = ["api.stripe.com", "api.github.com"]
 ---
 ---
 ### v0.13.14 — Watchdog/Exit-Handler Race & Goal Recovery
+<!-- status: done -->
 ---
 <!-- beta: yes — critical correctness fix; goal state machine must be reliable for all users -->
 **Goal**: Fix three related bugs where a long-running goal (10+ hours) is incorrectly marked `failed` on clean agent exit, add the `finalizing` lifecycle state to close the race window, and introduce `ta goal recover` for human-driven recovery when state goes wrong.
@@ -5943,6 +6020,7 @@ When goal state is wrong (e.g., `failed` but draft was created, `running` with d
 ---
 ---
 ### v0.13.15 — Fix Pass, Cross-Language Onboarding & Constitution Completion
+<!-- status: done -->
 ---
 --- Phase Run Summary ---
 <!-- beta: yes — correctness fixes + unlocking non-Rust project support -->
@@ -10182,6 +10260,7 @@ Phases may include a `#### Human Review` subsection (4th-level heading). Items u
 
 
 ### v0.15.X — Some Phase <!-- status: done -->
+<!-- status: done -->
 
 #### Items
 - [x] Agent writes code

--- a/apps/ta-cli/src/commands/governed_workflow.rs
+++ b/apps/ta-cli/src/commands/governed_workflow.rs
@@ -1027,6 +1027,9 @@ pub struct RunOptions<'a> {
     pub plan_phase: Option<&'a str>,
     /// Sub-workflow recursion depth. 0 = top-level. Hard limit: 5 (v0.15.13).
     pub depth: u32,
+    /// Resolved `--param key=value` pairs from the CLI (v0.15.23+).
+    /// Used to thread template params (e.g. phase_filter) into stage executors.
+    pub params: std::collections::HashMap<String, String>,
 }
 
 // ── Template interpolation & condition evaluation (v0.15.13) ─────────────────
@@ -1277,15 +1280,29 @@ pub fn run_governed_workflow(opts: &RunOptions) -> anyhow::Result<()> {
         // For loop workflows: call `ta plan next` once to show what would run first.
         if has_goto {
             println!();
-            println!("Next phase preview (calls `ta plan next`):");
+            // Resolve phase_filter from stage defs or top-level params.
+            let dry_run_filter = def
+                .stages
+                .iter()
+                .find_map(|s| s.phase_filter.as_deref())
+                .or_else(|| opts.params.get("phase_filter").map(|s| s.as_str()));
+            let filter_msg = dry_run_filter
+                .map(|f| format!(" --filter {}", f))
+                .unwrap_or_default();
+            println!("Next phase preview (calls `ta plan next{}`):", filter_msg);
+            let mut preview_args = vec![
+                "--project-root".to_string(),
+                opts.workspace_root.to_string_lossy().to_string(),
+                "plan".to_string(),
+                "next".to_string(),
+                "--no-version-check".to_string(),
+            ];
+            if let Some(f) = dry_run_filter {
+                preview_args.push("--filter".to_string());
+                preview_args.push(f.to_string());
+            }
             let output = std::process::Command::new("ta")
-                .args([
-                    "--project-root",
-                    &opts.workspace_root.to_string_lossy(),
-                    "plan",
-                    "next",
-                    "--no-version-check",
-                ])
+                .args(&preview_args)
                 .output();
             match output {
                 Ok(o) if o.status.success() => {
@@ -1693,9 +1710,13 @@ fn stage_plan_next(
     opts: &RunOptions,
 ) -> anyhow::Result<Option<String>> {
     let stage_name = &stage_def.name;
-    let filter_msg = stage_def
+    // Resolve phase_filter: stage YAML field takes priority; fall back to
+    // --param phase_filter=<value> passed on the CLI (v0.15.23+).
+    let effective_filter = stage_def
         .phase_filter
         .as_deref()
+        .or_else(|| opts.params.get("phase_filter").map(|s| s.as_str()));
+    let filter_msg = effective_filter
         .map(|f| format!(" --filter {}", f))
         .unwrap_or_default();
     println!("  Running: ta plan next{}", filter_msg);
@@ -1707,9 +1728,9 @@ fn stage_plan_next(
         "next".to_string(),
         "--no-version-check".to_string(),
     ];
-    if let Some(ref prefix) = stage_def.phase_filter {
+    if let Some(prefix) = effective_filter {
         args.push("--filter".to_string());
-        args.push(prefix.clone());
+        args.push(prefix.to_string());
     }
 
     let output = std::process::Command::new("ta")
@@ -2520,6 +2541,7 @@ fn stage_run_subworkflow(
         agent: opts.agent,
         plan_phase: child_phase.as_deref(),
         depth: opts.depth + 1,
+        params: opts.params.clone(),
     };
 
     // We need to capture the child run ID. Run the child workflow, then find
@@ -4071,6 +4093,7 @@ mod tests {
             agent: "claude-code",
             plan_phase: None,
             depth: 0,
+            params: Default::default(),
         };
         // dry_run=true validates the stage graph without executing agents.
         let result = run_governed_workflow(&opts);
@@ -4099,6 +4122,7 @@ mod tests {
             agent: "claude-code",
             plan_phase: None,
             depth: 0,
+            params: Default::default(),
         };
         // dry_run should succeed and print the graph.
         run_governed_workflow(&opts).unwrap();
@@ -4119,6 +4143,7 @@ mod tests {
             agent: "claude-code",
             plan_phase: Some("v0.4.0"),
             depth: 0,
+            params: Default::default(),
         };
         // plan_phase is visible on the options; the dry-run path would print it.
         assert_eq!(opts.plan_phase, Some("v0.4.0"));
@@ -4138,6 +4163,7 @@ mod tests {
             agent: "claude-code",
             plan_phase: None,
             depth: 0,
+            params: Default::default(),
         };
         assert!(opts.plan_phase.is_none());
     }
@@ -4555,6 +4581,7 @@ kind = "plan_next"
             agent: "claude-code",
             plan_phase: None,
             depth: 0,
+            params: Default::default(),
         };
         // Should succeed (dry-run doesn't execute anything).
         run_governed_workflow(&opts).unwrap();
@@ -4694,6 +4721,7 @@ kind = "static_analysis"
             agent: "claude-code",
             plan_phase: None,
             depth: 0,
+            params: Default::default(),
         };
 
         let result = stage_aggregate_draft(&mut run, &stage_def, &opts).unwrap();
@@ -4756,6 +4784,7 @@ kind = "static_analysis"
             agent: "claude-code",
             plan_phase: None,
             depth: 0,
+            params: Default::default(),
         };
 
         stage_aggregate_draft(&mut run, &stage_def, &opts).unwrap();
@@ -5001,6 +5030,7 @@ kind = "apply_draft"
             agent: "claude-code",
             plan_phase: None,
             depth: 0,
+            params: Default::default(),
         };
         let result = stage_consensus(&mut run, &stage_def, &opts, &config).unwrap();
         assert!(result.is_some());
@@ -5040,6 +5070,7 @@ kind = "apply_draft"
             agent: "claude-code",
             plan_phase: None,
             depth: 0,
+            params: Default::default(),
         };
         let err = stage_consensus(&mut run, &stage_def, &opts, &config).unwrap_err();
         assert!(err.to_string().contains("BLOCKED"));
@@ -5062,6 +5093,7 @@ kind = "apply_draft"
             agent: "claude-code",
             plan_phase: None,
             depth: 0,
+            params: Default::default(),
         };
         // With 1 timed-out reviewer (score=0.0), proceed=false → BLOCKED
         let err = stage_consensus(&mut run, &stage_def, &opts, &config).unwrap_err();
@@ -5243,6 +5275,7 @@ stages:
             agent: "claude-code",
             plan_phase: None,
             depth: 0,
+            params: Default::default(),
         };
         // Dry-run should succeed without invoking any external commands.
         run_governed_workflow(&opts).unwrap();

--- a/apps/ta-cli/src/commands/governed_workflow.rs
+++ b/apps/ta-cli/src/commands/governed_workflow.rs
@@ -4532,6 +4532,7 @@ kind = "plan_next"
             agent: "claude-code",
             plan_phase: None,
             depth: 6, // exceeds MAX_DEPTH = 5
+            params: Default::default(),
         };
         let err = run_governed_workflow(&opts).unwrap_err();
         assert!(

--- a/apps/ta-cli/src/commands/workflow.rs
+++ b/apps/ta-cli/src/commands/workflow.rs
@@ -261,6 +261,13 @@ pub fn execute(command: &WorkflowCommands, config: &GatewayConfig) -> anyhow::Re
                     name
                 )
             })?;
+            // Parse --param key=value pairs into a map for governed workflow stages.
+            let mut param_map = std::collections::HashMap::new();
+            for pair in params.iter() {
+                if let Some((k, v)) = pair.split_once('=') {
+                    param_map.insert(k.to_string(), v.to_string());
+                }
+            }
             let opts = RunOptions {
                 workspace_root: &config.workspace_root,
                 workflow_name: name,
@@ -270,6 +277,7 @@ pub fn execute(command: &WorkflowCommands, config: &GatewayConfig) -> anyhow::Re
                 agent,
                 plan_phase: phase.as_deref(),
                 depth: 0,
+                params: param_map,
             };
             governed_workflow::run_governed_workflow(&opts)
         }


### PR DESCRIPTION
## Summary
- `ta workflow run plan-build-phases --param phase_filter=v0.15` was picking v0.9.0 instead of v0.15.24 — two root causes fixed

**PLAN.md**: Added `<!-- status: done -->` to 79 phases (v0.9.0–v0.14.x) that completed before status markers were introduced. These phases were being reported as pending, so `ta plan next` without `--filter` returned v0.9.0.

Why fixes "never stick": `ta draft apply` copies PLAN.md from staging snapshots taken before the marker commits. Committing the markers to main ensures all future staging copies inherit them.

**Code** (`RunOptions` + `stage_plan_next`): `--param phase_filter=v0.15` is now threaded into the governed workflow's `plan_next`/`loop_next` stage executors. Precedence: stage YAML `phase_filter` field > CLI `--param phase_filter`. Dry-run preview also applies the filter. params propagate to child sub-workflows.

## Test plan
- `ta workflow run plan-build-phases --param phase_filter=v0.15 --dry-run` → `ta plan next --filter v0.15` → `v0.15.24`
- `ta plan next` (no filter) → `v0.15.24` (v0.9.0–v0.14.x all now have `<!-- status: done -->`)
- `cargo clippy -p ta-cli -- -D warnings` passes
- `cargo fmt --all -- --check` passes