### PR TITLE
fix: auto-clean staging on draft deny + GC for denied-draft goals (v0.16.4.5)

### DIFF
--- a/apps/ta-cli/src/commands/draft.rs
+++ b/apps/ta-cli/src/commands/draft.rs
@@ -4551,6 +4551,40 @@ fn deny_package(
         }
     }
 
+    // Clean staging directory on denial, same as on apply (Fix B — disk pressure).
+    // A denied draft is a terminal state; keeping 7-8 GB of staging indefinitely
+    // was the root cause of runaway .ta/staging/ disk usage.
+    if let Some(goal_id) = package_goal_id {
+        let goal_store = ta_goal::GoalRunStore::new(&config.goals_dir);
+        if let Ok(store) = goal_store {
+            if let Ok(Some(goal)) = store.get(goal_id) {
+                let wf_cfg = ta_submit::WorkflowConfig::load_or_default(
+                    &config.workspace_root.join(".ta/workflow.toml"),
+                );
+                if wf_cfg.staging.auto_clean
+                    && !goal.workspace_path.as_os_str().is_empty()
+                    && goal.workspace_path.exists()
+                {
+                    match std::fs::remove_dir_all(&goal.workspace_path) {
+                        Ok(()) => {
+                            println!(
+                                "Auto-cleaned staging directory: {} (staging.auto_clean=true)",
+                                goal.workspace_path.display(),
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "Warning: could not auto-clean staging {}: {}",
+                                goal.workspace_path.display(),
+                                e,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     println!("Denied draft package {}: {}", package_id, reason);
     Ok(())
 }

--- a/crates/ta-daemon/src/watchdog.rs
+++ b/crates/ta-daemon/src/watchdog.rs
@@ -1316,16 +1316,27 @@ pub fn startup_gc_pass(
     let mut removed = 0u32;
     let mut freed_bytes = 0u64;
 
+    // Load the pr_packages dir once for denied-draft checks below.
+    let pr_packages_dir = project_root.join(".ta").join("pr_packages");
+
     for goal in &goals {
         let is_failed = matches!(goal.state, GoalRunState::Failed { .. });
         let is_applied_completed = matches!(
             goal.state,
             GoalRunState::Applied | GoalRunState::Completed | GoalRunState::Merged
         );
+        // PrReady goals whose draft was denied never transition to a terminal state.
+        // GC treats them as terminal once they're past the applied cutoff.
+        let is_denied_pr_ready = matches!(
+            goal.state,
+            GoalRunState::PrReady | GoalRunState::UnderReview
+        ) && goal
+            .pr_package_id
+            .is_some_and(|id| is_draft_denied(&pr_packages_dir, id));
 
         let past_cutoff = if is_failed {
             goal.updated_at < failed_cutoff
-        } else if is_applied_completed {
+        } else if is_applied_completed || is_denied_pr_ready {
             goal.updated_at < applied_cutoff
         } else {
             false
@@ -1356,6 +1367,20 @@ pub fn startup_gc_pass(
     }
 
     (removed, freed_bytes)
+}
+
+/// Check whether the draft package with `id` has `Denied` status.
+///
+/// Reads the package JSON file directly to avoid a dependency on ta-cli from
+/// the daemon crate. Uses a simple string search so it degrades gracefully if
+/// the file is absent or unreadable.
+fn is_draft_denied(pr_packages_dir: &Path, id: uuid::Uuid) -> bool {
+    let path = pr_packages_dir.join(format!("{}.json", id));
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    // DraftStatus::Denied serialises as {"Denied": {...}} — check for the key.
+    content.contains("\"Denied\"")
 }
 
 fn walkdir_size_wd(path: &Path) -> u64 {


### PR DESCRIPTION
## Summary
- **Fix B**: `deny_package()` in `draft.rs` now runs `auto_clean` on staging immediately after denial — same block that `apply_package()` already had. Denied drafts are a terminal state; staging was persisting indefinitely (7-8 GB per denied goal).
- **Fix C**: `startup_gc_pass()` in `watchdog.rs` now recognises `PrReady`/`UnderReview` goals whose draft package has `Denied` status as GC-eligible. The existing 6h periodic GC task in the daemon will catch any that slipped through Fix B. Uses a lightweight JSON string-search (`is_draft_denied()`) to avoid adding a ta-cli crate dependency to ta-daemon.

## Root cause
`startup_gc_pass` only checked `Failed`, `Applied`, `Completed`, `Merged` states. Goals whose draft was denied remain in `PrReady` state (no `GoalRunState::Denied` variant exists), so they were invisible to GC. Combined with the apply-only `auto_clean` block, a single denied goal could hold 7+ GB of staging indefinitely.

## Test plan
- [ ] All 371 ta-daemon tests pass
- [ ] All ta-cli tests pass
- [ ] `cargo clippy -p ta-cli -p ta-daemon -- -D warnings` clean
- [ ] Deny a draft, verify staging is removed immediately (Fix B)
- [ ] Create a goal with old denied draft, run `startup_gc_pass`, verify staging removed (Fix C)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)