### PR TITLE
fix: install WixToolset.UI.wixext before wix build in CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -207,6 +207,7 @@ jobs:
           HEAD_SHA: ${{ needs.check-for-changes.outputs.head_sha }}
         run: |
           dotnet tool install --global wix --version "4.*"
+          wix extension add WixToolset.UI.wixext
           $ShortSha = "$env:HEAD_SHA".Substring(0, [Math]::Min(7, "$env:HEAD_SHA".Length))
           # Use a fixed semver for MSI since nightly doesn't have a version tag.
           # Read from Cargo.toml to get current version digits.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,7 @@ jobs:
           # Install WiX v4 .NET global tool (~10s; windows-latest ships .NET SDK).
           # Pin to v4.x — v5+ requires OSMF EULA acceptance and uses a different schema.
           dotnet tool install --global wix --version "4.*"
+          wix extension add WixToolset.UI.wixext
 
           # Extract MSI version from tag. MSI versions are a.b.c.d; only a.b.c
           # are used for upgrade comparisons. To ensure patch releases within the


### PR DESCRIPTION
## Summary
- WiX v4 extensions are separate NuGet packages, not bundled with `dotnet tool install --global wix`
- Both nightly and release workflows used `wix build -ext WixToolset.UI.wixext` without first calling `wix extension add WixToolset.UI.wixext`
- This caused `WIX0144: The extension 'WixToolset.UI.wixext' could not be found`
- The MSI was still created but without the FeatureTree UI (WixUI_FeatureTree requires this extension)

## Fix
Add `wix extension add WixToolset.UI.wixext` immediately after the `dotnet tool install` line in both `nightly.yml` and `release.yml`.

## Test plan
- [ ] Nightly Windows build produces an MSI with the feature-selection UI (WixUI_FeatureTree) intact
- [ ] Release workflow MSI build passes without WIX0144