### PR TITLE
fix: restore terminal state when PTY agent session exits or is killed

### DIFF
--- a/apps/ta-cli/src/commands/pty_capture.rs
+++ b/apps/ta-cli/src/commands/pty_capture.rs
@@ -413,6 +413,33 @@ pub struct CapturedInput {
     pub text: String,
 }
 
+/// RAII guard that restores the terminal to its saved state on drop.
+///
+/// Handles both normal return and panics. Without this, killing `ta run`
+/// while an interactive agent session is running leaves the terminal in
+/// whatever raw/alternate-screen state the agent set — causing ^M on Enter
+/// and ^C on Ctrl+C in the calling shell.
+struct TerminalRestoreGuard {
+    saved: libc::termios,
+}
+
+impl TerminalRestoreGuard {
+    fn save() -> Option<Self> {
+        let mut t: libc::termios = unsafe { std::mem::zeroed() };
+        if unsafe { libc::tcgetattr(libc::STDIN_FILENO, &mut t) } == 0 {
+            Some(Self { saved: t })
+        } else {
+            None
+        }
+    }
+}
+
+impl Drop for TerminalRestoreGuard {
+    fn drop(&mut self) {
+        unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSAFLUSH, &self.saved) };
+    }
+}
+
 /// Run an agent in a PTY with stdin interleaving.
 ///
 /// This is the main entry point for interactive sessions:
@@ -421,6 +448,12 @@ pub struct CapturedInput {
 /// 3. Human input from stdin is forwarded to the agent's PTY stdin
 /// 4. All I/O is logged with timestamps for audit
 pub fn run_interactive_pty(config: PtyLaunchConfig<'_>) -> io::Result<PtySessionResult> {
+    // Save terminal state now; restored on drop regardless of how we exit.
+    // Without this, abruptly killing `ta run` leaves ^M/^C artifacts because
+    // the agent's escape sequences (raw mode, alternate screen) were forwarded
+    // to the parent terminal but the cleanup sequences never ran.
+    let _term_guard = TerminalRestoreGuard::save();
+
     let sink = config.output_sink.unwrap_or_else(|| Arc::new(TerminalSink));
 
     let mut pty = PtySession::spawn_with_sink(


### PR DESCRIPTION
## Summary
- Adds `TerminalRestoreGuard` (RAII struct) to `run_interactive_pty` in `pty_capture.rs`
- Saves parent terminal's `termios` state on entry via `tcgetattr(STDIN_FILENO)`
- Restores it on `Drop` via `tcsetattr(STDIN_FILENO, TCSAFLUSH, &saved)` — fires on normal return, early `?` returns, and panic unwinding
- No new dependencies — uses `libc` which was already linked

## Root cause
When `ta run` launches an interactive Claude session, the agent's escape sequences (raw mode enable, alternate screen, cursor control) are forwarded verbatim to the parent terminal via `TerminalSink`. When the session ends cleanly, Claude sends cleanup sequences. When `ta run` is killed (`kill <pid>` or Ctrl+C from outside), those cleanup sequences never run — leaving the calling shell with ^M on Enter and ^C on Ctrl+C.

## Test plan
- [x] `cargo build -p ta-cli` — clean
- [x] `cargo clippy -p ta-cli -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- Manual: run `ta run` for an interactive goal, kill the process from another shell — terminal should be restored automatically

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)