### PR TITLE
fix(windows): delay-load ProjectedFSLib.dll — fix startup crash without Client-ProjFS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ All outcomes must be **observable** (with details and logging) and **actionable*
 
 ## Current State
 
-**Current version**: `0.15.30-alpha.2`
+**Current version**: `0.15.30-alpha.2.1`
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --phase 4b`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "ta-actions"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "ta-agent-ollama"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "ta-build"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-comfyui"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -3485,7 +3485,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3548,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unity"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unreal"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-overlay"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-proxy"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3686,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-proxy-sqlite"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "ta-extension"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "regex",
@@ -3785,7 +3785,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "glob",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "ta-output-schema"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3830,7 +3830,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "glob",
@@ -3845,7 +3845,7 @@ dependencies = [
 
 [[package]]
 name = "ta-runtime"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "libc",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 dependencies = [
  "chrono",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.15.30-alpha.2"
+version = "0.15.30-alpha.2.1"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -7402,6 +7402,18 @@ pub enum NoteDelivery {
 #### Version: `0.15.30-alpha.2`
 
 ---
+### v0.15.30.2.1 — Windows: Delay-load ProjectedFSLib.dll to fix startup crash
+<!-- status: done -->
+
+**Goal**: Fix the Windows binary crashing on startup with "projectedfs.dll not found" on machines without the `Client-ProjFS` optional Windows feature.
+
+**Why**: The `windows` crate's `Win32_Storage_ProjectedFileSystem` feature adds `ProjectedFSLib.dll` to the binary's static import table. The OS loader rejects the binary at startup on machines where `Client-ProjFS` is not installed — before `is_projfs_available()` can run its graceful fallback. The release was demoted from Latest and rolled back to `public-alpha-v0.15.15.1.1` pending this fix.
+
+1. [x] **Add `build.rs` with `/DELAYLOAD:ProjectedFSLib.dll`**: On Windows MSVC targets, emit `cargo:rustc-link-arg=/DELAYLOAD:ProjectedFSLib.dll` and `cargo:rustc-link-lib=delayimp`. Delay-loading shifts DLL resolution from process startup to first call site — combined with the `is_projfs_available()` check, the DLL is never needed on machines without ProjFS.
+
+#### Version: `0.15.30-alpha.2.1`
+
+---
 ### v0.15.30.3 — `ta init` Template: Pragma Game Services Backend (Kotlin/BMAD)
 <!-- status: pending -->
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -42,26 +42,26 @@ which = { workspace = true }
 arboard = { workspace = true }
 
 # Internal crates — version kept in sync with workspace by bump-version.sh
-ta-audit = { path = "../../crates/ta-audit", version = "0.15.30-alpha.2" }
-ta-credentials = { path = "../../crates/ta-credentials", version = "0.15.30-alpha.2" }
-ta-memory = { path = "../../crates/ta-memory", version = "0.15.30-alpha.2" }
-ta-changeset = { path = "../../crates/ta-changeset", version = "0.15.30-alpha.2" }
-ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.15.30-alpha.2" }
-ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.15.30-alpha.2" }
-ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.15.30-alpha.2" }
-ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.15.30-alpha.2" }
-ta-goal = { path = "../../crates/ta-goal", version = "0.15.30-alpha.2" }
-ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.15.30-alpha.2" }
-ta-policy = { path = "../../crates/ta-policy", version = "0.15.30-alpha.2" }
-ta-mediation = { path = "../../crates/ta-mediation", version = "0.15.30-alpha.2" }
-ta-session = { path = "../../crates/ta-session", version = "0.15.30-alpha.2" }
-ta-events = { path = "../../crates/ta-events", version = "0.15.30-alpha.2" }
-ta-submit = { path = "../../crates/ta-submit", version = "0.15.30-alpha.2" }
-ta-workspace = { path = "../../crates/ta-workspace", version = "0.15.30-alpha.2" }
-ta-workflow = { path = "../../crates/ta-workflow", version = "0.15.30-alpha.2" }
-ta-build = { path = "../../crates/ta-build", version = "0.15.30-alpha.2" }
-ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.15.30-alpha.2" }
-ta-runtime = { path = "../../crates/ta-runtime", version = "0.15.30-alpha.2" }
+ta-audit = { path = "../../crates/ta-audit", version = "0.15.30-alpha.2.1" }
+ta-credentials = { path = "../../crates/ta-credentials", version = "0.15.30-alpha.2.1" }
+ta-memory = { path = "../../crates/ta-memory", version = "0.15.30-alpha.2.1" }
+ta-changeset = { path = "../../crates/ta-changeset", version = "0.15.30-alpha.2.1" }
+ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.15.30-alpha.2.1" }
+ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.15.30-alpha.2.1" }
+ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.15.30-alpha.2.1" }
+ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.15.30-alpha.2.1" }
+ta-goal = { path = "../../crates/ta-goal", version = "0.15.30-alpha.2.1" }
+ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.15.30-alpha.2.1" }
+ta-policy = { path = "../../crates/ta-policy", version = "0.15.30-alpha.2.1" }
+ta-mediation = { path = "../../crates/ta-mediation", version = "0.15.30-alpha.2.1" }
+ta-session = { path = "../../crates/ta-session", version = "0.15.30-alpha.2.1" }
+ta-events = { path = "../../crates/ta-events", version = "0.15.30-alpha.2.1" }
+ta-submit = { path = "../../crates/ta-submit", version = "0.15.30-alpha.2.1" }
+ta-workspace = { path = "../../crates/ta-workspace", version = "0.15.30-alpha.2.1" }
+ta-workflow = { path = "../../crates/ta-workflow", version = "0.15.30-alpha.2.1" }
+ta-build = { path = "../../crates/ta-build", version = "0.15.30-alpha.2.1" }
+ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.15.30-alpha.2.1" }
+ta-runtime = { path = "../../crates/ta-runtime", version = "0.15.30-alpha.2.1" }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/crates/ta-connectors/comfyui/Cargo.toml
+++ b/crates/ta-connectors/comfyui/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.15.30-alpha.2" }
+ta-changeset = { path = "../../ta-changeset", version = "0.15.30-alpha.2.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/discord/Cargo.toml
+++ b/crates/ta-connectors/discord/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.15.30-alpha.2" }
+ta-events = { path = "../../ta-events", version = "0.15.30-alpha.2.1" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/email/Cargo.toml
+++ b/crates/ta-connectors/email/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.15.30-alpha.2" }
+ta-events = { path = "../../ta-events", version = "0.15.30-alpha.2.1" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/fs/Cargo.toml
+++ b/crates/ta-connectors/fs/Cargo.toml
@@ -16,10 +16,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.15.30-alpha.2" }
-ta-workspace = { path = "../../ta-workspace", version = "0.15.30-alpha.2" }
-ta-audit = { path = "../../ta-audit", version = "0.15.30-alpha.2" }
+ta-changeset = { path = "../../ta-changeset", version = "0.15.30-alpha.2.1" }
+ta-workspace = { path = "../../ta-workspace", version = "0.15.30-alpha.2.1" }
+ta-audit = { path = "../../ta-audit", version = "0.15.30-alpha.2.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-ta-policy = { path = "../../ta-policy", version = "0.15.30-alpha.2" }
+ta-policy = { path = "../../ta-policy", version = "0.15.30-alpha.2.1" }

--- a/crates/ta-connectors/slack/Cargo.toml
+++ b/crates/ta-connectors/slack/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.15.30-alpha.2" }
+ta-events = { path = "../../ta-events", version = "0.15.30-alpha.2.1" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/unreal/Cargo.toml
+++ b/crates/ta-connectors/unreal/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.15.30-alpha.2" }
+ta-changeset = { path = "../../ta-changeset", version = "0.15.30-alpha.2.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -31,20 +31,20 @@ async-stream = { workspace = true }
 sha2 = { workspace = true }
 
 # Internal crates
-ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.15.30-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2" }
-ta-memory = { path = "../ta-memory", version = "0.15.30-alpha.2" }
-ta-events = { path = "../ta-events", version = "0.15.30-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.15.30-alpha.2" }
-ta-runtime = { path = "../ta-runtime", version = "0.15.30-alpha.2" }
-ta-audit = { path = "../ta-audit", version = "0.15.30-alpha.2" }
-ta-policy = { path = "../ta-policy", version = "0.15.30-alpha.2" }
-ta-connector-slack = { path = "../ta-connectors/slack", version = "0.15.30-alpha.2" }
-ta-connector-email = { path = "../ta-connectors/email", version = "0.15.30-alpha.2" }
+ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.15.30-alpha.2.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2.1" }
+ta-memory = { path = "../ta-memory", version = "0.15.30-alpha.2.1" }
+ta-events = { path = "../ta-events", version = "0.15.30-alpha.2.1" }
+ta-goal = { path = "../ta-goal", version = "0.15.30-alpha.2.1" }
+ta-runtime = { path = "../ta-runtime", version = "0.15.30-alpha.2.1" }
+ta-audit = { path = "../ta-audit", version = "0.15.30-alpha.2.1" }
+ta-policy = { path = "../ta-policy", version = "0.15.30-alpha.2.1" }
+ta-connector-slack = { path = "../ta-connectors/slack", version = "0.15.30-alpha.2.1" }
+ta-connector-email = { path = "../ta-connectors/email", version = "0.15.30-alpha.2.1" }
 reqwest = { workspace = true }
-ta-output-schema = { path = "../ta-output-schema", version = "0.15.30-alpha.2" }
-ta-extension = { path = "../ta-extension", version = "0.15.30-alpha.2" }
-ta-session = { path = "../ta-session", version = "0.15.30-alpha.2" }
+ta-output-schema = { path = "../ta-output-schema", version = "0.15.30-alpha.2.1" }
+ta-extension = { path = "../ta-extension", version = "0.15.30-alpha.2.1" }
+ta-session = { path = "../ta-session", version = "0.15.30-alpha.2.1" }
 which = "7"
 libc = { workspace = true }
 async-trait = "0.1"

--- a/crates/ta-db-proxy-sqlite/Cargo.toml
+++ b/crates/ta-db-proxy-sqlite/Cargo.toml
@@ -18,8 +18,8 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 rusqlite = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.15.30-alpha.2" }
-ta-db-proxy = { path = "../ta-db-proxy", version = "0.15.30-alpha.2" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.15.30-alpha.2.1" }
+ta-db-proxy = { path = "../ta-db-proxy", version = "0.15.30-alpha.2.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-db-proxy/Cargo.toml
+++ b/crates/ta-db-proxy/Cargo.toml
@@ -17,4 +17,4 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.15.30-alpha.2" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.15.30-alpha.2.1" }

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -23,20 +23,20 @@ tokio = { workspace = true }
 regex = { workspace = true }
 
 # Internal crates
-ta-audit = { path = "../ta-audit", version = "0.15.30-alpha.2" }
-ta-events = { path = "../ta-events", version = "0.15.30-alpha.2" }
-ta-memory = { path = "../ta-memory", version = "0.15.30-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2" }
-ta-connector-fs = { path = "../ta-connectors/fs", version = "0.15.30-alpha.2" }
-ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.15.30-alpha.2" }
-ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.15.30-alpha.2" }
-ta-connector-unity = { path = "../ta-connectors/unity", version = "0.15.30-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.15.30-alpha.2" }
-ta-policy = { path = "../ta-policy", version = "0.15.30-alpha.2" }
-ta-workspace = { path = "../ta-workspace", version = "0.15.30-alpha.2" }
-ta-workflow = { path = "../ta-workflow", version = "0.15.30-alpha.2" }
-ta-actions = { path = "../ta-actions", version = "0.15.30-alpha.2" }
-ta-submit = { path = "../ta-submit", version = "0.15.30-alpha.2" }
+ta-audit = { path = "../ta-audit", version = "0.15.30-alpha.2.1" }
+ta-events = { path = "../ta-events", version = "0.15.30-alpha.2.1" }
+ta-memory = { path = "../ta-memory", version = "0.15.30-alpha.2.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2.1" }
+ta-connector-fs = { path = "../ta-connectors/fs", version = "0.15.30-alpha.2.1" }
+ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.15.30-alpha.2.1" }
+ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.15.30-alpha.2.1" }
+ta-connector-unity = { path = "../ta-connectors/unity", version = "0.15.30-alpha.2.1" }
+ta-goal = { path = "../ta-goal", version = "0.15.30-alpha.2.1" }
+ta-policy = { path = "../ta-policy", version = "0.15.30-alpha.2.1" }
+ta-workspace = { path = "../ta-workspace", version = "0.15.30-alpha.2.1" }
+ta-workflow = { path = "../ta-workflow", version = "0.15.30-alpha.2.1" }
+ta-actions = { path = "../ta-actions", version = "0.15.30-alpha.2.1" }
+ta-submit = { path = "../ta-submit", version = "0.15.30-alpha.2.1" }
 
 
 [dev-dependencies]

--- a/crates/ta-mediation/Cargo.toml
+++ b/crates/ta-mediation/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates for FsMediator
-ta-workspace = { path = "../ta-workspace", version = "0.15.30-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2" }
+ta-workspace = { path = "../ta-workspace", version = "0.15.30-alpha.2.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-runtime/Cargo.toml
+++ b/crates/ta-runtime/Cargo.toml
@@ -23,7 +23,7 @@ which = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
 
-ta-credentials = { path = "../ta-credentials", version = "0.15.30-alpha.2" }
+ta-credentials = { path = "../ta-credentials", version = "0.15.30-alpha.2.1" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }
-ta-policy = { path = "../ta-policy", version = "0.15.30-alpha.2" }
+ta-policy = { path = "../ta-policy", version = "0.15.30-alpha.2.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-session/Cargo.toml
+++ b/crates/ta-session/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates
-ta-goal = { path = "../ta-goal", version = "0.15.30-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.15.30-alpha.2.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -16,8 +16,8 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.15.30-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2.1" }
+ta-goal = { path = "../ta-goal", version = "0.15.30-alpha.2.1" }
 toml = "0.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/ta-workflow/Cargo.toml
+++ b/crates/ta-workflow/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -17,7 +17,7 @@ uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = "0.10"
-ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.15.30-alpha.2.1" }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/ta-workspace/build.rs
+++ b/crates/ta-workspace/build.rs
@@ -1,0 +1,24 @@
+// build.rs — ta-workspace build script.
+//
+// On Windows MSVC, delay-load ProjectedFSLib.dll so the binary starts
+// successfully on machines where the Windows "Client-ProjFS" optional feature
+// is not installed. Without delay-loading, the OS loader rejects the binary
+// at startup because the DLL is absent from System32 — even though TA falls
+// back to a non-ProjFS strategy at runtime.
+//
+// With delay-loading:
+//   1. Binary starts on all Windows machines.
+//   2. is_projfs_available() probes for the DLL at runtime.
+//   3. If unavailable, TA uses the copy-based workspace strategy.
+//   4. PrjStartVirtualizing / PrjStopVirtualizing are never called, so the
+//      delay-load resolver never needs to touch ProjectedFSLib.dll.
+
+fn main() {
+    #[cfg(all(target_os = "windows", target_env = "msvc"))]
+    {
+        // Delay-load ProjectedFSLib.dll — resolves symbols lazily at first call,
+        // not at process startup. Requires delayimp.lib (ships with MSVC).
+        println!("cargo:rustc-link-arg=/DELAYLOAD:ProjectedFSLib.dll");
+        println!("cargo:rustc-link-lib=delayimp");
+    }
+}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: 0.15.30-alpha
+**Version**: 0.15.30-alpha.2.1
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 


### PR DESCRIPTION
## Summary
- Windows binary crashes at startup with "projectedfs.dll not found" on machines where the `Client-ProjFS` Windows optional feature is not installed
- Root cause: `windows` crate's `Win32_Storage_ProjectedFileSystem` adds `ProjectedFSLib.dll` to the static import table — OS loader rejects the binary before any code runs
- Fix: `build.rs` in `ta-workspace` emits `/DELAYLOAD:ProjectedFSLib.dll` + `delayimp.lib` on Windows MSVC, shifting resolution to first call site
- With delay-loading, `is_projfs_available()` runs its graceful `LoadLibraryW` check; if ProjFS is absent, TA falls back to copy-based strategy and never touches the DLL
- Bumped to `0.15.30-alpha.2.1`
- `public-alpha-v0.15.30.2` demoted to prerelease; `public-alpha-v0.15.15.1.1` restored as Latest

## Test plan
- [ ] CI passes (Windows build is the key check)
- [ ] Windows binary starts on a machine without `Client-ProjFS` enabled
- [ ] `ta status` works on Windows without ProjFS
- [ ] `ta status` with ProjFS enabled still uses ProjFS strategy

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)