### PR TITLE
fix: auto-approve all MCP servers in Claude agent goals

### DIFF
--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -4266,9 +4266,11 @@ const DEFAULT_ALLOWED_TOOLS: &[&str] = &[
     "Skill(*)",
     "TodoRead(*)",
     "TodoWrite(*)",
-    // TA's own MCP tools — always auto-approved so agents never prompt
-    // for the tools they need to interact with the TA daemon.
-    "mcp__ta__*",
+    // Approve all MCP tools from all servers — covers TA-injected servers
+    // (ta, ta-memory) and any MCPs the user has configured globally in
+    // ~/.claude/settings.json. User-configured servers are trusted by
+    // definition; they can't appear unless the user explicitly added them.
+    "mcp__*",
 ];
 
 /// Built-in forbidden tool patterns — community-maintained deny list.


### PR DESCRIPTION
## Summary
- Changes `mcp__ta__*` to `mcp__*` in `DEFAULT_ALLOWED_TOOLS` (injected into `.claude/settings.local.json`)
- Covers all MCP servers: TA-injected (`ta`, `ta-memory`) **and** any MCPs the user has configured globally in `~/.claude/settings.json`
- User-configured MCP servers are trusted by definition — they can't appear unless the user explicitly added them

## Root cause
PR #479 added `mcp_allowed_tools_args()` to pass `--allowedTools mcp__<name>__*` per-server from staging `.mcp.json`. That function was lost when commit `32adfb80f0` (CARGO_TARGET_DIR, direct-to-main from stale staging) overwrote run.rs. Additionally, the per-server pattern approach only covered servers in the project `.mcp.json`, not servers from `~/.claude/settings.json`.

The proper fix is simpler: `mcp__*` in the existing `settings.local.json` permissions allow list — one line, covers everything, consistent with how other tool patterns work here.

## Test plan
- [x] `cargo build -p ta-cli` — clean
- [x] `cargo test -p ta-cli -- settings` — 5 pass
- [x] `cargo clippy -p ta-cli -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)