### PR TITLE
fix: self-heal stale phase claims; release daemon claim on goal delete/reset

### DIFF
--- a/apps/ta-cli/src/commands/plan.rs
+++ b/apps/ta-cli/src/commands/plan.rs
@@ -1341,7 +1341,31 @@ pub fn reset_phase_if_in_progress(
         .append(true)
         .open(&history_path)?;
     writeln!(file, "{}", entry)?;
+
+    // Best-effort: tell the daemon to release its in-memory claim so future
+    // `ta run` calls succeed without requiring a daemon restart.
+    release_daemon_phase_claim(project_root, phase_id);
+
     Ok(())
+}
+
+/// Fire-and-forget HTTP call to release the daemon's in-memory phase claim.
+///
+/// The daemon holds phase claims in RAM — resetting PLAN.md alone leaves a
+/// stale entry that blocks the next `ta run` with "already claimed". This
+/// function corrects that. Errors are silently swallowed: the daemon may not
+/// be running, and PLAN.md is already the authoritative source of truth.
+fn release_daemon_phase_claim(project_root: &Path, phase_id: &str) {
+    let Ok(client) = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+    else {
+        return;
+    };
+    let daemon_url = super::daemon::resolve_daemon_url(project_root, None);
+    let url = format!("{}/api/plan/phase/release", daemon_url);
+    let body = serde_json::json!({ "phase_id": phase_id });
+    let _ = client.post(&url).json(&body).send();
 }
 
 /// CLI handler for `ta plan reset <phase-id>`.

--- a/crates/ta-daemon/src/api/plan.rs
+++ b/crates/ta-daemon/src/api/plan.rs
@@ -550,7 +550,91 @@ pub async fn claim_phase(
             .into_response();
     }
 
-    // Step 1: acquire in-memory claim (serialised by mutex).
+    // Step 1: read PLAN.md and validate phase status.
+    //
+    // We check PLAN.md BEFORE the in-memory registry so we can self-heal stale
+    // claims: if PLAN.md says `pending` but the registry still holds an entry
+    // (e.g. the goal was deleted without the daemon being notified), we auto-
+    // release the stale registry entry so the new run proceeds without requiring
+    // a daemon restart.
+    let plan_path = state.project_root.join("PLAN.md");
+    let plan_content: Option<String> = if plan_path.exists() {
+        match std::fs::read_to_string(&plan_path) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": format!("Failed to read PLAN.md: {}", e) })),
+                )
+                    .into_response();
+            }
+        }
+    } else {
+        None
+    };
+
+    if let Some(ref content) = plan_content {
+        let phases = parse_plan_phases(content);
+        let maybe_phase = phases.iter().find(|p| ids_match(&p.id, &phase_id));
+
+        match maybe_phase.map(|p| p.status.as_str()) {
+            Some("done") => {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": format!("Phase {} is already done", phase_id)
+                    })),
+                )
+                    .into_response();
+            }
+            Some("pending") => {
+                // PLAN.md says pending — any in-memory claim is stale.
+                // Auto-release so this run can proceed without a daemon restart.
+                state.phase_claims.release(&phase_id);
+            }
+            Some("in_progress") => {
+                // PLAN.md still shows in_progress. Only block if the in-memory
+                // claim is also held — that's the legitimate concurrent-run guard.
+                if state.phase_claims.is_claimed(&phase_id) {
+                    let goal_hint = state
+                        .phase_claims
+                        .snapshot()
+                        .into_iter()
+                        .find(|(k, _)| k == &phase_id)
+                        .and_then(|(_, g)| g)
+                        .map(|g| format!("goal {}", g))
+                        .unwrap_or_else(|| "unknown goal".to_string());
+                    return (
+                        StatusCode::CONFLICT,
+                        Json(serde_json::json!({
+                            "error": format!(
+                                "Phase {} could not be claimed: already in progress ({}). \
+                                 If the previous run was killed or failed before producing a draft, \
+                                 run `ta goal delete <id>` or `ta plan reset {}` to reclaim it.",
+                                phase_id, goal_hint, phase_id
+                            ),
+                            "hint": {
+                                "phase_id": phase_id,
+                                "held_by": goal_hint,
+                                "recovery": [
+                                    "ta goal list   # find the stuck goal ID",
+                                    format!("ta goal delete <id>       # delete goal + auto-unclaim"),
+                                    format!("ta plan reset {}          # force-clear if goal is gone", phase_id),
+                                ]
+                            }
+                        })),
+                    )
+                        .into_response();
+                }
+                // In-memory claim absent but PLAN.md says in_progress — the daemon
+                // was restarted and its registry was cleared. Allow the claim; the
+                // in_progress marker will be rewritten below.
+            }
+            _ => {} // phase not found or unrecognised status — proceed
+        }
+    }
+
+    // Step 2: acquire the in-memory claim (serialised by mutex).
     if let Err(msg) = state
         .phase_claims
         .try_claim(&phase_id, body.goal_id.as_deref())
