### PR TITLE
fix: write stable MCP agent config for all goal types

### DIFF
--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -1889,10 +1889,11 @@ pub fn execute(
     // This file has STABLE content (no TA_PROJECT_ROOT varying per UUID staging path),
     // so Claude Code approves it once and never re-prompts. ta serve inherits the cwd
     // (staging_path) from the Claude process and discovers the project root that way.
-    if macro_goal {
-        if let Err(e) = write_stable_agent_mcp_config(&config.workspace_root, mcp_memory_injected) {
-            tracing::warn!("Failed to write stable MCP agent config: {}", e);
-        }
+    //
+    // Must run for ALL goal types (macro and non-macro): launch_agent_via_runtime always
+    // passes --mcp-config pointing here. If the file doesn't exist, claude exits code 1.
+    if let Err(e) = write_stable_agent_mcp_config(&config.workspace_root, mcp_memory_injected) {
+        tracing::warn!("Failed to write stable MCP agent config: {}", e);
     }
 
     // v0.13.8 item 12: Memory bridge — context mode.


### PR DESCRIPTION
## Summary
- `launch_agent_via_runtime` always passes `--mcp-config project_root/.ta/mcp-agent.json` to claude
- PR #504 introduced `write_stable_agent_mcp_config` but gated it behind `if macro_goal`
- Regular `ta run` (non-macro) never wrote the file → claude received `--mcp-config <nonexistent path>` → exited code 1 immediately
- Remove the `macro_goal` guard so the config is always written before any agent launch

## Test plan
- [ ] `ta run "..."` (non-macro) completes without immediate exit
- [ ] `ta run "..." --macro-goal` still works
- [ ] CI passes (clippy, fmt, tests)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)