### PR TITLE
fix: auto-correct unchecked items in done phases after update_phase_status

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -7427,17 +7427,17 @@ pub enum NoteDelivery {
 
 **Depends on**: v0.12.x (agent framework), v0.15.30 (AgentContextChannel)
 
-1. [ ] **`ta init --template pragma` project template**: Scaffolds `.ta/workflow.toml` (Kotlin verify: `./gradlew ktlintCheck test`), `.ta/agents/planner.toml` (BMAD planner manifest, Pragma docs URL injected as context), `.ta/constitution.toml` (Kotlin-appropriate rules), and a `PLAN.md` stub with Pragma service categories as phase groups.
+1. [x] **`ta init --template pragma` project template**: Scaffolds `.ta/workflow.toml` (Kotlin verify: `./gradlew ktlintCheck test`), `.ta/agents/planner.toml` (BMAD planner manifest, Pragma docs URL injected as context), `.ta/constitution.toml` (Kotlin-appropriate rules), and a `PLAN.md` stub with Pragma service categories as phase groups.
 
-2. [ ] **BMAD planner agent manifest** (`.ta/agents/pragma-planner.toml`): Agent pre-loaded with Pragma 2026.1.0 architecture context — service catalog (player, matchmaking, commerce, social, game-data, ops, portal), Pragma's plugin extension model, and BMAD milestone decomposition methodology. On first run, the agent reads the project's Pragma config files and existing service implementations to build an architecture snapshot.
+2. [x] **BMAD planner agent manifest** (`.ta/agents/pragma-planner.toml`): Agent pre-loaded with Pragma 2026.1.0 architecture context — service catalog (player, matchmaking, commerce, social, game-data, ops, portal), Pragma's plugin extension model, and BMAD milestone decomposition methodology. On first run, the agent reads the project's Pragma config files and existing service implementations to build an architecture snapshot.
 
-3. [ ] **Architecture discovery step**: On `ta plan init --pragma`, the planner agent scans for Pragma config files (`pragma-ext-service`, `pragma-core`, Gradle modules), interviews the user about which services are active, and produces a structured architecture summary in PLAN.md preamble: services deployed, custom plugins, SDK integrations (Unreal/Unity), and current tech debt.
+3. [x] **Architecture discovery step**: On `ta plan init --pragma`, the planner agent scans for Pragma config files (`pragma-ext-service`, `pragma-core`, Gradle modules), interviews the user about which services are active, and produces a structured architecture summary in PLAN.md preamble: services deployed, custom plugins, SDK integrations (Unreal/Unity), and current tech debt.
 
-4. [ ] **Milestone planning from architecture**: After discovery, the planner produces a concrete next-milestone proposal: goal title, acceptance criteria, affected Pragma services, estimated complexity, and a draft PLAN.md phase entry. User approves or iterates via `ta_ask_human` before the phase is committed.
+4. [x] **Milestone planning from architecture**: After discovery, the planner produces a concrete next-milestone proposal: goal title, acceptance criteria, affected Pragma services, estimated complexity, and a draft PLAN.md phase entry. User approves or iterates via `ta_ask_human` before the phase is committed.
 
-5. [ ] **Git VCS auto-detection**: `ta init` on a Pragma project detects the existing git repo (no re-init), sets `adapter = "git"` in `workflow.toml`, and reads `git log --oneline -20` to give the planner recent commit context for the architecture snapshot.
+5. [x] **Git VCS auto-detection**: `ta init` on a Pragma project detects the existing git repo (no re-init), sets `adapter = "git"` in `workflow.toml`, and reads `git log --oneline -20` to give the planner recent commit context for the architecture snapshot.
 
-6. [ ] **`ta plan --pragma` command alias**: Shortcut to run the Pragma planner interactively at any time: re-scans architecture, shows drift from last snapshot, and offers to update the plan. Useful after Pragma version upgrades or new service additions.
+6. [x] **`ta plan --pragma` command alias**: Shortcut to run the Pragma planner interactively at any time: re-scans architecture, shows drift from last snapshot, and offers to update the plan. Useful after Pragma version upgrades or new service additions.
 
 #### Version: `0.15.30-alpha.3`
 

--- a/apps/ta-cli/src/commands/draft.rs
+++ b/apps/ta-cli/src/commands/draft.rs
@@ -7075,6 +7075,42 @@ fn apply_package(
 
             std::fs::write(&plan_path, &content)?;
 
+            // v0.15.30.6: Auto-correct unchecked items in done phases AFTER status update.
+            // update_phase_status runs before auto_correct_done_phase_items in the 3-way merge
+            // block, so the merge may have left a phase as in_progress (skipped by auto_correct)
+            // before update_phase_status promotes it to done. Re-running here guarantees items
+            // are checked regardless of merge order.
+            {
+                use ta_changeset::plan_merge::auto_correct_done_phase_items;
+                let current = std::fs::read_to_string(&plan_path)?;
+                let (corrected, corrections) = auto_correct_done_phase_items(&current);
+                if !corrections.is_empty() {
+                    for (phase_id, item_num) in &corrections {
+                        eprintln!(
+                            "[plan] auto-checked item {} in {} (done phase had unchecked item after status update)",
+                            item_num, phase_id
+                        );
+                    }
+                    std::fs::write(&plan_path, corrected.as_bytes())?;
+                }
+
+                // Hard validation: fail apply if any done phase still has unchecked items.
+                use ta_changeset::plan_merge::check_done_phase_item_consistency;
+                let final_content = std::fs::read_to_string(&plan_path)?;
+                let issues = check_done_phase_item_consistency(&final_content);
+                if !issues.is_empty() {
+                    for issue in &issues {
+                        eprintln!("[plan] ERROR: [{}] {}", issue.section_id, issue.description);
+                    }
+                    anyhow::bail!(
+                        "PLAN.md apply aborted: {} done phase(s) have unchecked items after auto-correct.\n\
+                         This indicates a merge corruption that auto-correct could not fix.\n\
+                         Run `ta plan fix-markers --apply` to repair, or mark items [x] manually.",
+                        issues.len()
+                    );
+                }
+            }
+
             // Auto-bump workspace version to match the completed phase.
             // Agents should NOT set the version — this is the single authority.
             if let Some(new_ver) = super::plan::phase_id_to_semver(&last_phase_id) {
@@ -7386,6 +7422,47 @@ fn apply_package(
                         }
 
                         std::fs::write(&plan_path, &content)?;
+
+                        // v0.15.30.6: Auto-correct unchecked items in done phases AFTER status
+                        // update (VCS path). Mirrors the non-VCS fix — same root cause.
+                        {
+                            use ta_changeset::plan_merge::auto_correct_done_phase_items;
+                            let current = std::fs::read_to_string(&plan_path)?;
+                            let (corrected, corrections) = auto_correct_done_phase_items(&current);
+                            if !corrections.is_empty() {
+                                for (phase_id, item_num) in &corrections {
+                                    eprintln!(
+                                        "[plan] auto-checked item {} in {} (done phase had unchecked item after status update)",
+                                        item_num, phase_id
+                                    );
+                                }
+                                std::fs::write(&plan_path, corrected.as_bytes())?;
+                                // Stage the corrected PLAN.md so adapter.commit() includes it.
+                                let _ = std::process::Command::new("git")
+                                    .args(["add", "PLAN.md"])
+                                    .current_dir(&target_dir)
+                                    .output();
+                            }
+
+                            // Hard validation: fail apply if any done phase still has unchecked items.
+                            use ta_changeset::plan_merge::check_done_phase_item_consistency;
+                            let final_content = std::fs::read_to_string(&plan_path)?;
+                            let issues = check_done_phase_item_consistency(&final_content);
+                            if !issues.is_empty() {
+                                for issue in &issues {
+                                    eprintln!(
+                                        "[plan] ERROR: [{}] {}",
+                                        issue.section_id, issue.description
+                                    );
+                                }
+                                anyhow::bail!(
+                                    "PLAN.md apply aborted: {} done phase(s) have unchecked items after auto-correct.\n\
+                                     This indicates a merge corruption that auto-correct could not fix.\n\
+                                     Run `ta plan fix-markers --apply` to repair, or mark items [x] manually.",
+                                    issues.len()
+                                );
+                            }
+                        }
 
                         // Auto-bump workspace version to match the completed phase.
                         if let Some(new_ver) = super::plan::phase_id_to_semver(&last_phase_id) {


### PR DESCRIPTION
## Root cause

`auto_correct_done_phase_items` runs on the 3-way merge result **before** `update_phase_status` promotes the phase to `done`. When the 3-way merge produces `in_progress` (source and base both had `in_progress`, staging had `done`), `auto_correct` skips the phase because it isn't `done` yet. Then `update_phase_status` correctly writes `done` — but items are already `[ ]` on disk. This is why phase done markers were set correctly but checklist items stayed unchecked.

Reproduced in v0.15.30.3: the draft correctly set `<!-- status: done -->` but all 6 Pragma template items remained `[ ]`.

## Fix

Re-run `auto_correct_done_phase_items` immediately after the `std::fs::write` at both plan-update call sites:
- Non-VCS path (~line 7075)
- VCS/git-commit path (~line 7387)

At both sites the phase is now definitively `done` on disk, so auto_correct will find and fix any `[ ]` items. Also added a hard validation `bail!` if items are still unchecked after auto_correct — this catches merge corruption that auto_correct can't fix and fails with an actionable message instead of silently committing a broken PLAN.md.

## Manual repair included

Marked all 6 v0.15.30.3 items `[x]` in PLAN.md (left unchecked by the bug).

## Test plan
- [ ] CI passes
- [ ] `ta draft apply --phase vX.Y.Z --git-commit` on a draft where agent set `done` but didn't check items: items come out `[x]`
- [ ] `ta draft apply --phase vX.Y.Z` (non-git-commit): same
- [ ] Corrupted PLAN.md (done phase, unchecked items, auto_correct can't fix): apply bails with clear error

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)