### PR TITLE
fix: daemon restart sends SIGTERM on 3s HTTP timeout

### DIFF
--- a/apps/ta-cli/src/commands/daemon.rs
+++ b/apps/ta-cli/src/commands/daemon.rs
@@ -324,8 +324,10 @@ pub fn stop(project_root: &Path) -> anyhow::Result<()> {
     // The shutdown endpoint requires X-TA-Admin-Confirm: shutdown (v0.17.0.9)
     // to prevent accidental shutdown by agent subprocesses. Auth is bypassed for
     // loopback, so no Bearer token is needed from the CLI.
+    // Use a 10s timeout: the daemon is known alive (drain check already passed),
+    // so 3s was too short — a busy daemon handling drain cleanup could miss it.
     let client = reqwest::blocking::Client::builder()
-        .timeout(std::time::Duration::from_secs(3))
+        .timeout(std::time::Duration::from_secs(10))
         .build()?;
 
     let resp = client
@@ -342,18 +344,26 @@ pub fn stop(project_root: &Path) -> anyhow::Result<()> {
             false // fall through to PID kill
         }
         Ok(_) => true,
-        Err(_) => false,
+        Err(e) if e.is_timeout() => {
+            // Daemon is alive (drain check passed) but took > 10s to ack shutdown.
+            // Send SIGTERM — the daemon's signal handler triggers clean shutdown.
+            eprintln!(
+                "Warning: daemon did not acknowledge HTTP shutdown within 10s \
+                 — sending SIGTERM to allow clean exit. Use --force to skip waiting."
+            );
+            false
+        }
+        Err(_) => false, // connection error: daemon not reachable, fall through to PID
     };
 
     if !http_sent {
-        // If HTTP fails, try to kill by PID.
+        // HTTP shutdown didn't succeed — try to kill by PID.
         if let Some(pid) = read_pid(project_root) {
             if is_process_alive(pid) {
                 #[cfg(unix)]
                 {
                     let _ = Command::new("kill").arg(pid.to_string()).output();
                 }
-                eprintln!("Sent SIGTERM to daemon (pid {}).", pid);
             } else {
                 eprintln!("Daemon not running (stale PID file).");
                 remove_pid_file(project_root);


### PR DESCRIPTION
## Summary
- `stop()` used a 3s HTTP timeout to send `POST /api/shutdown`. After `drain_and_poll` confirmed the daemon was alive, a busy daemon taking >3s to ack caused the timeout error to fall through to the PID SIGTERM path — printing \"Sent SIGTERM to daemon\" during a normal graceful restart.
- Raise shutdown HTTP timeout from 3s to 10s (daemon is known alive after drain check)
- Distinguish `e.is_timeout()` from connection errors: timeout → warn + SIGTERM with explanation; connection error → silent PID fallback
- Remove alarming \"Sent SIGTERM to daemon (pid N)\" from the silent connection-error path

## Test plan
- [ ] `ta daemon restart` on a running daemon completes without printing SIGTERM message
- [ ] `ta daemon restart --force` still works (skips drain entirely, uses SIGKILL path)
- [ ] `ta daemon restart` when daemon is not running prints \"Daemon not running\" not SIGTERM