### PR TITLE
fix: restore terminal state in release pipeline shell steps

### DIFF
--- a/apps/ta-cli/src/commands/release.rs
+++ b/apps/ta-cli/src/commands/release.rs
@@ -1095,12 +1095,37 @@ fn execute_shell_step(
         .env_remove("GIT_WORK_TREE")
         .env_remove("GIT_CEILING_DIRECTORIES");
 
+    // Null stdin so the subprocess cannot access or modify the controlling
+    // terminal's settings (e.g., nix develop / bash subshells call tcsetattr
+    // on fd 0, leaving the terminal in raw mode and breaking subsequent
+    // read_line() calls at approval gates).
+    command.stdin(std::process::Stdio::null());
+
     // Inject step-level env vars with substitution.
     for (k, v) in &step.env {
         command.env(k, substitute_vars(v, version, commits, last_tag));
     }
 
+    // Save terminal state before the subprocess runs and restore it after,
+    // in case anything still reaches the terminal device via stdout/stderr.
+    #[cfg(unix)]
+    let saved_termios: Option<libc::termios> = {
+        let mut t: libc::termios = unsafe { std::mem::zeroed() };
+        if unsafe { libc::tcgetattr(libc::STDIN_FILENO, &mut t) } == 0 {
+            Some(t)
+        } else {
+            None
+        }
+    };
+
     let status = command.status()?;
+
+    #[cfg(unix)]
+    if let Some(saved) = saved_termios {
+        unsafe {
+            libc::tcsetattr(libc::STDIN_FILENO, libc::TCSAFLUSH, &saved);
+        }
+    }
     if !status.success() {
         anyhow::bail!(
             "Step '{}' failed (exit code: {:?})",
@@ -2104,6 +2129,18 @@ fn prompt_approval_default(
 
     // TTY context: prompt directly.
     if stdin_is_tty() {
+        // Restore terminal to canonical mode before reading user input.
+        // Shell pipeline steps (e.g., nix develop subshells) may have left
+        // the terminal in raw mode, causing Enter to echo ^M instead of \n.
+        #[cfg(unix)]
+        unsafe {
+            let mut t: libc::termios = std::mem::zeroed();
+            if libc::tcgetattr(libc::STDIN_FILENO, &mut t) == 0 {
+                t.c_lflag |= libc::ICANON | libc::ECHO | libc::ECHOE | libc::ECHOK;
+                t.c_iflag |= libc::ICRNL;
+                libc::tcsetattr(libc::STDIN_FILENO, libc::TCSAFLUSH, &t);
+            }
+        }
         let prompt_hint = if default_yes { "[Y/n]" } else { "[y/N]" };
         print!("Proceed with '{}'? {} ", step_name, prompt_hint);
         io::stdout().flush()?;

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: 0.16.4-alpha.3
+**Version**: 0.16.6-alpha.1
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 


### PR DESCRIPTION
## Summary
- `ta release run` shell steps use `command.status()` which inherits stdin — programs like `nix develop`/bash can call `tcsetattr` on that fd and leave the terminal in raw mode
- When the next approval gate calls `read_line()`, raw mode causes Enter to echo `^M` instead of newline
- PR #484 fixed this for interactive agent sessions (`run_interactive_pty`) but not the release pipeline code path

## Fix (three layers)

1. **Null stdin** on every `execute_shell_step` subprocess — prevents `tcsetattr(0, ...)` from affecting the parent terminal at all
2. **Save/restore termios** around `command.status()` — belt-and-suspenders for processes that reach the terminal via stdout/stderr  
3. **Restore canonical mode** (`ICANON | ECHO | ICRNL`) at the top of `prompt_approval_default()` before reading user input — catches anything that slips through between steps

## Test plan
- [ ] Run `ta release run <version>` without `--yes` — approval gate prompts should respond normally to Enter (no `^M`)
- [ ] Confirm `./dev cargo build` steps still work (null stdin doesn't break build output)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)