### PR TITLE
fix: probe Nix PATH after reboot; fix MSI license.rtf path

### DIFF
--- a/apps/ta-cli/wix/main.wxs
+++ b/apps/ta-cli/wix/main.wxs
@@ -216,7 +216,7 @@
       Silent installs (/qn) bypass this UI entirely.
     -->
     <ui:WixUI Id="WixUI_FeatureTree" />
-    <WixVariable Id="WixUILicenseRtf" Value="license.rtf" />
+    <WixVariable Id="WixUILicenseRtf" Value="apps/ta-cli/wix/license.rtf" />
 
     <!--
       Custom action: run DISM to enable Client-ProjFS when the ProjFS feature is selected.

--- a/install_local.sh
+++ b/install_local.sh
@@ -58,6 +58,17 @@ run_cargo() {
     fi
 }
 
+# Probe for Nix at known install paths before relying on PATH.
+# After a reboot, Nix isn't on PATH in a fresh shell until the profile is sourced.
+if ! command -v nix &>/dev/null; then
+    for _nix_dir in "/nix/var/nix/profiles/default/bin" "$HOME/.nix-profile/bin"; do
+        if [[ -x "$_nix_dir/nix" ]]; then
+            export PATH="$_nix_dir:$PATH"
+            break
+        fi
+    done
+fi
+
 if command -v nix &>/dev/null && [[ -f flake.nix ]]; then
     echo "  Using Nix devShell..."
     export PATH="/nix/var/nix/profiles/default/bin:$HOME/.nix-profile/bin:$PATH"


### PR DESCRIPTION
## Summary

- **install_local.sh**: After a system reboot, Nix isn't on PATH in a fresh shell until the profile is sourced. The script called `command -v nix` before adding Nix to PATH — chicken-and-egg that produced _"Neither Nix nor Cargo found."_ Fix: probe known Nix install paths (`/nix/var/nix/profiles/default/bin`, `~/.nix-profile/bin`) directly before the `command -v` check.

- **apps/ta-cli/wix/main.wxs**: `wix build` is invoked from the repo root in both nightly and release workflows. `WixUILicenseRtf` was set to `"license.rtf"` (relative), which WiX resolves from the working directory (repo root) — not from the `.wxs` file's directory. The file lives at `apps/ta-cli/wix/license.rtf`. Fix: use the repo-root-relative path so both CI workflows find it.

  This was causing the nightly Windows MSI build to fail for at least 3 consecutive days:
  ```
  error WIX0103: Cannot find the Control file 'license.rtf'. The following paths were checked: license.rtf
  ```

## Test plan

- [ ] Run `./install_local.sh` in a fresh shell after reboot (or with Nix not on PATH) — should proceed to build instead of erroring
- [ ] Nightly Windows CI build should produce the MSI successfully