### PR TITLE
fix: resolve_phase handles done-phase titles without contradictory errors

### DIFF
--- a/apps/ta-cli/src/commands/plan.rs
+++ b/apps/ta-cli/src/commands/plan.rs
@@ -4271,8 +4271,33 @@ pub fn resolve_phase(
             }));
         }
 
-        // Step 2: prefix expansion — only among pending phases.
+        // Step 1b: if the token exactly matches a Done phase with no pending sub-phases,
+        // proceed without phase linkage rather than falling through to a misleading
+        // "not yet in PLAN.md" message and then failing at the claim step.
         let token_norm = token.trim_start_matches('v');
+        let done_match = phases
+            .iter()
+            .any(|p| phase_ids_match(&p.id, token) && p.status == PlanStatus::Done);
+        if done_match {
+            let has_pending_sub = phases.iter().any(|p| {
+                p.status == PlanStatus::Pending
+                    && p.id
+                        .trim_start_matches('v')
+                        .starts_with(&format!("{}.", token_norm))
+            });
+            if !has_pending_sub {
+                if !quiet {
+                    println!(
+                        "Title matches completed phase {token} — proceeding without phase \
+                         linking.\nTo run in the context of a specific phase use --phase."
+                    );
+                }
+                return Ok(None);
+            }
+            // Has pending sub-phases — fall through to prefix expansion so the sub-phase is picked.
+        }
+
+        // Step 2: prefix expansion — only among pending phases.
         let prefix_matches: Vec<&PlanPhase> = phases
             .iter()
             .filter(|p| {


### PR DESCRIPTION
## Summary

- `resolve_phase()` produced contradictory errors when a goal title contained a semver token matching a *Done* phase (e.g. `"v0.16.2 — Ollama Agent Framework Plugin"`):
  1. Step 1 filtered Done phases out → fell through to "not yet in PLAN.md" message
  2. Claim logic separately looked up the same token → found it was Done → printed "already done"
  - Result: two contradictory errors, goal not started

- Added **Step 1b** between the existing steps 1 and 2:
  - If the title token exactly matches a Done phase **and** that phase has no pending sub-phases → return `Ok(None)` with a clear "Title matches completed phase X — proceeding without phase linking" message
  - If the Done phase has pending sub-phases (e.g. `v0.16.2` done but `v0.16.2.1` pending) → falls through to Step 2 prefix expansion, which finds the pending child (existing behaviour preserved)

## Test plan

- [ ] `cargo clippy -p ta-cli -- -D warnings` — clean
- [ ] `cargo test -p ta-cli resolve_phase` — 6 tests pass
- [ ] `cargo fmt --all -- --check` — clean
- [ ] Reproduce fix: `ta run "v0.16.2 — Ollama..."` should print the clear message and start without phase linkage, not two contradictory error lines

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)