### PR TITLE
fix: MSI upgrade silently skips patch releases (same version, ta.exe never replaced)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -211,8 +211,15 @@ jobs:
           # Use a fixed semver for MSI since nightly doesn't have a version tag.
           # Read from Cargo.toml to get current version digits.
           $cargoVersion = (Select-String -Path "Cargo.toml" -Pattern '^version\s*=\s*"([^"]+)"' | Select-Object -First 1).Matches.Groups[1].Value
-          $versionDigits = [regex]::Match($cargoVersion, '(\d+\.\d+\.\d+)').Groups[1].Value
-          $msiVersion = "${versionDigits}.0"
+          $vm = [regex]::Match($cargoVersion, '(\d+)\.(\d+)\.(\d+)')
+          $major = [int]$vm.Groups[1].Value
+          $minor = [int]$vm.Groups[2].Value
+          $patch = [int]$vm.Groups[3].Value
+          $subPatch = 0
+          $sm = [regex]::Match($cargoVersion, '\.(\d+)$')
+          if ($sm.Success) { $subPatch = [int]$sm.Groups[1].Value }
+          $msiPatch = $patch * 100 + $subPatch
+          $msiVersion = "${major}.${minor}.${msiPatch}.0"
           Write-Host "MSI version: $msiVersion (nightly SHA: $ShortSha)"
 
           $env:PATH = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path', 'User')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,16 +175,29 @@ jobs:
           # Pin to v4.x — v5+ requires OSMF EULA acceptance and uses a different schema.
           dotnet tool install --global wix --version "4.*"
 
-          # Extract version digits from any tag format:
-          # "v0.13.12-alpha" → "0.13.12.0"
-          # "public-alpha-v0.13.12" → "0.13.12.0"
-          $versionMatch = [regex]::Match("$env:TAG", 'v?(\d+\.\d+\.\d+)')
-          if (-not $versionMatch.Success) {
+          # Extract MSI version from tag. MSI versions are a.b.c.d; only a.b.c
+          # are used for upgrade comparisons. To ensure patch releases within the
+          # same semver base (e.g. 0.15.30.2.1 through 0.15.30.2.3) produce
+          # distinct MSI versions that trigger file replacement on upgrade, we
+          # encode patch*100 + subpatch into the c field:
+          #   "public-alpha-v0.15.30.2.3" -> major=0, minor=15, patch=30, sub=3
+          #   msiPatch = 30*100 + 3 = 3003  ->  MSI version "0.15.3003.0"
+          # This keeps a.b.c monotonically increasing across all releases.
+          $m = [regex]::Match("$env:TAG", 'v?(\d+)\.(\d+)\.(\d+)')
+          if (-not $m.Success) {
             Write-Error "Could not extract version from tag '$env:TAG' — aborting MSI build"
             exit 1
           }
-          $msiVersion = $versionMatch.Groups[1].Value + ".0"
-          Write-Host "MSI version: $msiVersion (from tag $env:TAG)"
+          $major = [int]$m.Groups[1].Value
+          $minor = [int]$m.Groups[2].Value
+          $patch = [int]$m.Groups[3].Value
+          # Extract trailing sub-patch number (the last .N in the tag, if any)
+          $subPatch = 0
+          $subMatch = [regex]::Match("$env:TAG", '\.(\d+)$')
+          if ($subMatch.Success) { $subPatch = [int]$subMatch.Groups[1].Value }
+          $msiPatch = $patch * 100 + $subPatch
+          $msiVersion = "${major}.${minor}.${msiPatch}.0"
+          Write-Host "MSI version: $msiVersion (from tag $env:TAG, sub-patch $subPatch)"
 
           # Generate USAGE.html into the release dir for bundling in the MSI.
           # main.wxs references $(var.SourceDir)\USAGE.html as a required file.

--- a/apps/ta-cli/wix/main.wxs
+++ b/apps/ta-cli/wix/main.wxs
@@ -31,9 +31,12 @@
     Language="1033"
     UpgradeCode="A8B3C4D5-E6F7-4A5B-9C8D-1E2F3A4B5C6D">
 
-    <!-- Allow upgrade from prior versions -->
+    <!-- Allow upgrade from prior versions, including same-version patch reinstalls.
+         AllowSameVersionUpgrades="yes" is required because our sub-patch releases
+         (e.g. 0.15.30.2.1 → 0.15.30.2.3) all map to the same MSI major.minor.patch
+         trio — Windows Installer would silently skip without this flag. -->
     <MajorUpgrade
-      AllowSameVersionUpgrades="no"
+      AllowSameVersionUpgrades="yes"
       DowngradeErrorMessage="A newer version of Trusted Autonomy is already installed." />
 
     <MediaTemplate EmbedCab="yes" />


### PR DESCRIPTION
## Root cause

All sub-patch releases (0.15.30.2.1 through 0.15.30.2.3) produce MSI version **0.15.30.0** — the regex only captures the first three numeric parts. Windows Installer with `AllowSameVersionUpgrades="no"` **silently skips** the entire upgrade when the installed version equals the package version. No error, no replacement, old `ta.exe` stays.

This is why the user kept seeing the old binary after installing each new MSI.

## Two-part fix

**1. `AllowSameVersionUpgrades="yes"` in `main.wxs`**  
Forces file replacement even when MSI version is equal. Correct for patch releases within a semver base.

**2. Encode sub-patch into MSI `c` field (release.yml + nightly.yml)**  
```
0.15.30-alpha.2.3  →  MSI 0.15.3003.0   (c = 30*100 + 3)
0.15.30-alpha.2.4  →  MSI 0.15.3004.0
0.15.31-alpha      →  MSI 0.15.3100.0
0.16.0-alpha       →  MSI 0.16.0.0
```
MSI `a.b.c` is now monotonically increasing across all releases, so `MajorUpgrade` correctly detects version changes even without `AllowSameVersionUpgrades`.

## Test plan
- [ ] Windows CI green
- [ ] Install v0.15.30.2.3 MSI, then install v0.15.30.2.4 (next patch) — `ta.exe` is replaced
- [ ] `ta --version` shows new version after upgrade

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)