### PR TITLE
fix: release tests hang on TTY stdin when run in terminal

### DIFF
--- a/apps/ta-cli/src/commands/release.rs
+++ b/apps/ta-cli/src/commands/release.rs
@@ -18,6 +18,18 @@ use ta_mcp_gateway::GatewayConfig;
 use crate::commands::release_git;
 use ta_events;
 
+// In tests stdin is always treated as non-TTY so the fast-fail paths are
+// exercised regardless of whether the test runner is attached to a terminal.
+#[cfg(not(test))]
+fn stdin_is_tty() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdin().is_terminal()
+}
+#[cfg(test)]
+fn stdin_is_tty() -> bool {
+    false
+}
+
 // ── CLI definition ──────────────────────────────────────────────
 
 #[derive(Subcommand, Debug)]
@@ -885,23 +897,20 @@ fn run_pipeline(
     // Fail fast if any step requires approval and we cannot answer it.
     // This check runs before any steps execute so there is no partial execution
     // followed by a hang.
-    if !skip_approvals && !dry_run && !interactive {
-        use std::io::IsTerminal;
-        if !std::io::stdin().is_terminal() {
-            let needs_gate = pipeline
-                .steps
-                .iter()
-                .skip(start_idx)
-                .any(|s| s.requires_approval || s.constitution_check);
-            if needs_gate {
-                anyhow::bail!(
-                    "approval gate requires human input but stdin is not a TTY. \
-                     Run with --interactive (routes approvals via ta_ask_human for \
-                     daemon/Studio use) or --auto-approve to skip all gates. \
-                     Example: ta release run {} --auto-approve",
-                    version
-                );
-            }
+    if !skip_approvals && !dry_run && !interactive && !stdin_is_tty() {
+        let needs_gate = pipeline
+            .steps
+            .iter()
+            .skip(start_idx)
+            .any(|s| s.requires_approval || s.constitution_check);
+        if needs_gate {
+            anyhow::bail!(
+                "approval gate requires human input but stdin is not a TTY. \
+                 Run with --interactive (routes approvals via ta_ask_human for \
+                 daemon/Studio use) or --auto-approve to skip all gates. \
+                 Example: ta release run {} --auto-approve",
+                version
+            );
         }
     }
 
@@ -1185,7 +1194,7 @@ fn ask_human_on_step_failure(
     error_summary: &str,
     interactive: bool,
 ) -> anyhow::Result<HumanStepDecision> {
-    use std::io::{self, IsTerminal, Write};
+    use std::io::{self, Write};
 
     let question_text = format!(
         "Release step '{}' timed out / failed.\n\
@@ -1200,7 +1209,7 @@ fn ask_human_on_step_failure(
         step_name, error_summary
     );
 
-    if io::stdin().is_terminal() {
+    if stdin_is_tty() {
         print!("{}\n> ", question_text);
         io::stdout().flush()?;
         let mut input = String::new();
@@ -2030,10 +2039,10 @@ fn prompt_approval_default(
     default_yes: bool,
     interactive: bool,
 ) -> anyhow::Result<bool> {
-    use std::io::{self, IsTerminal, Write};
+    use std::io::{self, Write};
 
     // TTY context: prompt directly.
-    if io::stdin().is_terminal() {
+    if stdin_is_tty() {
         let prompt_hint = if default_yes { "[Y/n]" } else { "[y/N]" };
         print!("Proceed with '{}'? {} ", step_name, prompt_hint);
         io::stdout().flush()?;
@@ -3197,8 +3206,7 @@ fn dispatch_release(
                     );
                 } else {
                     // Non-TTY: cannot prompt, so fail with actionable message.
-                    use std::io::IsTerminal;
-                    if !std::io::stdin().is_terminal() {
+                    if !stdin_is_tty() {
                         anyhow::bail!(
                             "Version drift detected: Cargo.toml is at {} but tag {} implies {}. \
                              Cannot prompt for version bump in non-TTY context. \


### PR DESCRIPTION
## Summary
- `stdin.is_terminal()` returns `true` when `cargo test` runs inside a real terminal, causing `prompt_approval_default`, `ask_human_on_step_failure`, and the `run_pipeline` gate check to block on `read_line()` waiting for input that never arrives
- Introduces `stdin_is_tty()` with a `#[cfg(test)]` override that always returns `false`, so all non-TTY fast-fail paths are exercised regardless of whether the test runner is attached to a terminal
- Collapses the now-redundant nested `if` in `run_pipeline` (clippy required it)

## Test plan
- [ ] `cargo test -p ta-cli non_tty` — 4 tests pass in < 1s
- [ ] `cargo test -p ta-cli ask_human` — 1 test passes in < 1s
- [ ] `cargo clippy -p ta-cli --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all -- --check` — clean

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)