@@ -562,53 +646,9 @@ pub async fn claim_phase(
             .into_response();
     }
 
-    // Step 2: validate PLAN.md — phase must be pending.
-    let plan_path = state.project_root.join("PLAN.md");
-    if plan_path.exists() {
-        let content = match std::fs::read_to_string(&plan_path) {
-            Ok(c) => c,
-            Err(e) => {
-                state.phase_claims.release(&phase_id);
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "error": format!("Failed to read PLAN.md: {}", e) })),
-                )
-                    .into_response();
-            }
-        };
-
-        let phases = parse_plan_phases(&content);
-        let maybe_phase = phases.iter().find(|p| ids_match(&p.id, &phase_id));
-
-        match maybe_phase.map(|p| p.status.as_str()) {
-            Some("done") => {
-                state.phase_claims.release(&phase_id);
-                return (
-                    StatusCode::CONFLICT,
-                    Json(serde_json::json!({
-                        "error": format!("Phase {} is already done", phase_id)
-                    })),
-                )
-                    .into_response();
-            }
-            Some("in_progress") => {
-                state.phase_claims.release(&phase_id);
-                return (
-                    StatusCode::CONFLICT,
-                    Json(serde_json::json!({
-                        "error": format!(
-                            "Phase {} is already claimed (in_progress in PLAN.md)",
-                            phase_id
-                        )
-                    })),
-                )
-                    .into_response();
-            }
-            _ => {} // pending or not found — proceed
-        }
-
-        // Step 3: write in_progress marker to PLAN.md.
-        let updated = update_phase_status_in_content(&content, &phase_id, "in_progress");
+    // Step 3: write `in_progress` marker to PLAN.md.
+    if let Some(ref content) = plan_content {
+        let updated = update_phase_status_in_content(content, &phase_id, "in_progress");
         if let Err(e) = std::fs::write(&plan_path, &updated) {
             state.phase_claims.release(&phase_id);
             return (
@@ -617,24 +657,24 @@ pub async fn claim_phase(
             )
                 .into_response();
         }
+    }
 
-        // Step 4: record in plan_history.jsonl.
-        let history_path = state.project_root.join(".ta/plan_history.jsonl");
-        if let Ok(mut file) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&history_path)
-        {
-            use std::io::Write as _;
-            let entry = serde_json::json!({
-                "timestamp": chrono::Utc::now().to_rfc3339(),
-                "phase_id": phase_id,
-                "old_status": "pending",
-                "new_status": "in_progress",
-                "source": "daemon_claim",
-            });
-            let _ = writeln!(file, "{}", entry);
-        }
+    // Step 4: record in plan_history.jsonl.
+    let history_path = state.project_root.join(".ta/plan_history.jsonl");
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&history_path)
+    {
+        use std::io::Write as _;
+        let entry = serde_json::json!({
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+            "phase_id": phase_id,
+            "old_status": "pending",
+            "new_status": "in_progress",
+            "source": "daemon_claim",
+        });
+        let _ = writeln!(file, "{}", entry);
     }
 
     (

--- a/crates/ta-daemon/src/api/plan.rs
+++ b/crates/ta-daemon/src/api/plan.rs
@@ -592,44 +592,43 @@ pub async fn claim_phase(
                 // Auto-release so this run can proceed without a daemon restart.
                 state.phase_claims.release(&phase_id);
             }
-            Some("in_progress") => {
-                // PLAN.md still shows in_progress. Only block if the in-memory
-                // claim is also held — that's the legitimate concurrent-run guard.
-                if state.phase_claims.is_claimed(&phase_id) {
-                    let goal_hint = state
-                        .phase_claims
-                        .snapshot()
-                        .into_iter()
-                        .find(|(k, _)| k == &phase_id)
-                        .and_then(|(_, g)| g)
-                        .map(|g| format!("goal {}", g))
-                        .unwrap_or_else(|| "unknown goal".to_string());
-                    return (
-                        StatusCode::CONFLICT,
-                        Json(serde_json::json!({
-                            "error": format!(
-                                "Phase {} could not be claimed: already in progress ({}). \
-                                 If the previous run was killed or failed before producing a draft, \
-                                 run `ta goal delete <id>` or `ta plan reset {}` to reclaim it.",
-                                phase_id, goal_hint, phase_id
-                            ),
-                            "hint": {
-                                "phase_id": phase_id,
-                                "held_by": goal_hint,
-                                "recovery": [
-                                    "ta goal list   # find the stuck goal ID",
-                                    format!("ta goal delete <id>       # delete goal + auto-unclaim"),
-                                    format!("ta plan reset {}          # force-clear if goal is gone", phase_id),
-                                ]
-                            }
-                        })),
-                    )
-                        .into_response();
-                }
-                // In-memory claim absent but PLAN.md says in_progress — the daemon
-                // was restarted and its registry was cleared. Allow the claim; the
-                // in_progress marker will be rewritten below.
+            // PLAN.md in_progress + in-memory claim held → genuine concurrent run,
+            // block and surface recovery options.
+            Some("in_progress") if state.phase_claims.is_claimed(&phase_id) => {
+                let goal_hint = state
+                    .phase_claims
+                    .snapshot()
+                    .into_iter()
+                    .find(|(k, _)| k == &phase_id)
+                    .and_then(|(_, g)| g)
+                    .map(|g| format!("goal {}", g))
+                    .unwrap_or_else(|| "unknown goal".to_string());
+                return (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": format!(
+                            "Phase {} could not be claimed: already in progress ({}). \
+                             If the previous run was killed or failed before producing a draft, \
+                             run `ta goal delete <id>` or `ta plan reset {}` to reclaim it.",
+                            phase_id, goal_hint, phase_id
+                        ),
+                        "hint": {
+                            "phase_id": phase_id,
+                            "held_by": goal_hint,
+                            "recovery": [
+                                "ta goal list   # find the stuck goal ID",
+                                format!("ta goal delete <id>       # delete goal + auto-unclaim"),
+                                format!("ta plan reset {}          # force-clear if goal is gone", phase_id),
+                            ]
+                        }
+                    })),
+                )
+                    .into_response();
             }
