### PR TITLE
fix: gate ProjFS behind projfs Cargo feature (eliminates ProjectedFSLib.dll import)

### DIFF
--- a/apps/ta-cli/build.rs
+++ b/apps/ta-cli/build.rs
@@ -15,16 +15,6 @@
 use std::process::Command;
 
 fn main() {
-    // Delay-load ProjectedFSLib.dll so ta.exe starts on machines without the
-    // Windows "Client-ProjFS" optional feature. The /DELAYLOAD flag must be on
-    // the final binary's link step — cargo:rustc-link-arg is NOT propagated
-    // from dependency (ta-workspace) build scripts to reverse dependents.
-    #[cfg(all(target_os = "windows", target_env = "msvc"))]
-    {
-        println!("cargo:rustc-link-arg=/DELAYLOAD:ProjectedFSLib.dll");
-        println!("cargo:rustc-link-lib=delayimp");
-    }
-
     // Windows icon embedding (v0.10.18.7).
     #[cfg(windows)]
     {

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -23,9 +23,18 @@ tempfile = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { workspace = true }
 
+[features]
+# Enable Windows Projected File System (ProjFS) virtual workspace support.
+# Activating this feature adds Win32_Storage_ProjectedFileSystem to the
+# windows crate, which causes ProjectedFSLib.dll to appear in the binary's
+# import table. Release binaries are built WITHOUT this feature so that
+# ta.exe starts on all Windows machines regardless of ProjFS installation.
+# Users with Client-ProjFS installed get automatic fallback to copy-based
+# staging when this feature is absent.
+projfs = ["windows/Win32_Storage_ProjectedFileSystem"]
+
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58", features = [
-    "Win32_Storage_ProjectedFileSystem",
     "Win32_Foundation",
     "Win32_System_Registry",
     "Win32_System_LibraryLoader",

--- a/crates/ta-workspace/src/overlay.rs
+++ b/crates/ta-workspace/src/overlay.rs
@@ -229,7 +229,7 @@ pub struct OverlayWorkspace {
     /// Must outlive the workspace root directory. `None` on non-Windows or
     /// when ProjFS mode is not in use. Held for RAII drop — intentionally
     /// not read after construction.
-    #[cfg(target_os = "windows")]
+    #[cfg(all(target_os = "windows", feature = "projfs"))]
     #[allow(dead_code)]
     projfs_provider: Option<crate::projfs_strategy::ProjFsProvider>,
 }
@@ -315,8 +315,8 @@ impl OverlayWorkspace {
 
         let mut stat = CopyStat::new(effective_copy_strategy);
 
-        // Track the ProjFS provider (Windows only).
-        #[cfg(target_os = "windows")]
+        // Track the ProjFS provider (Windows + projfs feature only).
+        #[cfg(all(target_os = "windows", feature = "projfs"))]
         let mut projfs_provider: Option<crate::projfs_strategy::ProjFsProvider> = None;
 
         match effective_mode {
@@ -332,7 +332,7 @@ impl OverlayWorkspace {
             }
             OverlayStagingMode::ProjFs => {
                 // Start ProjFS virtualization. No file copying needed.
-                #[cfg(target_os = "windows")]
+                #[cfg(all(target_os = "windows", feature = "projfs"))]
                 {
                     match crate::projfs_strategy::ProjFsProvider::start(&source_dir, &staging_dir) {
                         Ok(provider) => {
@@ -355,10 +355,10 @@ impl OverlayWorkspace {
                         }
                     }
                 }
-                #[cfg(not(target_os = "windows"))]
+                #[cfg(not(all(target_os = "windows", feature = "projfs")))]
                 {
-                    // Should not be reachable: resolve_staging_mode maps ProjFs → Smart
-                    // on non-Windows. This is a safety fallback.
+                    // Not reachable: resolve_staging_mode maps ProjFs → Smart when
+                    // the projfs feature is absent. Safety fallback.
                     copy_dir_recursive_smart(
                         &source_dir,
                         &staging_dir,
@@ -411,7 +411,7 @@ impl OverlayWorkspace {
             excludes,
             source_snapshot: snapshot,
             copy_stat: Some(stat),
-            #[cfg(target_os = "windows")]
+            #[cfg(all(target_os = "windows", feature = "projfs"))]
             projfs_provider,
         })
     }
@@ -430,7 +430,7 @@ impl OverlayWorkspace {
             excludes,
             source_snapshot: None, // Snapshot must be loaded separately if needed.
             copy_stat: None,       // Not available when reopening an existing workspace.
-            #[cfg(target_os = "windows")]
+            #[cfg(all(target_os = "windows", feature = "projfs"))]
             projfs_provider: None, // Not available when reopening an existing workspace.
         }
     }
@@ -1235,17 +1235,27 @@ fn resolve_staging_mode(mode: OverlayStagingMode, _staging_dir: &Path) -> Overla
             }
         }
         OverlayStagingMode::ProjFs => {
-            // ProjFS is Windows-only. On non-Windows always fall back to Smart.
-            if crate::windows_features::is_projfs_available() {
-                OverlayStagingMode::ProjFs
-            } else {
+            // ProjFS requires both the projfs Cargo feature AND Client-ProjFS
+            // installed at runtime. Fall back to Smart in either case.
+            #[cfg(all(target_os = "windows", feature = "projfs"))]
+            {
+                if crate::windows_features::is_projfs_available() {
+                    return OverlayStagingMode::ProjFs;
+                }
                 tracing::info!(
                     "projfs requested but Client-ProjFS is not available — \
                      falling back to smart staging. \
                      Enable with: Dism.exe /Online /Enable-Feature /FeatureName:Client-ProjFS /NoRestart"
                 );
-                OverlayStagingMode::Smart
             }
+            #[cfg(not(all(target_os = "windows", feature = "projfs")))]
+            {
+                tracing::info!(
+                    "projfs requested but this binary was built without the projfs feature — \
+                     falling back to smart staging"
+                );
+            }
+            OverlayStagingMode::Smart
         }
         other => other,
     }

--- a/crates/ta-workspace/src/projfs_strategy.rs
+++ b/crates/ta-workspace/src/projfs_strategy.rs
@@ -43,9 +43,9 @@ pub fn load_deletions(scratch_dir: &Path) -> Vec<DeletionRecord> {
         .collect()
 }
 
-// ── Windows implementation ──────────────────────────────────────────────────
+// ── Windows + projfs-feature implementation ─────────────────────────────────
 
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", feature = "projfs"))]
 mod windows_impl {
     use crate::error::WorkspaceError;
     use std::collections::HashMap;
@@ -535,28 +535,28 @@ mod windows_impl {
     }
 }
 
-// ── Non-Windows stub ────────────────────────────────────────────────────────
+// ── Stub (non-Windows OR Windows without the projfs feature) ────────────────
 
-/// Non-Windows stub for ProjFS provider.
+/// Stub ProjFS provider used when ProjFS is not compiled in.
 ///
-/// On Linux and macOS `ProjFsProvider` is an empty struct that cannot be
-/// constructed via any public API. Callers hold `Option<ProjFsProvider>` which
-/// is always `None` on non-Windows.
-#[cfg(not(target_os = "windows"))]
+/// On Linux, macOS, or Windows builds without the `projfs` feature,
+/// `ProjFsProvider` is an empty struct with no public constructor. Callers
+/// hold `Option<ProjFsProvider>` which is always `None` in this configuration.
+#[cfg(not(all(target_os = "windows", feature = "projfs")))]
 #[derive(Debug)]
 pub struct ProjFsProvider {
     _private: (),
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(all(target_os = "windows", feature = "projfs")))]
 impl ProjFsProvider {
-    // No public constructor on non-Windows.
-    // The overlay module creates None directly without calling any method here.
+    // No public constructor without the projfs feature.
+    // The overlay module sets None directly without calling any method here.
 }
 
 // ── Re-exports ───────────────────────────────────────────────────────────────
 
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", feature = "projfs"))]
 pub use windows_impl::ProjFsProvider;
 
 // ── Cross-platform tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Root cause

`windows` crate 0.58 uses **raw-dylib** linking (via `windows-link`). With raw-dylib, `/DELAYLOAD` linker flags from `build.rs` do **not** apply — rustc generates import table entries directly, bypassing traditional import-lib interception entirely. This is why PRs #439 and #441 both failed: `ta.exe` still had `ProjectedFSLib.dll` in its static import table regardless of where we put the `/DELAYLOAD` flag.

## Fix

Introduce a `projfs` Cargo feature in `ta-workspace`:

```toml
[features]
projfs = ["windows/Win32_Storage_ProjectedFileSystem"]
```

- **Without `projfs`** (release builds): `windows` crate never sees `Win32_Storage_ProjectedFileSystem`, no ProjFS types are referenced, `ProjectedFSLib.dll` is absent from the import table. `ta.exe` starts on all Windows machines.  
- **With `--features projfs`**: full ProjFS virtual workspace support for users with `Client-ProjFS` installed.

All ProjFS code in `projfs_strategy.rs` and `overlay.rs` is gated behind `cfg(all(target_os = "windows", feature = "projfs"))`. Without the feature, `ProjFs` staging mode falls back to `Smart` (copy-based) automatically.

Removes the now-ineffective `/DELAYLOAD` approach from `apps/ta-cli/build.rs`.

## Test plan
- [ ] Windows CI green
- [ ] `ta --version` succeeds on a machine without `Client-ProjFS` (no DLL error)
- [ ] `ta goal start` uses copy-based staging on Windows without ProjFS (expected fallback)
- [ ] Building with `--features ta-workspace/projfs` compiles ProjFS code (existing CI for ProjFS users)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)