### PR TITLE
fix: preserve trailing newline in PLAN.md writes

### DIFF
--- a/apps/ta-cli/src/commands/plan.rs
+++ b/apps/ta-cli/src/commands/plan.rs
@@ -990,7 +990,12 @@ pub fn update_phase_status_with_schema(
         i += 1;
     }
 
-    result.join("\n")
+    let mut out = result.join("\n");
+    // Preserve trailing newline: `str::lines()` strips it, join() doesn't restore it.
+    if content.ends_with('\n') {
+        out.push('\n');
+    }
+    out
 }
 
 /// Read and parse PLAN.md from a project directory.
@@ -3310,6 +3315,18 @@ Write the completed PLAN.md to the workspace root. Do NOT write any other files.
 
 // ─── Plan Intelligence (v0.11.3) ─────────────────────────────────────────────
 
+fn join_preserving_newline(lines: &[impl AsRef<str>], original: &str) -> String {
+    let mut out = lines
+        .iter()
+        .map(|l| l.as_ref())
+        .collect::<Vec<_>>()
+        .join("\n");
+    if original.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
 fn plan_add_item(
     config: &GatewayConfig,
     description: &str,
@@ -3352,7 +3369,7 @@ fn plan_add_item(
     };
     let mut new_lines: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
     new_lines.insert(insert, new_item.clone());
-    std::fs::write(&plan_path, new_lines.join("\n"))?;
+    std::fs::write(&plan_path, join_preserving_newline(&new_lines, &content))?;
     println!("Added to phase {}: {}", target.id, new_item);
     Ok(())
 }
@@ -3412,7 +3429,7 @@ fn plan_move_item(
         }
     }
     nl.insert(last_item.map(|i| i + 1).unwrap_or(te), line.clone());
-    std::fs::write(&plan_path, nl.join("\n"))?;
+    std::fs::write(&plan_path, join_preserving_newline(&nl, &content))?;
     println!("Moved from {} to {}: {}", from_id, to_id, line.trim());
     Ok(())
 }
@@ -3501,6 +3518,9 @@ fn plan_create_phase(
     out.push_str(&section);
     if at < lines.len() {
         out.push_str(&lines[at..].join("\n"));
+    }
+    if content.ends_with('\n') && !out.ends_with('\n') {
+        out.push('\n');
     }
     std::fs::write(&plan_path, out)?;
     println!("Created phase: {} — {}", id, title);


### PR DESCRIPTION
## Summary
- `str::lines()` silently strips a trailing `\n`; `join("\n")` on the result never restores it
- Every PLAN.md write through `update_phase_status_with_schema`, `plan add-item`, `plan move-item`, and `plan create-phase` was stripping the file's terminal newline
- This caused a spurious one-line diff on every `ta run` invocation — the last line of PLAN.md appeared modified (git tracks the missing newline as a change)
- Adds `join_preserving_newline()` helper and applies it to all four write sites

## Test plan
- [ ] `./dev cargo clippy -p ta-cli -- -D warnings` passes
- [ ] `./dev cargo fmt --all -- --check` passes
- [ ] Run `ta run` on any phase and verify PLAN.md diff no longer shows a spurious trailing-line change

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)