+            // PLAN.md in_progress but in-memory claim absent — daemon was restarted and
+            // its registry was cleared. Allow the claim; the in_progress marker will be
+            // rewritten below.
+            Some("in_progress") => {}
             _ => {} // phase not found or unrecognised status — proceed
         }
     }


### PR DESCRIPTION
## Summary
- **Root cause**: `PhaseClaims` is purely in-memory. When a goal was killed/deleted, PLAN.md was reset to `pending` but the daemon's in-memory registry was never cleared — every `ta run` for that phase then got \"already claimed\" until a `ta daemon restart`.
- **`reset_phase_if_in_progress` (CLI)**: Now calls `POST /api/plan/phase/release` after writing PLAN.md — best-effort, silently ignores if daemon is down.
- **`claim_phase` handler (daemon)**: Reads PLAN.md FIRST. If PLAN.md says `pending` but in-memory registry has a stale entry → auto-release and proceed (no daemon restart required). If PLAN.md says `in_progress` but registry is empty (daemon was restarted) → allow the claim.
- **Better conflict error**: When a genuine conflict occurs, names the holding goal and lists recovery steps (`ta goal list`, `ta goal delete <id>`, `ta plan reset <phase>`).

## Test plan
- [ ] Kill a running goal mid-run → `ta run` same phase immediately succeeds (no restart needed)
- [ ] `ta goal delete <id>` on a stuck goal → phase is immediately re-claimable
- [ ] `ta plan reset <phase>` releases the daemon claim
- [ ] Genuine concurrent claim (two simultaneous `ta run`) → clear error with holding goal ID and recovery options