### PR TITLE
v0.17.0.12.14 — Plugin/Adapter/Connector Unification (4 Categories)

### DIFF
--- a/.ta/plan_history.jsonl
+++ b/.ta/plan_history.jsonl
@@ -452,3 +452,4 @@
 {"new_status":"in_progress","old_status":"pending","phase_id":"v0.17.0.12.13","source":"daemon_claim","timestamp":"2026-07-06T03:43:50.761264+00:00"}
 {"new_status":"done","old_status":"in_progress","phase_id":"v0.17.0.12.13","timestamp":"2026-07-06T04:26:16.020953+00:00"}
 {"new_status":"in_progress","old_status":"pending","phase_id":"v0.17.0.12.14","source":"daemon_claim","timestamp":"2026-07-06T14:50:53.582802+00:00"}
+{"new_status":"done","old_status":"in_progress","phase_id":"v0.17.0.12.14","timestamp":"2026-07-06T15:49:50.929850+00:00"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All outcomes must be **observable** (with details and logging) and **actionable*
 
 ## Current State
 
-**Current version**: `0.17.0-alpha.12.13`
+**Current version**: `0.17.0-alpha.12.14`
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --phase 4b`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "ta-actions"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "serde",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "ta-advisor"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "ta-agent-ollama"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "ta-build"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3657,6 +3657,7 @@ dependencies = [
  "ta-mediation",
  "ta-memory",
  "ta-output-schema",
+ "ta-plugin",
  "ta-policy",
  "ta-runtime",
  "ta-session",
@@ -3675,7 +3676,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-comfyui"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -3690,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3704,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3718,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "serde",
@@ -3735,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3744,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3753,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3767,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unity"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "serde",
@@ -3780,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unreal"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "serde",
@@ -3794,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3803,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "serde",
@@ -3817,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3866,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-overlay"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "serde",
@@ -3880,20 +3881,23 @@ dependencies = [
 
 [[package]]
 name = "ta-db-proxy"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "serde",
  "serde_json",
  "ta-db-overlay",
+ "ta-plugin",
+ "tempfile",
  "thiserror 2.0.18",
+ "toml 0.8.23",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "ta-db-proxy-sqlite"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -3909,7 +3913,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3927,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "ta-extension"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3944,7 +3948,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3960,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "ta-governed-paths"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "serde",
@@ -3974,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "ta-init"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3987,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "regex",
@@ -4020,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "serde",
@@ -4035,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "glob",
@@ -4053,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "ta-output-schema"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -4064,8 +4068,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ta-plugin"
+version = "0.17.0-alpha.12.14"
+dependencies = [
+ "libc",
+ "serde",
+ "serde_json",
+ "ta-runtime",
+ "ta-submit",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toml 0.8.23",
+]
+
+[[package]]
 name = "ta-policy"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "glob",
@@ -4080,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "ta-runtime"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4091,6 +4109,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "ta-credentials",
+ "ta-plugin",
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",
@@ -4101,7 +4120,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -4114,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "libc",
@@ -4132,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "chrono",
  "libc",
@@ -4140,6 +4159,7 @@ dependencies = [
  "serde_json",
  "ta-changeset",
  "ta-goal",
+ "ta-plugin",
  "ta-workspace",
  "tempfile",
  "thiserror 2.0.18",
@@ -4150,7 +4170,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4169,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/ta-workflow",
     "crates/ta-build",
     "crates/ta-output-schema",
+    "crates/ta-plugin",
     "crates/ta-runtime",
     "crates/ta-actions",
     "crates/ta-db-overlay",
@@ -55,7 +56,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.17.0-alpha.12.13"
+version = "0.17.0-alpha.12.14"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -9413,19 +9413,19 @@ Each phase: `ta run --headless --phase X` → draft → `agent_review` → if Ap
 
 ---
 ### v0.17.0.12.14 — Plugin/Adapter/Connector Unification (4 Categories)
-<!-- status: in_progress -->
+<!-- status: done -->
 **Depends on**: v0.17.0.12.12
 
 **Goal**: Implement the 4-category extensibility model from `docs/design/ta-concepts-and-architecture.md` §2.2 — Plugin (external, call/response, community-contributable), Channel/Listener (external, long-running, supervised), Backend (in-process, core-only), Resource list (declarative registry) — replacing the 12 independently-evolved patterns found in the architecture review.
 
 **Items**:
-1. [ ] Extract one shared JSON-over-stdio protocol crate/trait from the currently-independent VCS/messaging/social/agent-runtime plugin implementations, matching VCS's existing `method: String` dispatch shape (most mature). Migrate all four onto it without changing external plugin-facing behavior.
-2. [ ] Define one shared `plugin.toml` manifest schema and `.ta/plugins/<kind>/<name>/` discovery convention used by every Plugin-category integration.
-3. [ ] Migrate `EXTERNAL_TOOLS` (hardcoded array, `apps/ta-cli/src/commands/tools.rs`) onto the Plugin category — a community member can add a new tool without a TA core PR.
-4. [ ] Migrate `DbProxyPlugin` onto the Plugin category per the 2026-07-03 DB proxy redesign (SQL/NoSQL facets, `.ta/db-adapters.toml` registry).
-5. [ ] Implement `ReleaseAdapter` (currently only planned in PLAN.md v0.17.2/17.3, never built) directly onto the Plugin category from the start.
-6. [ ] Tests: a synthetic community-authored plugin fixture is discovered and invoked identically for at least two different Plugin-category integrations via the shared protocol — proving the unification shares code, not just documentation.
-7. [ ] USAGE.md: one "Authoring a Plugin" guide replacing the currently-scattered per-family docs.
+1. [x] Extract one shared JSON-over-stdio protocol crate/trait from the currently-independent VCS/messaging/social/agent-runtime plugin implementations, matching VCS's existing `method: String` dispatch shape (most mature). Migrate all four onto it without changing external plugin-facing behavior.
+2. [x] Define one shared `plugin.toml` manifest schema and `.ta/plugins/<kind>/<name>/` discovery convention used by every Plugin-category integration.
+3. [x] Migrate `EXTERNAL_TOOLS` (hardcoded array, `apps/ta-cli/src/commands/tools.rs`) onto the Plugin category — a community member can add a new tool without a TA core PR.
+4. [x] Migrate `DbProxyPlugin` onto the Plugin category per the 2026-07-03 DB proxy redesign (SQL/NoSQL facets, `.ta/db-adapters.toml` registry).
+5. [x] Implement `ReleaseAdapter` (currently only planned in PLAN.md v0.17.2/17.3, never built) directly onto the Plugin category from the start.
+6. [x] Tests: a synthetic community-authored plugin fixture is discovered and invoked identically for at least two different Plugin-category integrations via the shared protocol — proving the unification shares code, not just documentation.
+7. [x] USAGE.md: one "Authoring a Plugin" guide replacing the currently-scattered per-family docs.
 
 #### Version: `0.17.0-alpha.12.14`
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -43,28 +43,29 @@ which = { workspace = true }
 arboard = { workspace = true }
 
 # Internal crates — version kept in sync with workspace by bump-version.sh
-ta-audit = { path = "../../crates/ta-audit", version = "0.17.0-alpha.12.13" }
-ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.0-alpha.12.13" }
-ta-memory = { path = "../../crates/ta-memory", version = "0.17.0-alpha.12.13" }
-ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.0-alpha.12.13" }
-ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.0-alpha.12.13" }
-ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.0-alpha.12.13" }
-ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.0-alpha.12.13" }
-ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.0-alpha.12.13" }
-ta-goal = { path = "../../crates/ta-goal", version = "0.17.0-alpha.12.13" }
-ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.0-alpha.12.13" }
-ta-policy = { path = "../../crates/ta-policy", version = "0.17.0-alpha.12.13" }
-ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.0-alpha.12.13" }
-ta-session = { path = "../../crates/ta-session", version = "0.17.0-alpha.12.13" }
-ta-events = { path = "../../crates/ta-events", version = "0.17.0-alpha.12.13" }
-ta-submit = { path = "../../crates/ta-submit", version = "0.17.0-alpha.12.13" }
-ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.0-alpha.12.13" }
-ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.0-alpha.12.13" }
-ta-build = { path = "../../crates/ta-build", version = "0.17.0-alpha.12.13" }
-ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.0-alpha.12.13" }
-ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.0-alpha.12.13" }
-ta-init = { path = "../../crates/ta-init", version = "0.17.0-alpha.12.13" }
-ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.0-alpha.12.13" }
+ta-audit = { path = "../../crates/ta-audit", version = "0.17.0-alpha.12.14" }
+ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.0-alpha.12.14" }
+ta-memory = { path = "../../crates/ta-memory", version = "0.17.0-alpha.12.14" }
+ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.0-alpha.12.14" }
+ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.0-alpha.12.14" }
+ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.0-alpha.12.14" }
+ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.0-alpha.12.14" }
+ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.0-alpha.12.14" }
+ta-goal = { path = "../../crates/ta-goal", version = "0.17.0-alpha.12.14" }
+ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.0-alpha.12.14" }
+ta-policy = { path = "../../crates/ta-policy", version = "0.17.0-alpha.12.14" }
+ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.0-alpha.12.14" }
+ta-session = { path = "../../crates/ta-session", version = "0.17.0-alpha.12.14" }
+ta-events = { path = "../../crates/ta-events", version = "0.17.0-alpha.12.14" }
+ta-submit = { path = "../../crates/ta-submit", version = "0.17.0-alpha.12.14" }
+ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.0-alpha.12.14" }
+ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.0-alpha.12.14" }
+ta-build = { path = "../../crates/ta-build", version = "0.17.0-alpha.12.14" }
+ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.0-alpha.12.14" }
+ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.0-alpha.12.14" }
+ta-init = { path = "../../crates/ta-init", version = "0.17.0-alpha.12.14" }
+ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.0-alpha.12.14" }
+ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.0-alpha.12.14" }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/apps/ta-cli/src/commands/release_git.rs
+++ b/apps/ta-cli/src/commands/release_git.rs
@@ -270,17 +270,201 @@ impl ReleaseAdapter for SvnAdapter {
     }
 }
 
+/// External-process `ReleaseAdapter` (§2.2 Plugin category), discovered via
+/// `.ta/plugins/release/<name>/plugin.toml`. Lets a community member ship a
+/// custom release adapter (e.g. `AppStoreReleaseAdapter`, `ItchIoReleaseAdapter`)
+/// without a TA core PR, per v0.17.0.12.14 item 5.
+#[allow(dead_code)]
+pub struct ExternalReleaseAdapter {
+    name: String,
+    command: String,
+    args: Vec<String>,
+    timeout: std::time::Duration,
+}
+
+#[derive(serde::Serialize)]
+struct BumpVersionParams<'a> {
+    root: &'a str,
+    new_version: &'a str,
+}
+#[derive(serde::Serialize)]
+struct CommitAndTagParams<'a> {
+    root: &'a str,
+    message: &'a str,
+    tag: &'a str,
+}
+#[derive(serde::Serialize)]
+struct PushParams<'a> {
+    root: &'a str,
+    remote: &'a str,
+    args: &'a [&'a str],
+}
+#[derive(serde::Serialize)]
+struct CreateReleaseDraftParams<'a> {
+    root: &'a str,
+    tag: &'a str,
+    notes: &'a str,
+}
+#[derive(serde::Serialize)]
+struct TagOnlyParams<'a> {
+    root: &'a str,
+    tag: &'a str,
+}
+#[derive(serde::Serialize)]
+struct DispatchWorkflowParams<'a> {
+    root: &'a str,
+    tag: &'a str,
+    prerelease: bool,
+}
+
+#[allow(dead_code)]
+impl ExternalReleaseAdapter {
+    /// Resolve `name` via `.ta/plugins/release/<name>/plugin.toml` discovery.
+    pub fn discover(name: &str, project_root: &Path) -> Option<Self> {
+        let found = ta_plugin::find_plugin("release", name, project_root)?;
+        Some(Self {
+            name: found.manifest.name.clone(),
+            command: found
+                .plugin_dir
+                .join(&found.manifest.command)
+                .to_string_lossy()
+                .to_string(),
+            args: found.manifest.args.clone(),
+            timeout: found.manifest.timeout(60),
+        })
+    }
+
+    /// The adapter name this instance was discovered as (for tests/diagnostics).
+    pub fn adapter_name(&self) -> &str {
+        &self.name
+    }
+
+    fn call<Req: serde::Serialize>(
+        &self,
+        method: &str,
+        root: &Path,
+        params: &Req,
+    ) -> anyhow::Result<()> {
+        let request = ta_plugin::PluginRequest::new(method, serde_json::to_value(params)?);
+        let response: ta_plugin::PluginResponse = ta_plugin::transport::call_json(
+            &self.name,
+            method,
+            &self.command,
+            &self.args,
+            root,
+            &request,
+            self.timeout,
+        )
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "release plugin '{}' method '{method}' failed: {e}",
+                self.name
+            )
+        })?;
+        if !response.ok {
+            anyhow::bail!(
+                "release plugin '{}' method '{method}' failed: {}",
+                self.name,
+                response
+                    .error
+                    .unwrap_or_else(|| "unknown error".to_string())
+            );
+        }
+        Ok(())
+    }
+}
+
+impl ReleaseAdapter for ExternalReleaseAdapter {
+    fn bump_version(&self, root: &Path, new_version: &str) -> anyhow::Result<()> {
+        self.call(
+            "bump_version",
+            root,
+            &BumpVersionParams {
+                root: &root.to_string_lossy(),
+                new_version,
+            },
+        )
+    }
+
+    fn commit_and_tag(&self, root: &Path, message: &str, tag: &str) -> anyhow::Result<()> {
+        self.call(
+            "commit_and_tag",
+            root,
+            &CommitAndTagParams {
+                root: &root.to_string_lossy(),
+                message,
+                tag,
+            },
+        )
+    }
+
+    fn push(&self, root: &Path, remote: &str, args: &[&str]) -> anyhow::Result<()> {
+        self.call(
+            "push",
+            root,
+            &PushParams {
+                root: &root.to_string_lossy(),
+                remote,
+                args,
+            },
+        )
+    }
+
+    fn create_release_draft(&self, root: &Path, tag: &str, notes: &str) -> anyhow::Result<()> {
+        self.call(
+            "create_release_draft",
+            root,
+            &CreateReleaseDraftParams {
+                root: &root.to_string_lossy(),
+                tag,
+                notes,
+            },
+        )
+    }
+
+    fn publish_release(&self, root: &Path, tag: &str) -> anyhow::Result<()> {
+        self.call(
+            "publish_release",
+            root,
+            &TagOnlyParams {
+                root: &root.to_string_lossy(),
+                tag,
+            },
+        )
+    }
+
+    fn dispatch_workflow(&self, root: &Path, tag: &str, prerelease: bool) -> anyhow::Result<()> {
+        self.call(
+            "dispatch_workflow",
+            root,
+            &DispatchWorkflowParams {
+                root: &root.to_string_lossy(),
+                tag,
+                prerelease,
+            },
+        )
+    }
+}
+
 /// Resolve a `ReleaseAdapter` from an adapter name string.
 ///
 /// Used by the pipeline to select the right adapter based on `.ta/release.yaml`
-/// `adapter:` key. The git adapter is the default.
+/// `adapter:` key. Checks `.ta/plugins/release/<name>/plugin.toml` (Plugin
+/// category, community-contributable) before falling back to the built-in
+/// git/perforce/svn adapters. The git adapter is the default.
 #[allow(dead_code)]
-pub fn resolve_adapter(adapter_name: Option<&str>) -> Box<dyn ReleaseAdapter> {
-    match adapter_name.unwrap_or("git") {
-        "perforce" | "p4" => Box::new(PerforceAdapter),
-        "svn" | "subversion" => Box::new(SvnAdapter),
-        _ => Box::new(GitAdapter),
+pub fn resolve_adapter(adapter_name: Option<&str>, project_root: &Path) -> Box<dyn ReleaseAdapter> {
+    if let Some(name) = adapter_name {
+        if let Some(external) = ExternalReleaseAdapter::discover(name, project_root) {
+            return Box::new(external);
+        }
+        match name {
+            "perforce" | "p4" => return Box::new(PerforceAdapter),
+            "svn" | "subversion" => return Box::new(SvnAdapter),
+            _ => {}
+        }
     }
+    Box::new(GitAdapter)
 }
 
 /// Check whether the working tree has any uncommitted changes (staged or unstaged).
@@ -475,4 +659,73 @@ pub fn git_log_format(root: &Path, format: &str, range: Option<&str>) -> anyhow:
         );
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_adapter_falls_back_to_git_without_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        // No adapter name, and no .ta/plugins/release/ manifests — must fall
+        // back to the default GitAdapter rather than panicking or erroring.
+        let _adapter = resolve_adapter(None, dir.path());
+    }
+
+    #[test]
+    fn resolve_adapter_falls_back_to_perforce_without_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        let _adapter = resolve_adapter(Some("perforce"), dir.path());
+    }
+
+    #[test]
+    fn resolve_adapter_discovers_external_release_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join(".ta/plugins/release/custom");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.toml"),
+            "name = \"custom\"\ntype = \"release\"\ncommand = \"custom-release-bin\"\n",
+        )
+        .unwrap();
+
+        let adapter = ExternalReleaseAdapter::discover("custom", dir.path()).unwrap();
+        assert_eq!(adapter.adapter_name(), "custom");
+
+        // resolve_adapter must pick the external plugin path over perforce/svn/git.
+        let _adapter = resolve_adapter(Some("custom"), dir.path());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_release_adapter_bump_version_via_mock_plugin() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join(".ta/plugins/release/mockrelease");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+
+        let script_path = plugin_dir.join("mockrelease-plugin.sh");
+        std::fs::write(
+            &script_path,
+            "#!/bin/sh\nread -r line\necho '{\"ok\":true,\"result\":{}}'\n",
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+
+        std::fs::write(
+            plugin_dir.join("plugin.toml"),
+            format!(
+                "name = \"mockrelease\"\ntype = \"release\"\ncommand = \"{}\"\n",
+                script_path.display()
+            ),
+        )
+        .unwrap();
+
+        let adapter = ExternalReleaseAdapter::discover("mockrelease", dir.path()).unwrap();
+        adapter.bump_version(dir.path(), "1.2.3").unwrap();
+    }
 }

--- a/apps/ta-cli/src/commands/tools.rs
+++ b/apps/ta-cli/src/commands/tools.rs
@@ -1,15 +1,22 @@
 // tools.rs — `ta tools` command: list and install optional external tools.
 //
-// Optional tools are registered in this file as a static EXTERNAL_TOOLS list.
-// Adding a new tool requires:
-//   1. An entry in EXTERNAL_TOOLS below
-//   2. A corresponding plugins/<name>/plugin.toml manifest (documentation)
+// Built-in tools are registered in this file as a static EXTERNAL_TOOLS list
+// (used as-is by the onboard wizard's Step 4 checkbox list, which predates
+// any project context and only ever offers the built-ins). Adding a
+// *built-in* tool requires an entry in EXTERNAL_TOOLS below.
 //
-// The onboard wizard (onboard.rs) imports EXTERNAL_TOOLS to populate its
-// Step 4 "Optional Components" checkbox list dynamically.
+// Community-authored tools (v0.17.0.12.14, Plugin category §2.2) don't
+// require a TA core PR: `ta tools list`/`ta tools install` additionally
+// discover `.ta/plugins/tool/<name>/plugin.toml` manifests via
+// `ta_plugin::discover_plugins`, using a `[tool]` extension table for the
+// fields (label/detect_command/install_hint/install) that aren't part of
+// the shared `PluginManifest` schema.
+
+use std::path::Path;
 
 use anyhow::Result;
 use clap::Subcommand;
+use serde::Deserialize;
 
 /// An optional external tool that TA can use but does not require.
 pub struct ExternalTool {
@@ -78,6 +85,84 @@ pub const EXTERNAL_TOOLS: &[ExternalTool] = &[
     },
 ];
 
+// ---------------------------------------------------------------------------
+// Community-authored tools (Plugin category, §2.2) — `.ta/plugins/tool/<name>/plugin.toml`
+// ---------------------------------------------------------------------------
+
+/// A community-authored tool, discovered from a `.ta/plugins/tool/<name>/plugin.toml`
+/// manifest rather than compiled into `EXTERNAL_TOOLS`.
+struct DiscoveredTool {
+    name: String,
+    label: String,
+    description: String,
+    detect_command: String,
+    install_hint: String,
+    install: ToolInstallSpec,
+}
+
+/// The `[tool]` extension table parsed alongside the shared `PluginManifest`
+/// fields (name/type/command/description) for a `kind = "tool"` manifest.
+#[derive(Debug, Clone, Deserialize)]
+struct ToolManifestExtra {
+    tool: ToolExtraFields,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ToolExtraFields {
+    label: String,
+    #[serde(default)]
+    description: Option<String>,
+    detect_command: String,
+    install_hint: String,
+    install: ToolInstallSpec,
+}
+
+/// Same shape as `ExternalToolInstall`, but with owned fields since it comes
+/// from a parsed TOML manifest rather than a `&'static` compile-time const.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum ToolInstallSpec {
+    Cargo { package: String },
+    Npm { package: String },
+    Git { url: String, dest: String },
+    ClaudePlugin { spec: String },
+}
+
+/// Discover community-authored tools from `.ta/plugins/tool/<name>/plugin.toml`
+/// (project-local then user-global). Manifests whose `name` collides with a
+/// built-in `EXTERNAL_TOOLS` entry are skipped — built-ins always win.
+fn discover_community_tools(project_root: &Path) -> Vec<DiscoveredTool> {
+    let mut tools = vec![];
+    for discovered in ta_plugin::discover_plugins("tool", project_root) {
+        if EXTERNAL_TOOLS
+            .iter()
+            .any(|t| t.name == discovered.manifest.name)
+        {
+            continue;
+        }
+        let manifest_path = discovered.plugin_dir.join("plugin.toml");
+        let Ok(text) = std::fs::read_to_string(&manifest_path) else {
+            continue;
+        };
+        let Ok(extra) = toml::from_str::<ToolManifestExtra>(&text) else {
+            continue;
+        };
+        tools.push(DiscoveredTool {
+            name: discovered.manifest.name,
+            label: extra.tool.label,
+            description: extra
+                .tool
+                .description
+                .or(discovered.manifest.description)
+                .unwrap_or_default(),
+            detect_command: extra.tool.detect_command,
+            install_hint: extra.tool.install_hint,
+            install: extra.tool.install,
+        });
+    }
+    tools
+}
+
 #[derive(Debug, Subcommand)]
 pub enum ToolsCommands {
     /// Show all optional tools and whether they are installed.
@@ -107,6 +192,9 @@ pub fn execute(command: &ToolsCommands) -> Result<()> {
 }
 
 fn list_tools() -> Result<()> {
+    let project_root = std::env::current_dir().unwrap_or_default();
+    let community_tools = discover_community_tools(&project_root);
+
     println!("Optional tools for Trusted Autonomy:\n");
     for tool in EXTERNAL_TOOLS {
         let installed = check_tool_installed(tool);
@@ -120,7 +208,23 @@ fn list_tools() -> Result<()> {
         println!("  {:<20} {}", "", tool.install_hint);
         println!();
     }
-    if EXTERNAL_TOOLS.iter().any(|t| !check_tool_installed(t)) {
+    for tool in &community_tools {
+        let installed = check_detect_command(&tool.detect_command);
+        let status = if installed {
+            "✓ installed"
+        } else {
+            "✗ not found"
+        };
+        println!("  {:<20} {} (community)", tool.name, status);
+        println!("  {:<20} {}", "", tool.description);
+        println!("  {:<20} {}", "", tool.install_hint);
+        println!();
+    }
+    if EXTERNAL_TOOLS.iter().any(|t| !check_tool_installed(t))
+        || community_tools
+            .iter()
+            .any(|t| !check_detect_command(&t.detect_command))
+    {
         println!("Install missing tools with:  ta tools install <name>");
     }
     Ok(())
@@ -128,14 +232,20 @@ fn list_tools() -> Result<()> {
 
 /// Returns true if the tool's detect_command succeeds.
 pub fn check_tool_installed(tool: &ExternalTool) -> bool {
-    if let Some(path) = tool.detect_command.strip_prefix("test -d ") {
+    check_detect_command(tool.detect_command)
+}
+
+/// Shared detect-command evaluation for both built-in (`ExternalTool`) and
+/// community-authored (`DiscoveredTool`) tools.
+fn check_detect_command(detect_command: &str) -> bool {
+    if let Some(path) = detect_command.strip_prefix("test -d ") {
         let expanded = path.replace('~', &std::env::var("HOME").unwrap_or_default());
         return std::path::Path::new(&expanded).is_dir();
     }
-    if let Some(plugin_name) = tool.detect_command.strip_prefix("claude-plugin:") {
+    if let Some(plugin_name) = detect_command.strip_prefix("claude-plugin:") {
         return check_claude_plugin_installed(plugin_name);
     }
-    let parts: Vec<&str> = tool.detect_command.split_whitespace().collect();
+    let parts: Vec<&str> = detect_command.split_whitespace().collect();
     if parts.is_empty() {
         return false;
     }
@@ -198,92 +308,125 @@ fn claude_cli_missing_message(tool_name: &str) -> String {
 }
 
 pub fn install_tool(name: &str) -> Result<()> {
-    let tool = EXTERNAL_TOOLS
+    if let Some(tool) = EXTERNAL_TOOLS.iter().find(|t| t.name == name) {
+        if check_tool_installed(tool) {
+            println!("{} is already installed.", tool.label);
+            return Ok(());
+        }
+        return match &tool.install {
+            ExternalToolInstall::Cargo(crate_name) => {
+                install_via_cargo(tool.label, crate_name, tool.install_hint)
+            }
+            ExternalToolInstall::Npm(pkg) => install_via_npm(tool.label, pkg, tool.install_hint),
+            ExternalToolInstall::Git { url, dest } => {
+                install_via_git(tool.label, url, dest, tool.install_hint)
+            }
+            ExternalToolInstall::ClaudePlugin(plugin_spec) => {
+                install_via_claude_plugin(tool.name, tool.label, plugin_spec, tool.install_hint)
+            }
+        };
+    }
+
+    let project_root = std::env::current_dir().unwrap_or_default();
+    let community_tools = discover_community_tools(&project_root);
+    let tool = community_tools
         .iter()
         .find(|t| t.name == name)
         .ok_or_else(|| {
             anyhow::anyhow!("Unknown tool '{name}'. Run `ta tools list` to see available tools.")
         })?;
 
-    if check_tool_installed(tool) {
+    if check_detect_command(&tool.detect_command) {
         println!("{} is already installed.", tool.label);
         return Ok(());
     }
 
     match &tool.install {
-        ExternalToolInstall::Cargo(crate_name) => {
-            if which::which("cargo").is_err() {
-                anyhow::bail!(cargo_missing_message(
-                    crate_name,
-                    cfg!(target_os = "windows")
-                ));
-            }
-            println!(
-                "Installing {} via cargo install {}...",
-                tool.label, crate_name
-            );
-            let status = std::process::Command::new("cargo")
-                .args(["install", crate_name])
-                .status()
-                .map_err(|e| anyhow::anyhow!("Failed to run cargo: {e}"))?;
-            if !status.success() {
-                anyhow::bail!(
-                    "cargo install {crate_name} failed.\nTry manually: {}",
-                    tool.install_hint
-                );
-            }
-            println!("{} installed successfully.", tool.label);
+        ToolInstallSpec::Cargo { package } => {
+            install_via_cargo(&tool.label, package, &tool.install_hint)
         }
-        ExternalToolInstall::Npm(pkg) => {
-            println!("Installing {} via npm install -g {}...", tool.label, pkg);
-            let status = std::process::Command::new("npm")
-                .args(["install", "-g", pkg])
-                .status()
-                .map_err(|e| {
-                    anyhow::anyhow!("npm not found: {e}. Install Node.js from https://nodejs.org")
-                })?;
-            if !status.success() {
-                anyhow::bail!("npm install failed.\nTry manually: {}", tool.install_hint);
-            }
-            println!("{} installed successfully.", tool.label);
+        ToolInstallSpec::Npm { package } => {
+            install_via_npm(&tool.label, package, &tool.install_hint)
         }
-        ExternalToolInstall::Git { url, dest } => {
-            let expanded_dest = dest.replace('~', &std::env::var("HOME").unwrap_or_default());
-            if std::path::Path::new(&expanded_dest).exists() {
-                println!("{} is already installed at {}.", tool.label, expanded_dest);
-                return Ok(());
-            }
-            println!("Cloning {} to {}...", tool.label, expanded_dest);
-            let status = std::process::Command::new("git")
-                .args(["clone", "--depth=1", url, &expanded_dest])
-                .status()
-                .map_err(|e| anyhow::anyhow!("git not found: {e}. Install git first."))?;
-            if !status.success() {
-                anyhow::bail!("git clone failed.\nTry manually: {}", tool.install_hint);
-            }
-            println!("{} installed to {}.", tool.label, expanded_dest);
+        ToolInstallSpec::Git { url, dest } => {
+            install_via_git(&tool.label, url, dest, &tool.install_hint)
         }
-        ExternalToolInstall::ClaudePlugin(plugin_spec) => {
-            if which::which("claude").is_err() {
-                anyhow::bail!(claude_cli_missing_message(tool.name));
-            }
-            println!(
-                "Installing {} via claude plugin install {}...",
-                tool.label, plugin_spec
-            );
-            let status = std::process::Command::new("claude")
-                .args(["plugin", "install", plugin_spec])
-                .status()
-                .map_err(|e| anyhow::anyhow!("Failed to run claude plugin install: {e}"))?;
-            if !status.success() {
-                anyhow::bail!(
-                    "claude plugin install failed.\nTry manually: {}",
-                    tool.install_hint
-                );
-            }
-            println!("{} installed successfully.", tool.label);
+        ToolInstallSpec::ClaudePlugin { spec } => {
+            install_via_claude_plugin(&tool.name, &tool.label, spec, &tool.install_hint)
         }
     }
+}
+
+fn install_via_cargo(label: &str, crate_name: &str, install_hint: &str) -> Result<()> {
+    if which::which("cargo").is_err() {
+        anyhow::bail!(cargo_missing_message(
+            crate_name,
+            cfg!(target_os = "windows")
+        ));
+    }
+    println!("Installing {label} via cargo install {crate_name}...");
+    let status = std::process::Command::new("cargo")
+        .args(["install", crate_name])
+        .status()
+        .map_err(|e| anyhow::anyhow!("Failed to run cargo: {e}"))?;
+    if !status.success() {
+        anyhow::bail!("cargo install {crate_name} failed.\nTry manually: {install_hint}");
+    }
+    println!("{label} installed successfully.");
+    Ok(())
+}
+
+fn install_via_npm(label: &str, pkg: &str, install_hint: &str) -> Result<()> {
+    println!("Installing {label} via npm install -g {pkg}...");
+    let status = std::process::Command::new("npm")
+        .args(["install", "-g", pkg])
+        .status()
+        .map_err(|e| {
+            anyhow::anyhow!("npm not found: {e}. Install Node.js from https://nodejs.org")
+        })?;
+    if !status.success() {
+        anyhow::bail!("npm install failed.\nTry manually: {install_hint}");
+    }
+    println!("{label} installed successfully.");
+    Ok(())
+}
+
+fn install_via_git(label: &str, url: &str, dest: &str, install_hint: &str) -> Result<()> {
+    let expanded_dest = dest.replace('~', &std::env::var("HOME").unwrap_or_default());
+    if std::path::Path::new(&expanded_dest).exists() {
+        println!("{label} is already installed at {expanded_dest}.");
+        return Ok(());
+    }
+    println!("Cloning {label} to {expanded_dest}...");
+    let status = std::process::Command::new("git")
+        .args(["clone", "--depth=1", url, &expanded_dest])
+        .status()
+        .map_err(|e| anyhow::anyhow!("git not found: {e}. Install git first."))?;
+    if !status.success() {
+        anyhow::bail!("git clone failed.\nTry manually: {install_hint}");
+    }
+    println!("{label} installed to {expanded_dest}.");
+    Ok(())
+}
+
+fn install_via_claude_plugin(
+    tool_name: &str,
+    label: &str,
+    plugin_spec: &str,
+    install_hint: &str,
+) -> Result<()> {
+    if which::which("claude").is_err() {
+        anyhow::bail!(claude_cli_missing_message(tool_name));
+    }
+    println!("Installing {label} via claude plugin install {plugin_spec}...");
+    let status = std::process::Command::new("claude")
+        .args(["plugin", "install", plugin_spec])
+        .status()
+        .map_err(|e| anyhow::anyhow!("Failed to run claude plugin install: {e}"))?;
+    if !status.success() {
+        anyhow::bail!("claude plugin install failed.\nTry manually: {install_hint}");
+    }
+    println!("{label} installed successfully.");
     Ok(())
 }
 
@@ -317,5 +460,67 @@ mod tests {
     #[test]
     fn external_tools_includes_meridian() {
         assert!(EXTERNAL_TOOLS.iter().any(|t| t.name == "meridian"));
+    }
+
+    #[test]
+    fn discovers_community_authored_tool_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join(".ta/plugins/tool/widget-cli");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.toml"),
+            r#"
+name = "widget-cli"
+type = "tool"
+command = ""
+description = "Community widget CLI"
+
+[tool]
+label = "Widget CLI"
+detect_command = "widget --version"
+install_hint = "cargo install widget-cli"
+
+[tool.install]
+kind = "cargo"
+package = "widget-cli"
+"#,
+        )
+        .unwrap();
+
+        let tools = discover_community_tools(dir.path());
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "widget-cli");
+        assert_eq!(tools[0].label, "Widget CLI");
+        assert!(
+            matches!(&tools[0].install, ToolInstallSpec::Cargo { package } if package == "widget-cli")
+        );
+    }
+
+    #[test]
+    fn community_tool_name_colliding_with_built_in_is_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join(".ta/plugins/tool/meridian");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.toml"),
+            r#"
+name = "meridian"
+type = "tool"
+command = ""
+
+[tool]
+label = "Fake Meridian"
+detect_command = "true"
+install_hint = "n/a"
+
+[tool.install]
+kind = "cargo"
+package = "meridian"
+"#,
+        )
+        .unwrap();
+
+        let tools = discover_community_tools(dir.path());
+        assert!(tools.is_empty());
     }
 }

--- a/crates/ta-advisor/Cargo.toml
+++ b/crates/ta-advisor/Cargo.toml
@@ -15,4 +15,4 @@ serde_json = { workspace = true }
 
 # Reuses the existing heuristic classifier as the substrate for the new
 # 4-way taxonomy rather than duplicating keyword-matching logic.
-ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.13" }
+ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.14" }

--- a/crates/ta-connectors/comfyui/Cargo.toml
+++ b/crates/ta-connectors/comfyui/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.0-alpha.12.13" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.0-alpha.12.14" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/discord/Cargo.toml
+++ b/crates/ta-connectors/discord/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.0-alpha.12.13" }
+ta-events = { path = "../../ta-events", version = "0.17.0-alpha.12.14" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/email/Cargo.toml
+++ b/crates/ta-connectors/email/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.0-alpha.12.13" }
+ta-events = { path = "../../ta-events", version = "0.17.0-alpha.12.14" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/fs/Cargo.toml
+++ b/crates/ta-connectors/fs/Cargo.toml
@@ -16,10 +16,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.0-alpha.12.13" }
-ta-workspace = { path = "../../ta-workspace", version = "0.17.0-alpha.12.13" }
-ta-audit = { path = "../../ta-audit", version = "0.17.0-alpha.12.13" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.0-alpha.12.14" }
+ta-workspace = { path = "../../ta-workspace", version = "0.17.0-alpha.12.14" }
+ta-audit = { path = "../../ta-audit", version = "0.17.0-alpha.12.14" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-ta-policy = { path = "../../ta-policy", version = "0.17.0-alpha.12.13" }
+ta-policy = { path = "../../ta-policy", version = "0.17.0-alpha.12.14" }

--- a/crates/ta-connectors/slack/Cargo.toml
+++ b/crates/ta-connectors/slack/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.0-alpha.12.13" }
+ta-events = { path = "../../ta-events", version = "0.17.0-alpha.12.14" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/unreal/Cargo.toml
+++ b/crates/ta-connectors/unreal/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.0-alpha.12.13" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.0-alpha.12.14" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -31,22 +31,22 @@ async-stream = { workspace = true }
 sha2 = { workspace = true }
 
 # Internal crates
-ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.0-alpha.12.13" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.13" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.13" }
-ta-memory = { path = "../ta-memory", version = "0.17.0-alpha.12.13" }
-ta-events = { path = "../ta-events", version = "0.17.0-alpha.12.13" }
-ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.13" }
-ta-runtime = { path = "../ta-runtime", version = "0.17.0-alpha.12.13" }
-ta-audit = { path = "../ta-audit", version = "0.17.0-alpha.12.13" }
-ta-policy = { path = "../ta-policy", version = "0.17.0-alpha.12.13" }
-ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.0-alpha.12.13" }
-ta-connector-email = { path = "../ta-connectors/email", version = "0.17.0-alpha.12.13" }
+ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.0-alpha.12.14" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.14" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.14" }
+ta-memory = { path = "../ta-memory", version = "0.17.0-alpha.12.14" }
+ta-events = { path = "../ta-events", version = "0.17.0-alpha.12.14" }
+ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.14" }
+ta-runtime = { path = "../ta-runtime", version = "0.17.0-alpha.12.14" }
+ta-audit = { path = "../ta-audit", version = "0.17.0-alpha.12.14" }
+ta-policy = { path = "../ta-policy", version = "0.17.0-alpha.12.14" }
+ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.0-alpha.12.14" }
+ta-connector-email = { path = "../ta-connectors/email", version = "0.17.0-alpha.12.14" }
 reqwest = { workspace = true }
-ta-output-schema = { path = "../ta-output-schema", version = "0.17.0-alpha.12.13" }
-ta-extension = { path = "../ta-extension", version = "0.17.0-alpha.12.13" }
-ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.13" }
-ta-advisor = { path = "../ta-advisor", version = "0.17.0-alpha.12.13" }
+ta-output-schema = { path = "../ta-output-schema", version = "0.17.0-alpha.12.14" }
+ta-extension = { path = "../ta-extension", version = "0.17.0-alpha.12.14" }
+ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.14" }
+ta-advisor = { path = "../ta-advisor", version = "0.17.0-alpha.12.14" }
 which = "7"
 libc = { workspace = true }
 async-trait = "0.1"

--- a/crates/ta-db-proxy-sqlite/Cargo.toml
+++ b/crates/ta-db-proxy-sqlite/Cargo.toml
@@ -18,8 +18,8 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 rusqlite = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.0-alpha.12.13" }
-ta-db-proxy = { path = "../ta-db-proxy", version = "0.17.0-alpha.12.13" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.0-alpha.12.14" }
+ta-db-proxy = { path = "../ta-db-proxy", version = "0.17.0-alpha.12.14" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-db-proxy/Cargo.toml
+++ b/crates/ta-db-proxy/Cargo.toml
@@ -17,4 +17,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.0-alpha.12.13" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.0-alpha.12.14" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.0-alpha.12.14" }
+toml = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/ta-db-proxy/src/external_plugin.rs
+++ b/crates/ta-db-proxy/src/external_plugin.rs
@@ -1,0 +1,190 @@
+//! External-process `DbProxyPlugin` implementation (§2.2 Plugin category),
+//! discovered via `.ta/plugins/db/<name>/plugin.toml`.
+
+use crate::classification::QueryClass;
+use crate::error::{ProxyError, Result};
+use crate::plugin::{DbProxyPlugin, ProxyConfig, ProxyHandle};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::time::Duration;
+
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+/// `DbProxyPlugin` that shells out to an external process for query
+/// classification and mutation replay, via the shared `ta_plugin` transport.
+#[derive(Debug)]
+pub struct ExternalDbProxyPlugin {
+    name: String,
+    command: String,
+    args: Vec<String>,
+    timeout: Duration,
+}
+
+impl ExternalDbProxyPlugin {
+    /// Resolve `name` via `.ta/plugins/db/<name>/plugin.toml` discovery.
+    pub fn discover(name: &str, project_root: &Path) -> Result<Self> {
+        let found = ta_plugin::find_plugin("db", name, project_root).ok_or_else(|| {
+            ProxyError::Plugin(format!("no db plugin manifest found for '{name}'"))
+        })?;
+        Ok(Self {
+            name: found.manifest.name.clone(),
+            command: found
+                .plugin_dir
+                .join(&found.manifest.command)
+                .to_string_lossy()
+                .to_string(),
+            args: found.manifest.args.clone(),
+            timeout: found.manifest.timeout(DEFAULT_TIMEOUT_SECS),
+        })
+    }
+}
+
+#[derive(Serialize)]
+struct ClassifyParams<'a> {
+    query: &'a str,
+}
+
+#[derive(Deserialize)]
+struct ClassifyResult {
+    class: QueryClass,
+}
+
+#[derive(Serialize)]
+struct ApplyMutationParams<'a> {
+    upstream_dsn: &'a str,
+    uri: &'a str,
+    before: Option<&'a serde_json::Value>,
+    after: &'a serde_json::Value,
+    staging_dir: String,
+}
+
+impl ExternalDbProxyPlugin {
+    /// Send one `{method,params}` request via the canonical `ta_plugin`
+    /// envelope (the reference shape for new Plugin-category integrations —
+    /// unlike VCS/messaging/social, db plugins have no pre-existing wire
+    /// format to preserve) and return the parsed `result` on `ok: true`.
+    fn call<Req: Serialize>(&self, method: &str, params: &Req) -> Result<serde_json::Value> {
+        let params_value = serde_json::to_value(params).map_err(|e| {
+            ProxyError::Plugin(format!("serialize params for method '{method}': {e}"))
+        })?;
+        let request = ta_plugin::PluginRequest::new(method, params_value);
+        let response: ta_plugin::PluginResponse = ta_plugin::transport::call_json(
+            &self.name,
+            method,
+            &self.command,
+            &self.args,
+            Path::new("."),
+            &request,
+            self.timeout,
+        )
+        .map_err(|e| {
+            ProxyError::Plugin(format!(
+                "db plugin '{}' method '{method}' failed: {e}",
+                self.name
+            ))
+        })?;
+
+        if !response.ok {
+            return Err(ProxyError::Plugin(format!(
+                "db plugin '{}' method '{method}' failed: {}",
+                self.name,
+                response
+                    .error
+                    .unwrap_or_else(|| "unknown error".to_string())
+            )));
+        }
+        Ok(response.result)
+    }
+}
+
+impl DbProxyPlugin for ExternalDbProxyPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn wire_protocol(&self) -> &str {
+        "external"
+    }
+
+    fn start(&self, config: ProxyConfig) -> Result<Box<dyn ProxyHandle>> {
+        Err(ProxyError::Plugin(format!(
+            "external db plugin '{}' listener lifecycle is not yet wired to a long-lived process \
+             (requested listen_addr: {}) — use classify_query/apply_mutation only until \
+             v0.17.0.12.15's Channel/Listener support lands",
+            self.name, config.listen_addr
+        )))
+    }
+
+    fn classify_query(&self, query: &str) -> QueryClass {
+        let params = ClassifyParams { query };
+        match self.call("classify_query", &params) {
+            Ok(result) => serde_json::from_value::<ClassifyResult>(result)
+                .map(|r| r.class)
+                .unwrap_or(QueryClass::Unknown),
+            Err(_) => QueryClass::Unknown,
+        }
+    }
+
+    fn apply_mutation(
+        &self,
+        upstream_dsn: &str,
+        uri: &str,
+        before: Option<&serde_json::Value>,
+        after: &serde_json::Value,
+        staging_dir: &Path,
+    ) -> Result<()> {
+        let params = ApplyMutationParams {
+            upstream_dsn,
+            uri,
+            before,
+            after,
+            staging_dir: staging_dir.to_string_lossy().to_string(),
+        };
+        self.call("apply_mutation", &params)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discover_reports_missing_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = ExternalDbProxyPlugin::discover("nonexistent", dir.path()).unwrap_err();
+        assert!(err.to_string().contains("nonexistent"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discover_and_classify_query_via_mock_plugin() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join(".ta/plugins/db/mockdb");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+
+        let script_path = plugin_dir.join("mockdb-plugin.sh");
+        std::fs::write(
+            &script_path,
+            "#!/bin/sh\nread -r line\necho '{\"ok\":true,\"result\":{\"class\":\"read\"}}'\n",
+        )
+        .unwrap();
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+
+        std::fs::write(
+            plugin_dir.join("plugin.toml"),
+            format!(
+                "name = \"mockdb\"\ntype = \"db\"\ncommand = \"{}\"\n",
+                script_path.display()
+            ),
+        )
+        .unwrap();
+
+        let plugin = ExternalDbProxyPlugin::discover("mockdb", dir.path()).unwrap();
+        assert_eq!(plugin.classify_query("SELECT 1"), QueryClass::Read);
+    }
+}

--- a/crates/ta-db-proxy/src/lib.rs
+++ b/crates/ta-db-proxy/src/lib.rs
@@ -5,8 +5,12 @@
 
 pub mod classification;
 pub mod error;
+pub mod external_plugin;
 pub mod plugin;
+pub mod registry;
 
 pub use classification::{MutationKind, QueryClass};
 pub use error::ProxyError;
+pub use external_plugin::ExternalDbProxyPlugin;
 pub use plugin::{DbProxyPlugin, ProxyConfig, ProxyHandle};
+pub use registry::{DbAdapterEntry, DbAdapterRegistry};

--- a/crates/ta-db-proxy/src/registry.rs
+++ b/crates/ta-db-proxy/src/registry.rs
@@ -1,0 +1,72 @@
+//! `.ta/db-adapters.toml` — a Resource-list-category (§2.2) registry mapping
+//! a DB URI scheme to the plugin name that handles it. Declarative only; no
+//! executable contract lives here (that's `DbProxyPlugin`/`external_plugin`).
+
+use crate::error::{ProxyError, Result};
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DbAdapterEntry {
+    pub scheme: String,
+    pub plugin: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct DbAdapterRegistry {
+    #[serde(default, rename = "adapter")]
+    pub entries: Vec<DbAdapterEntry>,
+}
+
+impl DbAdapterRegistry {
+    pub fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let text = std::fs::read_to_string(path)?;
+        toml::from_str(&text)
+            .map_err(|e| ProxyError::Plugin(format!("invalid db-adapters.toml: {e}")))
+    }
+
+    pub fn resolve(&self, scheme: &str) -> Option<&str> {
+        self.entries
+            .iter()
+            .find(|e| e.scheme == scheme)
+            .map(|e| e.plugin.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_registry_file_is_empty_not_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = DbAdapterRegistry::load(&dir.path().join("db-adapters.toml")).unwrap();
+        assert!(registry.entries.is_empty());
+        assert_eq!(registry.resolve("sqlite"), None);
+    }
+
+    #[test]
+    fn resolves_configured_scheme() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db-adapters.toml");
+        std::fs::write(
+            &path,
+            "[[adapter]]\nscheme = \"postgres\"\nplugin = \"pg-proxy\"\n",
+        )
+        .unwrap();
+        let registry = DbAdapterRegistry::load(&path).unwrap();
+        assert_eq!(registry.resolve("postgres"), Some("pg-proxy"));
+        assert_eq!(registry.resolve("mysql"), None);
+    }
+
+    #[test]
+    fn invalid_toml_is_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db-adapters.toml");
+        std::fs::write(&path, "{{not valid toml}}").unwrap();
+        assert!(DbAdapterRegistry::load(&path).is_err());
+    }
+}

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -24,20 +24,20 @@ regex = { workspace = true }
 which = { workspace = true }
 
 # Internal crates
-ta-audit = { path = "../ta-audit", version = "0.17.0-alpha.12.13" }
-ta-events = { path = "../ta-events", version = "0.17.0-alpha.12.13" }
-ta-memory = { path = "../ta-memory", version = "0.17.0-alpha.12.13" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.13" }
-ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.0-alpha.12.13" }
-ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.0-alpha.12.13" }
-ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.0-alpha.12.13" }
-ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.0-alpha.12.13" }
-ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.13" }
-ta-policy = { path = "../ta-policy", version = "0.17.0-alpha.12.13" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.13" }
-ta-workflow = { path = "../ta-workflow", version = "0.17.0-alpha.12.13" }
-ta-actions = { path = "../ta-actions", version = "0.17.0-alpha.12.13" }
-ta-submit = { path = "../ta-submit", version = "0.17.0-alpha.12.13" }
+ta-audit = { path = "../ta-audit", version = "0.17.0-alpha.12.14" }
+ta-events = { path = "../ta-events", version = "0.17.0-alpha.12.14" }
+ta-memory = { path = "../ta-memory", version = "0.17.0-alpha.12.14" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.14" }
+ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.0-alpha.12.14" }
+ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.0-alpha.12.14" }
+ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.0-alpha.12.14" }
+ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.0-alpha.12.14" }
+ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.14" }
+ta-policy = { path = "../ta-policy", version = "0.17.0-alpha.12.14" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.14" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.0-alpha.12.14" }
+ta-actions = { path = "../ta-actions", version = "0.17.0-alpha.12.14" }
+ta-submit = { path = "../ta-submit", version = "0.17.0-alpha.12.14" }
 
 
 [dev-dependencies]

--- a/crates/ta-mediation/Cargo.toml
+++ b/crates/ta-mediation/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates for FsMediator
-ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.13" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.13" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.14" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.14" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-plugin/Cargo.toml
+++ b/crates/ta-plugin/Cargo.toml
@@ -1,21 +1,24 @@
 [package]
-name = "ta-sandbox"
+name = "ta-plugin"
 version.workspace = true
 edition = "2021"
-description = "Allowlisted command execution sandbox for Trusted Autonomy"
+description = "Shared JSON-over-stdio plugin transport, manifest, and discovery for Trusted Autonomy Plugin-category integrations"
 license = "Apache-2.0"
 repository = "https://github.com/trustedautonomy/ta"
 homepage = "https://github.com/trustedautonomy/ta"
-keywords = ["ai", "agent", "autonomy", "sandbox", "security"]
+keywords = ["ai", "agent", "autonomy", "plugin"]
 categories = ["development-tools"]
 
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
-sha2 = { workspace = true }
-ta-policy = { path = "../ta-policy", version = "0.17.0-alpha.12.14" }
+toml = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+ta-submit = { path = "../ta-submit" }
+ta-runtime = { path = "../ta-runtime" }

--- a/crates/ta-plugin/src/discovery.rs
+++ b/crates/ta-plugin/src/discovery.rs
@@ -1,0 +1,125 @@
+//! `.ta/plugins/<kind>/<name>/plugin.toml` discovery convention (§2.2),
+//! shared by every Plugin-category integration.
+
+use crate::manifest::PluginManifest;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginSource {
+    ProjectLocal,
+    UserGlobal,
+}
+
+impl fmt::Display for PluginSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PluginSource::ProjectLocal => write!(f, "project"),
+            PluginSource::UserGlobal => write!(f, "global"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoveredPlugin {
+    pub manifest: PluginManifest,
+    pub plugin_dir: PathBuf,
+    pub source: PluginSource,
+}
+
+/// `$XDG_CONFIG_HOME` if set, else `$HOME/.config`. Intentionally not
+/// macOS-special-cased, matching the VCS/messaging/social behavior being
+/// unified (changing this would alter where existing plugins are found).
+pub fn user_config_dir() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        if !xdg.is_empty() {
+            return Some(PathBuf::from(xdg));
+        }
+    }
+    std::env::var("HOME")
+        .ok()
+        .map(|home| PathBuf::from(home).join(".config"))
+}
+
+fn scan_kind_dir(base: &Path, kind: &str, source: PluginSource) -> Vec<DiscoveredPlugin> {
+    let kind_dir = base.join("plugins").join(kind);
+    let Ok(entries) = std::fs::read_dir(&kind_dir) else {
+        return vec![];
+    };
+    let mut found = vec![];
+    for entry in entries.flatten() {
+        let plugin_dir = entry.path();
+        if !plugin_dir.is_dir() {
+            continue;
+        }
+        let manifest_path = plugin_dir.join("plugin.toml");
+        if let Ok(manifest) = PluginManifest::load(&manifest_path) {
+            found.push(DiscoveredPlugin {
+                manifest,
+                plugin_dir,
+                source,
+            });
+        }
+    }
+    found.sort_by(|a, b| a.manifest.name.cmp(&b.manifest.name));
+    found
+}
+
+/// Discover every `<kind>` plugin, project-local first then user-global.
+/// If a name exists in both, both entries are returned (callers that want a
+/// single result per name should use `find_plugin`, which takes the first
+/// match in this same project-then-global order).
+pub fn discover_plugins(kind: &str, project_root: &Path) -> Vec<DiscoveredPlugin> {
+    let mut found = scan_kind_dir(&project_root.join(".ta"), kind, PluginSource::ProjectLocal);
+    if let Some(config_dir) = user_config_dir() {
+        found.extend(scan_kind_dir(
+            &config_dir.join("ta"),
+            kind,
+            PluginSource::UserGlobal,
+        ));
+    }
+    found
+}
+
+pub fn find_plugin(kind: &str, name: &str, project_root: &Path) -> Option<DiscoveredPlugin> {
+    discover_plugins(kind, project_root)
+        .into_iter()
+        .find(|p| p.manifest.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_manifest(dir: &Path, kind: &str, name: &str) {
+        let plugin_dir = dir.join(".ta").join("plugins").join(kind).join(name);
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.toml"),
+            format!("name = \"{name}\"\ntype = \"{kind}\"\ncommand = \"{name}-bin\"\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn discovers_project_local_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), "vcs", "perforce");
+        let found = discover_plugins("vcs", dir.path());
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].manifest.name, "perforce");
+        assert_eq!(found[0].source, PluginSource::ProjectLocal);
+    }
+
+    #[test]
+    fn find_plugin_returns_none_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(find_plugin("vcs", "nope", dir.path()).is_none());
+    }
+
+    #[test]
+    fn ignores_kind_dir_with_no_plugins() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(discover_plugins("vcs", dir.path()).is_empty());
+    }
+}

--- a/crates/ta-plugin/src/envelope.rs
+++ b/crates/ta-plugin/src/envelope.rs
@@ -1,0 +1,68 @@
+//! The canonical `method:String` / `{ok,result,error}` call/response envelope
+//! (§2.2 Plugin category) — the reference shape for new Plugin-category
+//! integrations. Existing VCS/messaging/social wire types keep their own
+//! shapes for backward compatibility; they use `transport::call_json` with
+//! their own Req/Resp types instead of this envelope directly.
+
+use serde::{Deserialize, Serialize};
+
+pub const PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginRequest {
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+impl PluginRequest {
+    pub fn new(method: impl Into<String>, params: serde_json::Value) -> Self {
+        Self {
+            method: method.into(),
+            params,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub result: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl PluginResponse {
+    pub fn success(result: serde_json::Value) -> Self {
+        Self {
+            ok: true,
+            result,
+            error: None,
+        }
+    }
+
+    pub fn error(msg: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            result: serde_json::Value::Null,
+            error: Some(msg.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandshakeParams {
+    pub ta_version: String,
+    pub protocol_version: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandshakeResult {
+    pub plugin_version: String,
+    pub protocol_version: u32,
+    #[serde(default)]
+    pub adapter_name: String,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+}

--- a/crates/ta-plugin/src/error.rs
+++ b/crates/ta-plugin/src/error.rs
@@ -1,0 +1,37 @@
+//! Shared error type for all Plugin-category (§2.2) integrations.
+
+#[derive(Debug, thiserror::Error)]
+pub enum PluginError {
+    #[error("plugin '{name}' not found")]
+    NotFound { name: String },
+    #[error("plugin '{name}' method '{method}' failed: {reason}")]
+    CallFailed {
+        name: String,
+        method: String,
+        reason: String,
+    },
+    #[error("plugin '{name}' method '{method}' returned an invalid response: {reason}")]
+    InvalidResponse {
+        name: String,
+        method: String,
+        reason: String,
+    },
+    #[error("failed to spawn plugin command '{command}': {reason}")]
+    SpawnFailed { command: String, reason: String },
+    #[error("plugin '{name}' method '{method}' timed out after {timeout_secs}s")]
+    Timeout {
+        name: String,
+        method: String,
+        timeout_secs: u64,
+    },
+    #[error("plugin manifest not found at {path}")]
+    ManifestNotFound { path: String },
+    #[error("invalid plugin manifest at {path}: {reason}")]
+    InvalidManifest { path: String, reason: String },
+    #[error("plugin manifest at {path} is missing the required 'command' field")]
+    MissingCommand { path: String },
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}

--- a/crates/ta-plugin/src/lib.rs
+++ b/crates/ta-plugin/src/lib.rs
@@ -1,0 +1,19 @@
+//! Shared JSON-over-stdio plugin transport, manifest schema, and discovery
+//! convention for every Trusted Autonomy Plugin-category integration
+//! (docs/design/ta-concepts-and-architecture.md §2.2): VCS, messaging,
+//! social, agent-runtime, tool, db, and release plugins all use this crate.
+
+pub mod discovery;
+pub mod envelope;
+pub mod error;
+pub mod manifest;
+pub mod transport;
+
+pub use discovery::{
+    discover_plugins, find_plugin, user_config_dir, DiscoveredPlugin, PluginSource,
+};
+pub use envelope::{
+    HandshakeParams, HandshakeResult, PluginRequest, PluginResponse, PROTOCOL_VERSION,
+};
+pub use error::PluginError;
+pub use manifest::PluginManifest;

--- a/crates/ta-plugin/src/manifest.rs
+++ b/crates/ta-plugin/src/manifest.rs
@@ -1,0 +1,132 @@
+//! The canonical `plugin.toml` manifest schema (§2.2), a superset of the
+//! fields historically split across VcsPluginManifest/MessagingPluginManifest/
+//! SocialPluginManifest.
+
+use crate::error::PluginError;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+fn default_version() -> String {
+    "0.1.0".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginManifest {
+    pub name: String,
+    #[serde(default = "default_version")]
+    pub version: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+    #[serde(default)]
+    pub protocol_version: Option<u32>,
+    #[serde(default)]
+    pub min_daemon_version: Option<String>,
+    #[serde(default)]
+    pub source_url: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub staging_env: HashMap<String, String>,
+}
+
+impl PluginManifest {
+    pub fn load(path: &Path) -> Result<Self, PluginError> {
+        if !path.exists() {
+            return Err(PluginError::ManifestNotFound {
+                path: path.display().to_string(),
+            });
+        }
+        let text = std::fs::read_to_string(path)?;
+        let manifest: PluginManifest =
+            toml::from_str(&text).map_err(|e| PluginError::InvalidManifest {
+                path: path.display().to_string(),
+                reason: e.to_string(),
+            })?;
+        // Declarative "tool"-kind manifests have nothing to execute (their
+        // install/detect logic lives in a `[tool]` extension table parsed by
+        // the caller), so they're exempt from the MissingCommand check.
+        if manifest.command.trim().is_empty() && manifest.kind != "tool" {
+            return Err(PluginError::MissingCommand {
+                path: path.display().to_string(),
+            });
+        }
+        Ok(manifest)
+    }
+
+    pub fn validate(&self, expected_kind: &str) -> Result<(), PluginError> {
+        if self.kind != expected_kind {
+            return Err(PluginError::InvalidManifest {
+                path: self.name.clone(),
+                reason: format!(
+                    "expected type = \"{expected_kind}\", found \"{}\"",
+                    self.kind
+                ),
+            });
+        }
+        Ok(())
+    }
+
+    pub fn timeout(&self, default_secs: u64) -> std::time::Duration {
+        std::time::Duration::from_secs(self.timeout_secs.unwrap_or(default_secs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_minimal_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plugin.toml");
+        std::fs::write(
+            &path,
+            "name = \"demo\"\ntype = \"vcs\"\ncommand = \"demo-plugin\"\n",
+        )
+        .unwrap();
+        let manifest = PluginManifest::load(&path).unwrap();
+        assert_eq!(manifest.name, "demo");
+        assert_eq!(manifest.version, "0.1.0");
+        assert_eq!(manifest.timeout_secs, None);
+        assert!(manifest.validate("vcs").is_ok());
+        assert!(manifest.validate("messaging").is_err());
+    }
+
+    #[test]
+    fn missing_command_is_rejected_for_non_tool_kinds() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plugin.toml");
+        std::fs::write(&path, "name = \"demo\"\ntype = \"vcs\"\ncommand = \"\"\n").unwrap();
+        assert!(matches!(
+            PluginManifest::load(&path),
+            Err(PluginError::MissingCommand { .. })
+        ));
+    }
+
+    #[test]
+    fn tool_kind_allows_empty_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plugin.toml");
+        std::fs::write(&path, "name = \"demo\"\ntype = \"tool\"\ncommand = \"\"\n").unwrap();
+        assert!(PluginManifest::load(&path).is_ok());
+    }
+
+    #[test]
+    fn missing_file_is_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope").join("plugin.toml");
+        assert!(matches!(
+            PluginManifest::load(&path),
+            Err(PluginError::ManifestNotFound { .. })
+        ));
+    }
+}

--- a/crates/ta-plugin/src/transport.rs
+++ b/crates/ta-plugin/src/transport.rs
@@ -1,0 +1,305 @@
+//! Shared spawn + newline-delimited-JSON framing + timeout transport, used by
+//! every Plugin-category integration (VCS, messaging, social, agent-runtime,
+//! tool, db, release). Format-agnostic: `call_json` is generic over the
+//! caller's own request/response types, so it does not change any existing
+//! plugin's wire bytes.
+
+use crate::error::PluginError;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::io::{BufRead, Read, Write};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+
+const ETXTBSY_BACKOFF_MS: [u64; 4] = [0, 20, 80, 200];
+
+fn spawn_with_retry(
+    command: &str,
+    extra_args: &[String],
+    work_dir: &Path,
+) -> Result<Child, PluginError> {
+    let mut parts = command.split_whitespace();
+    let program = parts.next().ok_or_else(|| PluginError::SpawnFailed {
+        command: command.to_string(),
+        reason: "empty command".to_string(),
+    })?;
+    let baked_args: Vec<&str> = parts.collect();
+
+    let mut last_err = None;
+    for delay_ms in ETXTBSY_BACKOFF_MS {
+        if delay_ms > 0 {
+            std::thread::sleep(Duration::from_millis(delay_ms));
+        }
+        let mut cmd = Command::new(program);
+        cmd.args(&baked_args)
+            .args(extra_args)
+            .current_dir(work_dir)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        match cmd.spawn() {
+            Ok(child) => return Ok(child),
+            Err(e) if e.raw_os_error() == Some(26) => {
+                last_err = Some(e);
+                continue;
+            }
+            Err(e) => {
+                return Err(PluginError::SpawnFailed {
+                    command: command.to_string(),
+                    reason: e.to_string(),
+                })
+            }
+        }
+    }
+    Err(PluginError::SpawnFailed {
+        command: command.to_string(),
+        reason: last_err
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "ETXTBSY retry exhausted".to_string()),
+    })
+}
+
+/// Wait for `child` to exit, killing it after `timeout` via a watchdog thread.
+fn wait_with_timeout(child: Child, timeout: Duration) -> Result<std::process::Output, PluginError> {
+    let pid = child.id();
+    let (tx, rx) = mpsc::channel::<()>();
+    let killed = Arc::new(AtomicBool::new(false));
+    let killed_flag = killed.clone();
+    let watchdog = std::thread::spawn(move || {
+        if rx.recv_timeout(timeout).is_err() {
+            killed_flag.store(true, Ordering::SeqCst);
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
+            }
+            #[cfg(not(unix))]
+            let _ = pid;
+        }
+    });
+    let output = child.wait_with_output();
+    let _ = tx.send(());
+    let _ = watchdog.join();
+    let output = output?;
+    if killed.load(Ordering::SeqCst) {
+        return Err(PluginError::Timeout {
+            name: String::new(),
+            method: String::new(),
+            timeout_secs: timeout.as_secs(),
+        });
+    }
+    Ok(output)
+}
+
+/// Format-agnostic call: write `request_line` + "\n" to the plugin's stdin,
+/// return the first line of stdout. Non-zero exit or empty stdout is an error.
+#[allow(clippy::too_many_arguments)]
+pub fn call_raw(
+    name: &str,
+    method: &str,
+    command: &str,
+    extra_args: &[String],
+    work_dir: &Path,
+    request_line: &str,
+    timeout: Duration,
+) -> Result<String, PluginError> {
+    let mut child = spawn_with_retry(command, extra_args, work_dir)?;
+    {
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| PluginError::CallFailed {
+                name: name.to_string(),
+                method: method.to_string(),
+                reason: "plugin process has no stdin".to_string(),
+            })?;
+        stdin.write_all(request_line.as_bytes())?;
+        stdin.write_all(b"\n")?;
+    }
+    let output = wait_with_timeout(child, timeout).map_err(|e| match e {
+        PluginError::Timeout { .. } => PluginError::Timeout {
+            name: name.to_string(),
+            method: method.to_string(),
+            timeout_secs: timeout.as_secs(),
+        },
+        other => other,
+    })?;
+
+    if !output.status.success() {
+        let mut stderr = String::new();
+        let _ = std::io::Cursor::new(&output.stderr).read_to_string(&mut stderr);
+        return Err(PluginError::CallFailed {
+            name: name.to_string(),
+            method: method.to_string(),
+            reason: stderr.trim().to_string(),
+        });
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let first_line = stdout.lines().next().unwrap_or("");
+    if first_line.is_empty() {
+        return Err(PluginError::InvalidResponse {
+            name: name.to_string(),
+            method: method.to_string(),
+            reason: "plugin wrote no output line to stdout".to_string(),
+        });
+    }
+    Ok(first_line.to_string())
+}
+
+/// JSON convenience wrapper over `call_raw`, generic over the caller's own
+/// request/response wire types (VCS/messaging/social keep their existing
+/// types; new integrations use `envelope::{PluginRequest,PluginResponse}`).
+#[allow(clippy::too_many_arguments)]
+pub fn call_json<Req: Serialize, Resp: DeserializeOwned>(
+    name: &str,
+    method: &str,
+    command: &str,
+    extra_args: &[String],
+    work_dir: &Path,
+    request: &Req,
+    timeout: Duration,
+) -> Result<Resp, PluginError> {
+    let line = serde_json::to_string(request)?;
+    let response_line = call_raw(name, method, command, extra_args, work_dir, &line, timeout)?;
+    serde_json::from_str(&response_line).map_err(|e| PluginError::InvalidResponse {
+        name: name.to_string(),
+        method: method.to_string(),
+        reason: format!("{e} (raw: {})", truncate(&response_line, 200)),
+    })
+}
+
+/// Write one JSON request line to an already-open stdin handle (long-lived
+/// process framing, e.g. agent-runtime plugins that stay alive across calls).
+pub fn write_line<Req: Serialize>(
+    stdin: &mut impl Write,
+    request: &Req,
+) -> Result<(), PluginError> {
+    let line = serde_json::to_string(request)?;
+    stdin.write_all(line.as_bytes())?;
+    stdin.write_all(b"\n")?;
+    Ok(())
+}
+
+/// Read one JSON response line from an already-open stdout reader.
+pub fn read_line<Resp: DeserializeOwned>(reader: &mut impl BufRead) -> Result<Resp, PluginError> {
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    if line.trim().is_empty() {
+        return Err(PluginError::InvalidResponse {
+            name: String::new(),
+            method: String::new(),
+            reason: "plugin wrote no output line to stdout".to_string(),
+        });
+    }
+    serde_json::from_str(&line).map_err(PluginError::from)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn write_mock_script(dir: &Path, body: &str) -> String {
+        let path = dir.join("mock-plugin.sh");
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+        path.to_string_lossy().to_string()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn call_raw_round_trips_one_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_mock_script(
+            dir.path(),
+            "read -r line\necho '{\"ok\":true,\"result\":{}}'",
+        );
+        let result = call_raw(
+            "mock",
+            "ping",
+            &script,
+            &[],
+            dir.path(),
+            "{\"method\":\"ping\"}",
+            Duration::from_secs(5),
+        )
+        .unwrap();
+        assert_eq!(result, "{\"ok\":true,\"result\":{}}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn call_json_deserializes_response() {
+        use crate::envelope::{PluginRequest, PluginResponse};
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_mock_script(
+            dir.path(),
+            "read -r line\necho '{\"ok\":true,\"result\":{\"pong\":true}}'",
+        );
+        let req = PluginRequest::new("ping", serde_json::json!({}));
+        let resp: PluginResponse = call_json(
+            "mock",
+            "ping",
+            &script,
+            &[],
+            dir.path(),
+            &req,
+            Duration::from_secs(5),
+        )
+        .unwrap();
+        assert!(resp.ok);
+        assert_eq!(resp.result["pong"], serde_json::json!(true));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn call_raw_reports_nonzero_exit() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_mock_script(dir.path(), "echo 'boom' >&2\nexit 1");
+        let err = call_raw(
+            "mock",
+            "ping",
+            &script,
+            &[],
+            dir.path(),
+            "{}",
+            Duration::from_secs(5),
+        )
+        .unwrap_err();
+        match err {
+            PluginError::CallFailed { reason, .. } => assert!(reason.contains("boom")),
+            other => panic!("expected CallFailed, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn call_raw_kills_on_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_mock_script(dir.path(), "sleep 5\necho '{\"ok\":true,\"result\":{}}'");
+        let err = call_raw(
+            "mock",
+            "ping",
+            &script,
+            &[],
+            dir.path(),
+            "{}",
+            Duration::from_millis(200),
+        )
+        .unwrap_err();
+        assert!(matches!(err, PluginError::Timeout { .. }));
+    }
+}

--- a/crates/ta-plugin/src/transport.rs
+++ b/crates/ta-plugin/src/transport.rs
@@ -205,11 +205,11 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
-#[cfg(test)]
+// All tests in this module spawn a `#!/bin/sh` mock plugin script — unix-only.
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
     fn write_mock_script(dir: &Path, body: &str) -> String {
         let path = dir.join("mock-plugin.sh");
         std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
@@ -219,7 +219,6 @@ mod tests {
         path.to_string_lossy().to_string()
     }
 
-    #[cfg(unix)]
     #[test]
     fn call_raw_round_trips_one_line() {
         let dir = tempfile::tempdir().unwrap();
@@ -240,7 +239,6 @@ mod tests {
         assert_eq!(result, "{\"ok\":true,\"result\":{}}");
     }
 
-    #[cfg(unix)]
     #[test]
     fn call_json_deserializes_response() {
         use crate::envelope::{PluginRequest, PluginResponse};
@@ -264,7 +262,6 @@ mod tests {
         assert_eq!(resp.result["pong"], serde_json::json!(true));
     }
 
-    #[cfg(unix)]
     #[test]
     fn call_raw_reports_nonzero_exit() {
         let dir = tempfile::tempdir().unwrap();
@@ -285,7 +282,6 @@ mod tests {
         }
     }
 
-    #[cfg(unix)]
     #[test]
     fn call_raw_kills_on_timeout() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/ta-plugin/tests/cross_family_unification.rs
+++ b/crates/ta-plugin/tests/cross_family_unification.rs
@@ -1,0 +1,59 @@
+//! Proves the Plugin-category unification (v0.17.0.12.14 item 6): one
+//! synthetic, community-authored-style plugin script is discovered and
+//! invoked identically through two independent Plugin-category integrations
+//! (VCS and agent-runtime) via the shared ta-plugin transport.
+
+#![cfg(unix)]
+
+use std::path::Path;
+
+fn write_synthetic_plugin(dir: &Path) -> String {
+    let path = dir.join("synthetic-plugin.sh");
+    std::fs::write(
+        &path,
+        r#"#!/bin/sh
+read -r line
+echo '{"ok":true,"result":{"plugin_version":"9.9.9","protocol_version":1,"adapter_name":"synthetic","capabilities":["handshake"]}}'
+"#,
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&path).unwrap().permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    std::fs::set_permissions(&path, perms).unwrap();
+    path.to_string_lossy().to_string()
+}
+
+#[test]
+fn synthetic_plugin_works_identically_via_vcs_and_runtime_integrations() {
+    let dir = tempfile::tempdir().unwrap();
+    let command = write_synthetic_plugin(dir.path());
+
+    // Integration 1: VCS — per-call spawn via ta_plugin::transport::call_json.
+    let vcs_manifest = ta_submit::vcs_plugin_manifest::VcsPluginManifest {
+        name: "synthetic".to_string(),
+        version: "0.1.0".to_string(),
+        plugin_type: "vcs".to_string(),
+        command: command.clone(),
+        args: vec![],
+        capabilities: vec![],
+        description: None,
+        timeout_secs: 5,
+        min_daemon_version: None,
+        source_url: None,
+        staging_env: Default::default(),
+    };
+    let vcs_adapter = ta_submit::external_vcs_adapter::ExternalVcsAdapter::new(
+        &vcs_manifest,
+        dir.path(),
+        "0.17.0-test",
+    )
+    .expect("VCS handshake via synthetic plugin should succeed");
+    assert_eq!(vcs_adapter.plugin_version(), "9.9.9");
+
+    // Integration 2: agent-runtime — long-lived spawn, line framing via
+    // ta_plugin::transport::write_line/read_line.
+    let runtime_adapter =
+        ta_runtime::plugin::ExternalRuntimeAdapter::new(Path::new(&command), "synthetic")
+            .expect("runtime handshake via the same synthetic plugin should succeed");
+    assert_eq!(runtime_adapter.plugin_version(), "9.9.9");
+}

--- a/crates/ta-runtime/Cargo.toml
+++ b/crates/ta-runtime/Cargo.toml
@@ -23,7 +23,8 @@ which = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
 
-ta-credentials = { path = "../ta-credentials", version = "0.17.0-alpha.12.13" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.0-alpha.12.14" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.0-alpha.12.14" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/ta-runtime/src/plugin.rs
+++ b/crates/ta-runtime/src/plugin.rs
@@ -34,7 +34,7 @@
 // | shutdown   | Clean up the plugin session; plugin exits after reply  |
 
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader, Write};
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::Mutex;
@@ -156,26 +156,21 @@ struct PluginProcess {
 
 impl PluginProcess {
     /// Send a request and read back one response line.
+    ///
+    /// Line framing delegates to the shared `ta_plugin::transport` crate
+    /// (also used by VCS/messaging/social plugins) — this is a long-lived
+    /// process (spawn once, many calls), so it keeps its own `Child`/
+    /// `stdin`/`stdout_reader` rather than using `call_json`'s per-call spawn.
     fn call(&mut self, method: &str, params: serde_json::Value) -> Result<serde_json::Value> {
         let req = PluginRequest {
             method: method.to_string(),
             params,
         };
-        let mut line = serde_json::to_string(&req)
-            .map_err(|e| RuntimeError::PluginError(format!("serialize request: {}", e)))?;
-        line.push('\n');
+        ta_plugin::transport::write_line(&mut self.stdin, &req)
+            .map_err(|e| RuntimeError::PluginError(e.to_string()))?;
 
-        self.stdin
-            .write_all(line.as_bytes())
-            .map_err(RuntimeError::Io)?;
-
-        let mut response_line = String::new();
-        self.stdout_reader
-            .read_line(&mut response_line)
-            .map_err(RuntimeError::Io)?;
-
-        let resp: PluginResponse = serde_json::from_str(response_line.trim())
-            .map_err(|e| RuntimeError::PluginError(format!("parse response: {}", e)))?;
+        let resp: PluginResponse = ta_plugin::transport::read_line(&mut self.stdout_reader)
+            .map_err(|e| RuntimeError::PluginError(e.to_string()))?;
 
         if resp.ok {
             Ok(resp.result)
@@ -269,6 +264,17 @@ impl ExternalRuntimeAdapter {
             capabilities: handshake.capabilities,
             process: Mutex::new(proc),
         })
+    }
+
+    /// Resolve `name` via `.ta/plugins/agent/<name>/plugin.toml` discovery
+    /// (project-local then user-global), falling back to treating `name`
+    /// as a bare command on PATH if no manifest is found.
+    pub fn discover(name: &str, project_root: &Path) -> Result<Self> {
+        let command = match ta_plugin::find_plugin("agent", name, project_root) {
+            Some(found) => found.plugin_dir.join(&found.manifest.command),
+            None => PathBuf::from(name),
+        };
+        Self::new(&command, name)
     }
 
     /// Plugin version string (from handshake).
@@ -450,5 +456,20 @@ impl AgentHandle for ExternalAgentHandle {
         .unwrap();
         self.call_plugin("stop", params)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discover_falls_back_to_bare_name_when_no_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        // No .ta/plugins/agent/<name>/plugin.toml exists — discover() must not
+        // panic and must fall back to a bare-name command (which then fails to
+        // spawn, since "definitely-not-a-real-binary" doesn't exist on PATH).
+        let result = ExternalRuntimeAdapter::discover("definitely-not-a-real-binary", dir.path());
+        assert!(result.is_err());
     }
 }

--- a/crates/ta-session/Cargo.toml
+++ b/crates/ta-session/Cargo.toml
@@ -24,8 +24,8 @@ notify = { workspace = true }
 toml = { workspace = true }
 
 # Workspace crates
-ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.13" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.13" }
+ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.14" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.14" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -16,9 +16,10 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.13" }
-ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.13" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.13" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.14" }
+ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.14" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.14" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.0-alpha.12.14" }
 toml = "0.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/ta-submit/src/external_vcs_adapter.rs
+++ b/crates/ta-submit/src/external_vcs_adapter.rs
@@ -20,9 +20,7 @@
 //! validate protocol compatibility. An incompatible protocol version causes
 //! construction to fail with `SubmitError::ConfigError`.
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use ta_changeset::DraftPackage;
@@ -60,7 +58,6 @@ pub struct ExternalVcsAdapter {
     /// Plugin's self-reported adapter name (from handshake).
     adapter_name: String,
     /// Plugin version (from handshake; retained for diagnostics/logging).
-    #[allow(dead_code)]
     plugin_version: String,
     /// Per-call process timeout.
     timeout: Duration,
@@ -142,6 +139,11 @@ impl ExternalVcsAdapter {
             capabilities: result.capabilities,
             staging_env: manifest.staging_env.clone(),
         })
+    }
+
+    /// Plugin version string (from handshake).
+    pub fn plugin_version(&self) -> &str {
+        &self.plugin_version
     }
 
     /// Auto-detect using the plugin's `detect` method.
@@ -548,8 +550,11 @@ impl SourceAdapter for ExternalVcsAdapter {
 
 /// Spawn the plugin, send one JSON request, read one JSON response.
 ///
-/// Returns `SubmitError::IoError` / `SubmitError::VcsError` on infrastructure
-/// failures. Never panics.
+/// Delegates spawn/framing/timeout to the shared `ta_plugin::transport`
+/// crate (also used by messaging/social/agent-runtime plugins) — this
+/// function only maps the shared `PluginError` back onto `SubmitError`.
+///
+/// Returns `SubmitError::VcsError` on infrastructure failures. Never panics.
 fn call_plugin(
     command: &str,
     extra_args: &[String],
@@ -557,179 +562,16 @@ fn call_plugin(
     request: &VcsPluginRequest,
     timeout: Duration,
 ) -> Result<VcsPluginResponse> {
-    let request_json = serde_json::to_string(request).map_err(|e| {
-        SubmitError::VcsError(format!(
-            "Failed to serialize VCS plugin request for method '{}': {}",
-            request.method, e
-        ))
-    })?;
-
-    // Split command into program + built-in args.
-    let mut parts = command.split_whitespace();
-    let program = parts.next().ok_or_else(|| {
-        SubmitError::ConfigError(format!(
-            "VCS plugin command is empty for method '{}'",
-            request.method
-        ))
-    })?;
-
-    let mut cmd = Command::new(program);
-    for arg in parts {
-        cmd.arg(arg);
-    }
-    for arg in extra_args {
-        cmd.arg(arg);
-    }
-
-    cmd.current_dir(work_dir)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    // Retry on ETXTBSY (os error 26): on Linux the kernel can return this when a
-    // freshly-written executable has not yet been fully flushed through the page
-    // cache / copy-up layer (common on overlayfs in Nix CI). A short backoff is
-    // sufficient; real plugin binaries never trigger this in production.
-    let mut child = {
-        const ETXTBSY: i32 = 26;
-        let mut last_err: Option<std::io::Error> = None;
-        let mut spawned = None;
-        for delay_ms in [0u64, 20, 80, 200] {
-            if delay_ms > 0 {
-                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
-            }
-            match cmd.spawn() {
-                Ok(c) => {
-                    spawned = Some(c);
-                    break;
-                }
-                Err(e) if e.raw_os_error() == Some(ETXTBSY) => {
-                    last_err = Some(e);
-                }
-                Err(e) => {
-                    return Err(SubmitError::VcsError(format!(
-                        "Failed to spawn VCS plugin '{}' for method '{}': {}. \
-                         Ensure the plugin is installed and on PATH.",
-                        command, request.method, e
-                    )));
-                }
-            }
-        }
-        spawned.ok_or_else(|| {
-            let e = last_err.unwrap();
-            SubmitError::VcsError(format!(
-                "Failed to spawn VCS plugin '{}' for method '{}': {}. \
-                 Ensure the plugin is installed and on PATH.",
-                command, request.method, e
-            ))
-        })?
-    };
-
-    // Write request to stdin.
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(request_json.as_bytes())
-            .and_then(|_| stdin.write_all(b"\n"))
-            .map_err(|e| {
-                SubmitError::VcsError(format!(
-                    "Failed to write to VCS plugin '{}' stdin: {}",
-                    command, e
-                ))
-            })?;
-    }
-
-    // Wait with timeout (blocking — VCS operations are called synchronously).
-    // We use a thread with a join timeout since std::process::Child has no
-    // built-in timeout.
-    let timeout_millis = timeout.as_millis() as u64;
-    let output = wait_with_timeout(child, timeout_millis).map_err(|e| {
-        SubmitError::VcsError(format!(
-            "VCS plugin '{}' timed out or failed for method '{}': {}. \
-             Increase timeout_secs in plugin.toml.",
-            command, request.method, e
-        ))
-    })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(SubmitError::VcsError(format!(
-            "VCS plugin '{}' exited with status {} for method '{}'. stderr: {}",
-            command,
-            output.status,
-            request.method,
-            stderr.trim()
-        )));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let first_line = stdout.lines().next().unwrap_or("").trim();
-
-    if first_line.is_empty() {
-        return Err(SubmitError::VcsError(format!(
-            "VCS plugin '{}' produced no output for method '{}'. \
-             Plugin must write one JSON line to stdout.",
-            command, request.method
-        )));
-    }
-
-    serde_json::from_str(first_line).map_err(|e| {
-        SubmitError::VcsError(format!(
-            "VCS plugin '{}' produced invalid JSON for method '{}': {}. Got: '{}'",
-            command,
-            request.method,
-            e,
-            if first_line.len() > 200 {
-                &first_line[..200]
-            } else {
-                first_line
-            }
-        ))
-    })
-}
-
-/// Wait for a child process to exit, killing it after `timeout_ms` milliseconds.
-///
-/// Uses an `mpsc` channel to signal the watchdog thread as soon as the child
-/// exits, so `join()` returns immediately rather than blocking for the full
-/// `timeout_ms` on every successful (fast) invocation.
-fn wait_with_timeout(
-    child: std::process::Child,
-    timeout_ms: u64,
-) -> std::result::Result<std::process::Output, String> {
-    use std::sync::mpsc;
-
-    let child_id = child.id();
-    let (tx, rx) = mpsc::channel::<()>();
-
-    // Watchdog thread: waits for the "done" signal or the timeout, then kills.
-    let watchdog = std::thread::spawn(move || {
-        match rx.recv_timeout(Duration::from_millis(timeout_ms)) {
-            Ok(()) => {
-                // Child exited normally — nothing to do.
-            }
-            Err(_) => {
-                // Timeout expired (or sender dropped on early `?` return) — kill the child.
-                #[cfg(unix)]
-                unsafe {
-                    libc::kill(child_id as libc::pid_t, libc::SIGKILL);
-                }
-                #[cfg(not(unix))]
-                {
-                    let _ = child_id;
-                }
-            }
-        }
-    });
-
-    let output = child
-        .wait_with_output()
-        .map_err(|e| format!("wait_with_output failed: {}", e))?;
-
-    // Signal the watchdog that the child has exited — it will wake immediately.
-    let _ = tx.send(());
-    let _ = watchdog.join();
-
-    Ok(output)
+    ta_plugin::transport::call_json(
+        "vcs-plugin",
+        &request.method,
+        command,
+        extra_args,
+        work_dir,
+        request,
+        timeout,
+    )
+    .map_err(|e| SubmitError::VcsError(e.to_string()))
 }
 
 // ---------------------------------------------------------------------------
@@ -885,7 +727,7 @@ exit 1
 
         let err = ExternalVcsAdapter::new(&manifest, dir.path(), "0.13.5-alpha").unwrap_err();
         assert!(
-            err.to_string().contains("exited with status"),
+            err.to_string().contains("some error to stderr"),
             "Got: {}",
             err
         );
@@ -906,6 +748,11 @@ echo "this is not json"
         let manifest = mock_manifest(&plugin_path.display().to_string(), dir.path());
 
         let err = ExternalVcsAdapter::new(&manifest, dir.path(), "0.13.5-alpha").unwrap_err();
-        assert!(err.to_string().contains("invalid JSON"), "Got: {}", err);
+        assert!(
+            err.to_string().contains("invalid response")
+                || err.to_string().contains("invalid JSON"),
+            "Got: {}",
+            err
+        );
     }
 }

--- a/crates/ta-submit/src/messaging_adapter.rs
+++ b/crates/ta-submit/src/messaging_adapter.rs
@@ -22,9 +22,7 @@
 //! retrieve them via the `keyring` crate or by calling
 //! `ta adapter credentials get <key>`.
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -372,122 +370,46 @@ impl ExternalMessagingAdapter {
     // Internal
     // -----------------------------------------------------------------------
 
+    /// Spawn the plugin, send one JSON request, read one JSON response.
+    ///
+    /// Delegates spawn/framing/timeout to the shared `ta_plugin::transport`
+    /// crate (also used by VCS/social/agent-runtime plugins) — this method
+    /// only maps the shared `PluginError` back onto `MessagingPluginError`.
     fn call_plugin(
         &self,
         req: &MessagingPluginRequest,
         op: &str,
     ) -> Result<MessagingPluginResponse, MessagingPluginError> {
-        let req_json = serde_json::to_string(req)?;
-
-        let mut parts = self.command.split_whitespace();
-        let program = parts
-            .next()
-            .ok_or_else(|| MessagingPluginError::SpawnFailed {
-                command: self.command.clone(),
-                reason: "command string is empty".to_string(),
-            })?;
-
-        let mut cmd = Command::new(program);
-        for arg in parts {
-            cmd.arg(arg);
-        }
-        for arg in &self.args {
-            cmd.arg(arg);
-        }
-        cmd.stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        // Retry on ETXTBSY (os error 26) — the kernel marks an inode busy while a write fd
-        // is open; the condition is always transient and clears within a few milliseconds.
-        // Seen on GitHub Actions Ubuntu runners even when using /dev/shm.
-        let mut child = {
-            let mut last_err = None;
-            let mut spawned = None;
-            for attempt in 0u8..4 {
-                match cmd.spawn() {
-                    Ok(c) => {
-                        spawned = Some(c);
-                        break;
-                    }
-                    Err(ref e) if e.raw_os_error() == Some(26) => {
-                        last_err = Some(e.to_string());
-                        std::thread::sleep(std::time::Duration::from_millis(
-                            10u64 * (1 << attempt),
-                        ));
-                    }
-                    Err(e) => {
-                        last_err = Some(e.to_string());
-                        break;
-                    }
-                }
+        let resp: MessagingPluginResponse = ta_plugin::transport::call_json(
+            &self.provider,
+            op,
+            &self.command,
+            &self.args,
+            Path::new("."),
+            req,
+            self.timeout,
+        )
+        .map_err(|e| match e {
+            ta_plugin::PluginError::Timeout { timeout_secs, .. } => MessagingPluginError::Timeout {
+                name: self.provider.clone(),
+                op: op.to_string(),
+                timeout_secs,
+            },
+            ta_plugin::PluginError::SpawnFailed { command, reason } => {
+                MessagingPluginError::SpawnFailed { command, reason }
             }
-            spawned.ok_or_else(|| MessagingPluginError::SpawnFailed {
-                command: self.command.clone(),
-                reason: last_err.unwrap_or_default(),
-            })?
-        };
-
-        // Write request to stdin.
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(req_json.as_bytes())
-                .and_then(|_| stdin.write_all(b"\n"))
-                .map_err(|e| {
-                    MessagingPluginError::Io(std::io::Error::new(
-                        e.kind(),
-                        format!("failed to write to plugin stdin: {}", e),
-                    ))
-                })?;
-        }
-
-        // Wait with timeout.
-        let timeout_ms = self.timeout.as_millis() as u64;
-        let output =
-            wait_with_timeout(child, timeout_ms).map_err(|_| MessagingPluginError::Timeout {
+            ta_plugin::PluginError::CallFailed { reason, .. } => MessagingPluginError::OpFailed {
                 name: self.provider.clone(),
                 op: op.to_string(),
-                timeout_secs: self.timeout.as_secs(),
-            })?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(MessagingPluginError::OpFailed {
+                reason,
+            },
+            ta_plugin::PluginError::Io(io_err) => MessagingPluginError::Io(io_err),
+            ta_plugin::PluginError::Json(json_err) => MessagingPluginError::Json(json_err),
+            other => MessagingPluginError::InvalidResponse {
                 name: self.provider.clone(),
                 op: op.to_string(),
-                reason: format!(
-                    "plugin exited with status {}. stderr: {}",
-                    output.status,
-                    stderr.trim()
-                ),
-            });
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let first_line = stdout.lines().next().unwrap_or("").trim();
-
-        if first_line.is_empty() {
-            return Err(MessagingPluginError::InvalidResponse {
-                name: self.provider.clone(),
-                op: op.to_string(),
-                reason: "plugin produced no output (expected one JSON line)".to_string(),
-            });
-        }
-
-        let resp: MessagingPluginResponse = serde_json::from_str(first_line).map_err(|e| {
-            MessagingPluginError::InvalidResponse {
-                name: self.provider.clone(),
-                op: op.to_string(),
-                reason: format!(
-                    "invalid JSON: {}. Got: '{}'",
-                    e,
-                    if first_line.len() > 200 {
-                        &first_line[..200]
-                    } else {
-                        first_line
-                    }
-                ),
-            }
+                reason: other.to_string(),
+            },
         })?;
 
         if !resp.ok {
@@ -496,6 +418,7 @@ impl ExternalMessagingAdapter {
                 op: op.to_string(),
                 reason: resp
                     .error
+                    .clone()
                     .unwrap_or_else(|| "plugin returned ok=false".to_string()),
             });
         }
@@ -523,41 +446,6 @@ fn user_config_dir() -> Option<PathBuf> {
     std::env::var("HOME")
         .ok()
         .map(|home| PathBuf::from(home).join(".config"))
-}
-
-/// Wait for a child process to exit, killing it after `timeout_ms` milliseconds.
-fn wait_with_timeout(
-    child: std::process::Child,
-    timeout_ms: u64,
-) -> std::result::Result<std::process::Output, String> {
-    use std::sync::mpsc;
-
-    let child_id = child.id();
-    let (tx, rx) = mpsc::channel::<()>();
-
-    let watchdog =
-        std::thread::spawn(
-            move || match rx.recv_timeout(Duration::from_millis(timeout_ms)) {
-                Ok(()) => {}
-                Err(_) => {
-                    #[cfg(unix)]
-                    unsafe {
-                        libc::kill(child_id as libc::pid_t, libc::SIGKILL);
-                    }
-                    #[cfg(not(unix))]
-                    let _ = child_id;
-                }
-            },
-        );
-
-    let output = child
-        .wait_with_output()
-        .map_err(|e| format!("wait_with_output failed: {}", e))?;
-
-    let _ = tx.send(());
-    let _ = watchdog.join();
-
-    Ok(output)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ta-submit/src/social_adapter.rs
+++ b/crates/ta-submit/src/social_adapter.rs
@@ -21,9 +21,7 @@
 //! key `ta-social:<platform>:<handle>`. Plugins retrieve them via
 //! `ta adapter credentials get <key>`.
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -374,95 +372,50 @@ impl ExternalSocialAdapter {
     // Internal
     // -----------------------------------------------------------------------
 
+    /// Spawn the plugin, send one JSON request, read one JSON response.
+    ///
+    /// Delegates spawn/framing/timeout to the shared `ta_plugin::transport`
+    /// crate (also used by VCS/messaging/agent-runtime plugins) — this
+    /// method only maps the shared `PluginError` back onto `SocialPluginError`.
+    /// Note: this adds ETXTBSY-retry-on-spawn, which the previous
+    /// hand-rolled implementation lacked — a strict improvement, not a
+    /// behavior change any test depends on.
     fn call_plugin(
         &self,
         req: &SocialPluginRequest,
         op: &str,
     ) -> Result<SocialPluginResponse, SocialPluginError> {
-        let req_json = serde_json::to_string(req)?;
-
-        let mut parts = self.command.split_whitespace();
-        let program = parts.next().ok_or_else(|| SocialPluginError::SpawnFailed {
-            command: self.command.clone(),
-            reason: "command string is empty".to_string(),
+        let resp: SocialPluginResponse = ta_plugin::transport::call_json(
+            &self.platform,
+            op,
+            &self.command,
+            &self.args,
+            Path::new("."),
+            req,
+            self.timeout,
+        )
+        .map_err(|e| match e {
+            ta_plugin::PluginError::Timeout { timeout_secs, .. } => SocialPluginError::Timeout {
+                name: self.platform.clone(),
+                op: op.to_string(),
+                timeout_secs,
+            },
+            ta_plugin::PluginError::SpawnFailed { command, reason } => {
+                SocialPluginError::SpawnFailed { command, reason }
+            }
+            ta_plugin::PluginError::CallFailed { reason, .. } => SocialPluginError::OpFailed {
+                name: self.platform.clone(),
+                op: op.to_string(),
+                reason,
+            },
+            ta_plugin::PluginError::Io(io_err) => SocialPluginError::Io(io_err),
+            ta_plugin::PluginError::Json(json_err) => SocialPluginError::Json(json_err),
+            other => SocialPluginError::InvalidResponse {
+                name: self.platform.clone(),
+                op: op.to_string(),
+                reason: other.to_string(),
+            },
         })?;
-
-        let mut cmd = Command::new(program);
-        for arg in parts {
-            cmd.arg(arg);
-        }
-        for arg in &self.args {
-            cmd.arg(arg);
-        }
-        cmd.stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        let mut child = cmd.spawn().map_err(|e| SocialPluginError::SpawnFailed {
-            command: self.command.clone(),
-            reason: e.to_string(),
-        })?;
-
-        // Write request to stdin.
-        if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(req_json.as_bytes())
-                .and_then(|_| stdin.write_all(b"\n"))
-                .map_err(|e| {
-                    SocialPluginError::Io(std::io::Error::new(
-                        e.kind(),
-                        format!("failed to write to plugin stdin: {}", e),
-                    ))
-                })?;
-        }
-
-        // Wait with timeout.
-        let timeout_ms = self.timeout.as_millis() as u64;
-        let output =
-            wait_with_timeout(child, timeout_ms).map_err(|_| SocialPluginError::Timeout {
-                name: self.platform.clone(),
-                op: op.to_string(),
-                timeout_secs: self.timeout.as_secs(),
-            })?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(SocialPluginError::OpFailed {
-                name: self.platform.clone(),
-                op: op.to_string(),
-                reason: format!(
-                    "plugin exited with status {}. stderr: {}",
-                    output.status,
-                    stderr.trim()
-                ),
-            });
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let first_line = stdout.lines().next().unwrap_or("").trim();
-
-        if first_line.is_empty() {
-            return Err(SocialPluginError::InvalidResponse {
-                name: self.platform.clone(),
-                op: op.to_string(),
-                reason: "plugin produced no output (expected one JSON line)".to_string(),
-            });
-        }
-
-        let resp: SocialPluginResponse =
-            serde_json::from_str(first_line).map_err(|e| SocialPluginError::InvalidResponse {
-                name: self.platform.clone(),
-                op: op.to_string(),
-                reason: format!(
-                    "invalid JSON: {}. Got: '{}'",
-                    e,
-                    if first_line.len() > 200 {
-                        &first_line[..200]
-                    } else {
-                        first_line
-                    }
-                ),
-            })?;
 
         if !resp.ok {
             return Err(SocialPluginError::OpFailed {
@@ -470,6 +423,7 @@ impl ExternalSocialAdapter {
                 op: op.to_string(),
                 reason: resp
                     .error
+                    .clone()
                     .unwrap_or_else(|| "plugin returned ok=false".to_string()),
             });
         }
@@ -609,41 +563,6 @@ fn user_config_dir() -> Option<PathBuf> {
     std::env::var("HOME")
         .ok()
         .map(|home| PathBuf::from(home).join(".config"))
-}
-
-/// Wait for a child process to exit, killing it after `timeout_ms` milliseconds.
-fn wait_with_timeout(
-    child: std::process::Child,
-    timeout_ms: u64,
-) -> std::result::Result<std::process::Output, String> {
-    use std::sync::mpsc;
-
-    let child_id = child.id();
-    let (tx, rx) = mpsc::channel::<()>();
-
-    let watchdog =
-        std::thread::spawn(
-            move || match rx.recv_timeout(Duration::from_millis(timeout_ms)) {
-                Ok(()) => {}
-                Err(_) => {
-                    #[cfg(unix)]
-                    unsafe {
-                        libc::kill(child_id as libc::pid_t, libc::SIGKILL);
-                    }
-                    #[cfg(not(unix))]
-                    let _ = child_id;
-                }
-            },
-        );
-
-    let output = child
-        .wait_with_output()
-        .map_err(|e| format!("wait_with_output failed: {}", e))?;
-
-    let _ = tx.send(());
-    let _ = watchdog.join();
-
-    Ok(output)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ta-workflow/Cargo.toml
+++ b/crates/ta-workflow/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.13" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.14" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -21,8 +21,8 @@ reqwest = { workspace = true }
 anyhow = { workspace = true }
 sha2 = "0.10"
 base64 = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.13" }
-ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.13" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.14" }
+ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.14" }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/docs/PLUGIN-AUTHORING.md
+++ b/docs/PLUGIN-AUTHORING.md
@@ -1,5 +1,7 @@
 # Plugin Authoring Quickstart
 
+> **Note:** This guide covers **Channel/Listener**-category plugins specifically (long-running delivery adapters). For the **Plugin** category (VCS/messaging/social/agent/tool/db/release — call/response, `plugin.toml`, `.ta/plugins/<kind>/<name>/`), see `docs/USAGE.md` → "Authoring a Plugin".
+
 This guide walks you through building a TA channel plugin from scratch. By the end you will have a working plugin that delivers agent questions to an external service and integrates with the TA review workflow.
 
 ## Overview

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -83,6 +83,7 @@ Both paths install the same `ta` binary. Studio and CLI work side-by-side — yo
    - [Channel Registry](#channel-registry)
    - [Multi-Channel Routing](#multi-channel-routing)
    - [Channel Plugins](#channel-plugins)
+   - [Authoring a Plugin](#authoring-a-plugin)
    - [Inspecting Channel Configuration](#inspecting-channel-configuration)
    - [API Mediation](#api-mediation)
    - [Project Setup](#project-setup)
@@ -9692,6 +9693,90 @@ min_daemon_version = "0.10.16"
 ```
 
 If the running daemon is older than the declared minimum, `ta plugin check` warns about the incompatibility.
+
+#### Authoring a Plugin
+
+TA's extensibility model has four categories (see `docs/design/ta-concepts-and-architecture.md` §2.2). Pick the right one before writing code:
+
+| Category | Shape | Use when |
+|---|---|---|
+| **Plugin** | External process, call/response, `plugin.toml` manifest, `.ta/plugins/<kind>/<name>/` discovery | The integration is optional, should be swappable without a TA release, and a community member should be able to author one — VCS, messaging, social, agent runtimes, optional tools, database adapters, release adapters |
+| **Channel/Listener** | External, long-running, supervised, `channel.toml` manifest, `.ta/plugins/channels/<name>/` discovery | The integration needs to maintain a persistent session (Discord, Slack, Email, Teams) rather than answer discrete calls — see [Channel Plugins](#channel-plugins) above |
+| **Backend** | In-process Rust trait, core-only | It's first-party, needs zero IPC overhead, or has no reason to be community-extensible (connectors, output renderers) |
+| **Resource list** | Declarative registry (TOML), no executable contract | There's nothing to execute, just configuration or a pointer to a Plugin/Backend (`.ta/community-resources.toml`, `.ta/db-adapters.toml`) |
+
+This section covers the **Plugin** category, unified onto one shared transport/manifest/discovery crate (`ta-plugin`) as of v0.17.0.12.14.
+
+**Kinds shipped today:**
+
+| Kind | Discovery dir | Example manifest `command` |
+|---|---|---|
+| `vcs` | `.ta/plugins/vcs/<name>/` | `ta-submit-perforce` |
+| `messaging` | `.ta/plugins/messaging/<name>/` | `ta-messaging-gmail` |
+| `social` | `.ta/plugins/social/<name>/` | `ta-social-linkedin` |
+| `agent` | `.ta/plugins/agent/<name>/` | `ta-agent-ollama` |
+| `tool` | `.ta/plugins/tool/<name>/` | (community-defined; see `plugins/tool/*/plugin.toml` for examples) |
+| `db` | `.ta/plugins/db/<name>/` | (community-defined DB proxy adapter) |
+| `release` | `.ta/plugins/release/<name>/` | (community-defined release adapter) |
+
+**Discovery order:** project-local (`.ta/plugins/<kind>/<name>/plugin.toml`) is checked first, then user-global (`~/.config/ta/plugins/<kind>/<name>/plugin.toml`).
+
+**Manifest schema (`plugin.toml`):**
+
+```toml
+name = "my-plugin"
+version = "0.1.0"
+type = "vcs"                 # the plugin kind — must match the discovery directory
+command = "my-plugin-binary" # executable to spawn (relative to the manifest's directory, or on PATH)
+args = []                    # extra args appended on every invocation
+capabilities = ["commit", "push"]
+description = "One-line description"
+timeout_secs = 30            # per-call timeout; defaults vary by kind (VCS: 30s, messaging/social: 60s)
+
+[staging_env]                # static env vars merged into the agent's spawn env (VCS only)
+MY_VAR = "value"
+```
+
+**Wire protocol:** newline-delimited JSON, one request line in, one response line out. New plugin kinds (`tool`, `db`, `release`) use the canonical envelope:
+
+```
+TA → plugin: {"method":"<name>","params":{...}}\n
+plugin → TA: {"ok":true,"result":{...}}\n
+         or  {"ok":false,"error":"..."}\n
+```
+
+If you're authoring a **new** VCS/messaging/social/agent-runtime plugin, use each family's existing request/response shape (documented in `docs/PLUGIN-AUTHORING.md` and `docs/plugin-traits.md`) — those wire formats did not change when the transport was unified. Only the underlying spawn/framing/timeout/manifest/discovery code is now shared across all seven kinds; each kind's protocol is otherwise untouched.
+
+**Minimal example — a `tool`-kind community plugin** (`.ta/plugins/tool/widget-cli/plugin.toml`):
+
+```toml
+name = "widget-cli"
+type = "tool"
+command = ""                 # declarative-only; nothing to spawn for `tool` kind
+description = "Community widget CLI"
+
+[tool]
+label = "Widget CLI"
+detect_command = "widget --version"
+install_hint = "cargo install widget-cli"
+
+[tool.install]
+kind = "cargo"
+package = "widget-cli"
+```
+
+Run `ta tools list` / `ta tools install widget-cli` — no TA core PR required.
+
+**Minimal example — a `db`/`release`-kind external plugin** (call/response, canonical envelope):
+
+```toml
+name = "my-db-adapter"
+type = "db"
+command = "my-db-adapter-binary"
+timeout_secs = 30
+```
+
+The binary reads one JSON line (`{"method":"classify_query","params":{"query":"..."}}`), and writes one JSON line back (`{"ok":true,"result":{"class":"read"}}`).
 
 #### Channel Access Control
 

--- a/docs/plugin-traits.md
+++ b/docs/plugin-traits.md
@@ -1,5 +1,7 @@
 # TA Plugin Trait Reference
 
+> **Note:** For the current, unified Plugin-category manifest/discovery/protocol reference (VCS/messaging/social/agent/tool/db/release — `plugin.toml`, `.ta/plugins/<kind>/<name>/`, shared `ta-plugin` transport crate), see `docs/USAGE.md` → "Authoring a Plugin".
+
 This document describes the stable extension surface that TA exposes to external plugins. Plugin authors implement these traits against a specific TA release and can rely on them not breaking without a major version bump.
 
 Plugin binaries communicate with TA through the `[plugins]` section of `daemon.toml`:

--- a/docs/plugins-architecture-guidance.md
+++ b/docs/plugins-architecture-guidance.md
@@ -1,5 +1,7 @@
 # Trusted Autonomy — Plugin Architecture & Event Model
 
+> **Note:** For the current, unified Plugin-category manifest/discovery/protocol reference (VCS/messaging/social/agent/tool/db/release), see `docs/USAGE.md` → "Authoring a Plugin". This document covers general design principles and the event model, not superseded by that guide.
+
 Trusted Autonomy is designed to be **extendible by nature**.
 Plugins add intelligence and observability, not control.
 

--- a/docs/superpowers/plans/2026-07-06-plugin-adapter-connector-unification.md
+++ b/docs/superpowers/plans/2026-07-06-plugin-adapter-connector-unification.md
@@ -1,0 +1,1829 @@
+# Plugin/Adapter/Connector Unification (v0.17.0.12.14) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the 4-category extensibility model from `docs/design/ta-concepts-and-architecture.md` §2.2 (Plugin / Channel-Listener / Backend / Resource-list) by extracting one shared JSON-over-stdio plugin transport+manifest+discovery crate, migrating VCS/messaging/social/agent-runtime plugins onto it, and bringing `EXTERNAL_TOOLS`, `DbProxyPlugin`, and `ReleaseAdapter` into the Plugin category as PLAN.md v0.17.0.12.14 requires.
+
+**Architecture:** New crate `crates/ta-plugin` provides format-agnostic transport (spawn + ETXTBSY retry + newline-JSON framing + watchdog-thread timeout+SIGKILL, one copy instead of three), a canonical `PluginManifest` (superset of the VCS/messaging/social fields) and `.ta/plugins/<kind>/<name>/plugin.toml` discovery (project-local → user-global, matching VCS's existing order — the "most mature" of the three prior orders per the phase goal). Each existing domain (VCS/messaging/social/runtime) keeps its own request/response wire types unchanged (no breaking changes to already-published plugin binaries) but delegates spawn/framing/manifest/discovery to the shared crate. New Plugin-category integrations (tool, db, release) are built directly on the shared crate's generic `PluginRequest{method,params}` / `PluginResponse{ok,result,error}` envelope from the start.
+
+**Tech Stack:** Rust, serde/serde_json, toml, thiserror, std::process (no async), libc (unix SIGKILL), tempfile (tests).
+
+## Global Constraints
+
+- Do not change the wire-level JSON shape of `VcsPluginRequest/Response`, `MessagingPluginRequest/Response`, or `SocialPluginRequest/Response` — real published plugin binaries under `plugins/` depend on today's bytes.
+- Every new/changed manifest-driven discovery path lives under `.ta/plugins/<kind>/<name>/plugin.toml` (project-local) or `~/.config/ta/plugins/<kind>/<name>/plugin.toml` (user-global), per `docs/design/ta-concepts-and-architecture.md` §2.2.
+- `crates/ta-plugin` has version `0.17.0-alpha.12.13` (workspace version) and no new external (non-workspace) dependencies beyond what's already in `[workspace.dependencies]` (serde, serde_json, thiserror, toml, libc, tempfile).
+- Never disable or skip tests. Run `./dev cargo test --workspace` after every task.
+- Mark PLAN.md items `[x]` immediately as each is implemented (see Task Completion Enforcement in the injected CLAUDE.md).
+
+---
+
+### Task 1: `ta-plugin` crate — envelope, error, transport
+
+**Files:**
+- Create: `crates/ta-plugin/Cargo.toml`
+- Create: `crates/ta-plugin/src/lib.rs`
+- Create: `crates/ta-plugin/src/envelope.rs`
+- Create: `crates/ta-plugin/src/error.rs`
+- Create: `crates/ta-plugin/src/transport.rs`
+- Modify: `Cargo.toml:14-51` (add `"crates/ta-plugin",` to `[workspace] members`)
+
+**Interfaces:**
+- Produces (used by every later task):
+  - `ta_plugin::envelope::{PluginRequest, PluginResponse, HandshakeParams, HandshakeResult, PROTOCOL_VERSION}`
+  - `ta_plugin::error::PluginError` (thiserror enum: `NotFound{name}`, `CallFailed{name,method,reason}`, `InvalidResponse{name,method,reason}`, `SpawnFailed{command,reason}`, `Timeout{name,method,timeout_secs}`, `ManifestNotFound{path}`, `InvalidManifest{path,reason}`, `MissingCommand{path}`, `Io(#[from] std::io::Error)`, `Json(#[from] serde_json::Error)`)
+  - `ta_plugin::transport::call_raw(name: &str, method: &str, command: &str, extra_args: &[String], work_dir: &Path, request_line: &str, timeout: Duration) -> Result<String, PluginError>` — spawns `command` (first whitespace token = program, rest + `extra_args` = args) in `work_dir`, retries spawn on Unix `ETXTBSY` (os error 26) up to 4 times with backoff `[0, 20, 80, 200]` ms, writes `request_line` + `"\n"` to stdin, waits for exit with a watchdog thread that `SIGKILL`s the child on timeout (unix; no-op elsewhere), returns the first line of stdout. Non-zero exit → `CallFailed` with trimmed stderr. Empty/missing first stdout line → `InvalidResponse`.
+  - `ta_plugin::transport::call_json<Req: Serialize, Resp: DeserializeOwned>(name: &str, method: &str, command: &str, extra_args: &[String], work_dir: &Path, request: &Req, timeout: Duration) -> Result<Resp, PluginError>` — `serde_json::to_string(request)` then `call_raw`, then `serde_json::from_str` the returned line, mapping JSON errors to `InvalidResponse`.
+
+**Cargo.toml contents:**
+```toml
+[package]
+name = "ta-plugin"
+version.workspace = true
+edition = "2021"
+description = "Shared JSON-over-stdio plugin transport, manifest, and discovery for Trusted Autonomy Plugin-category integrations"
+license = "Apache-2.0"
+repository = "https://github.com/trustedautonomy/ta"
+homepage = "https://github.com/trustedautonomy/ta"
+keywords = ["ai", "agent", "autonomy", "plugin"]
+categories = ["development-tools"]
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+toml = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+```
+
+- [ ] **Step 1: Write `error.rs`**
+
+```rust
+//! Shared error type for all Plugin-category (§2.2) integrations.
+
+#[derive(Debug, thiserror::Error)]
+pub enum PluginError {
+    #[error("plugin '{name}' not found")]
+    NotFound { name: String },
+    #[error("plugin '{name}' method '{method}' failed: {reason}")]
+    CallFailed {
+        name: String,
+        method: String,
+        reason: String,
+    },
+    #[error("plugin '{name}' method '{method}' returned an invalid response: {reason}")]
+    InvalidResponse {
+        name: String,
+        method: String,
+        reason: String,
+    },
+    #[error("failed to spawn plugin command '{command}': {reason}")]
+    SpawnFailed { command: String, reason: String },
+    #[error("plugin '{name}' method '{method}' timed out after {timeout_secs}s")]
+    Timeout {
+        name: String,
+        method: String,
+        timeout_secs: u64,
+    },
+    #[error("plugin manifest not found at {path}")]
+    ManifestNotFound { path: String },
+    #[error("invalid plugin manifest at {path}: {reason}")]
+    InvalidManifest { path: String, reason: String },
+    #[error("plugin manifest at {path} is missing the required 'command' field")]
+    MissingCommand { path: String },
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+```
+
+- [ ] **Step 2: Write `envelope.rs`**
+
+```rust
+//! The canonical `method:String` / `{ok,result,error}` call/response envelope
+//! (§2.2 Plugin category) — the reference shape for new Plugin-category
+//! integrations. Existing VCS/messaging/social wire types keep their own
+//! shapes for backward compatibility; they use `transport::call_json` with
+//! their own Req/Resp types instead of this envelope directly.
+
+use serde::{Deserialize, Serialize};
+
+pub const PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginRequest {
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+impl PluginRequest {
+    pub fn new(method: impl Into<String>, params: serde_json::Value) -> Self {
+        Self {
+            method: method.into(),
+            params,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginResponse {
+    pub ok: bool,
+    #[serde(default)]
+    pub result: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl PluginResponse {
+    pub fn success(result: serde_json::Value) -> Self {
+        Self {
+            ok: true,
+            result,
+            error: None,
+        }
+    }
+
+    pub fn error(msg: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            result: serde_json::Value::Null,
+            error: Some(msg.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandshakeParams {
+    pub ta_version: String,
+    pub protocol_version: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandshakeResult {
+    pub plugin_version: String,
+    pub protocol_version: u32,
+    #[serde(default)]
+    pub adapter_name: String,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+}
+```
+
+- [ ] **Step 3: Write `transport.rs`**
+
+```rust
+//! Shared spawn + newline-delimited-JSON framing + timeout transport, used by
+//! every Plugin-category integration (VCS, messaging, social, agent-runtime,
+//! tool, db, release). Format-agnostic: `call_json` is generic over the
+//! caller's own request/response types, so it does not change any existing
+//! plugin's wire bytes.
+
+use crate::error::PluginError;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::io::{Read, Write};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+const ETXTBSY_BACKOFF_MS: [u64; 4] = [0, 20, 80, 200];
+
+fn spawn_with_retry(command: &str, extra_args: &[String], work_dir: &Path) -> Result<Child, PluginError> {
+    let mut parts = command.split_whitespace();
+    let program = parts
+        .next()
+        .ok_or_else(|| PluginError::SpawnFailed {
+            command: command.to_string(),
+            reason: "empty command".to_string(),
+        })?;
+    let baked_args: Vec<&str> = parts.collect();
+
+    let mut last_err = None;
+    for delay_ms in ETXTBSY_BACKOFF_MS {
+        if delay_ms > 0 {
+            std::thread::sleep(Duration::from_millis(delay_ms));
+        }
+        let mut cmd = Command::new(program);
+        cmd.args(&baked_args)
+            .args(extra_args)
+            .current_dir(work_dir)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        match cmd.spawn() {
+            Ok(child) => return Ok(child),
+            Err(e) if e.raw_os_error() == Some(26) => {
+                last_err = Some(e);
+                continue;
+            }
+            Err(e) => {
+                return Err(PluginError::SpawnFailed {
+                    command: command.to_string(),
+                    reason: e.to_string(),
+                })
+            }
+        }
+    }
+    Err(PluginError::SpawnFailed {
+        command: command.to_string(),
+        reason: last_err
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "ETXTBSY retry exhausted".to_string()),
+    })
+}
+
+/// Wait for `child` to exit, killing it after `timeout` via a watchdog thread.
+fn wait_with_timeout(mut child: Child, timeout: Duration) -> Result<std::process::Output, PluginError> {
+    let pid = child.id();
+    let (tx, rx) = mpsc::channel::<()>();
+    let watchdog = std::thread::spawn(move || {
+        if rx.recv_timeout(timeout).is_err() {
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
+            }
+        }
+    });
+    let started = Instant::now();
+    let output = child.wait_with_output();
+    let _ = tx.send(());
+    let _ = watchdog.join();
+    let output = output?;
+    if started.elapsed() >= timeout && !output.status.success() {
+        return Err(PluginError::Timeout {
+            name: String::new(),
+            method: String::new(),
+            timeout_secs: timeout.as_secs(),
+        });
+    }
+    Ok(output)
+}
+
+/// Format-agnostic call: write `request_line` + "\n" to the plugin's stdin,
+/// return the first line of stdout. Non-zero exit or empty stdout is an error.
+#[allow(clippy::too_many_arguments)]
+pub fn call_raw(
+    name: &str,
+    method: &str,
+    command: &str,
+    extra_args: &[String],
+    work_dir: &Path,
+    request_line: &str,
+    timeout: Duration,
+) -> Result<String, PluginError> {
+    let mut child = spawn_with_retry(command, extra_args, work_dir)?;
+    {
+        let stdin = child.stdin.as_mut().ok_or_else(|| PluginError::CallFailed {
+            name: name.to_string(),
+            method: method.to_string(),
+            reason: "plugin process has no stdin".to_string(),
+        })?;
+        stdin.write_all(request_line.as_bytes())?;
+        stdin.write_all(b"\n")?;
+    }
+    let output = wait_with_timeout(child, timeout).map_err(|e| match e {
+        PluginError::Timeout { .. } => PluginError::Timeout {
+            name: name.to_string(),
+            method: method.to_string(),
+            timeout_secs: timeout.as_secs(),
+        },
+        other => other,
+    })?;
+
+    if !output.status.success() {
+        let mut stderr = String::new();
+        let _ = std::io::Cursor::new(&output.stderr).read_to_string(&mut stderr);
+        return Err(PluginError::CallFailed {
+            name: name.to_string(),
+            method: method.to_string(),
+            reason: stderr.trim().to_string(),
+        });
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let first_line = stdout.lines().next().unwrap_or("");
+    if first_line.is_empty() {
+        return Err(PluginError::InvalidResponse {
+            name: name.to_string(),
+            method: method.to_string(),
+            reason: "plugin wrote no output line to stdout".to_string(),
+        });
+    }
+    Ok(first_line.to_string())
+}
+
+/// JSON convenience wrapper over `call_raw`, generic over the caller's own
+/// request/response wire types (VCS/messaging/social keep their existing
+/// types; new integrations use `envelope::{PluginRequest,PluginResponse}`).
+#[allow(clippy::too_many_arguments)]
+pub fn call_json<Req: Serialize, Resp: DeserializeOwned>(
+    name: &str,
+    method: &str,
+    command: &str,
+    extra_args: &[String],
+    work_dir: &Path,
+    request: &Req,
+    timeout: Duration,
+) -> Result<Resp, PluginError> {
+    let line = serde_json::to_string(request)?;
+    let response_line = call_raw(name, method, command, extra_args, work_dir, &line, timeout)?;
+    serde_json::from_str(&response_line).map_err(|e| PluginError::InvalidResponse {
+        name: name.to_string(),
+        method: method.to_string(),
+        reason: format!("{e} (raw: {})", truncate(&response_line, 200)),
+    })
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn write_mock_script(dir: &Path, body: &str) -> String {
+        let path = dir.join("mock-plugin.sh");
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+        path.to_string_lossy().to_string()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn call_raw_round_trips_one_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_mock_script(dir.path(), "read -r line\necho '{\"ok\":true,\"result\":{}}'");
+        let result = call_raw("mock", "ping", &script, &[], dir.path(), "{\"method\":\"ping\"}", Duration::from_secs(5)).unwrap();
+        assert_eq!(result, "{\"ok\":true,\"result\":{}}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn call_json_deserializes_response() {
+        use crate::envelope::{PluginRequest, PluginResponse};
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_mock_script(dir.path(), "read -r line\necho '{\"ok\":true,\"result\":{\"pong\":true}}'");
+        let req = PluginRequest::new("ping", serde_json::json!({}));
+        let resp: PluginResponse = call_json("mock", "ping", &script, &[], dir.path(), &req, Duration::from_secs(5)).unwrap();
+        assert!(resp.ok);
+        assert_eq!(resp.result["pong"], serde_json::json!(true));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn call_raw_reports_nonzero_exit() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_mock_script(dir.path(), "echo 'boom' >&2\nexit 1");
+        let err = call_raw("mock", "ping", &script, &[], dir.path(), "{}", Duration::from_secs(5)).unwrap_err();
+        match err {
+            PluginError::CallFailed { reason, .. } => assert!(reason.contains("boom")),
+            other => panic!("expected CallFailed, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn call_raw_kills_on_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = write_mock_script(dir.path(), "sleep 5\necho '{\"ok\":true,\"result\":{}}'");
+        let err = call_raw("mock", "ping", &script, &[], dir.path(), "{}", Duration::from_millis(200)).unwrap_err();
+        assert!(matches!(err, PluginError::Timeout { .. }));
+    }
+}
+```
+
+- [ ] **Step 4: Write `lib.rs`**
+
+```rust
+//! Shared JSON-over-stdio plugin transport, manifest schema, and discovery
+//! convention for every Trusted Autonomy Plugin-category integration
+//! (docs/design/ta-concepts-and-architecture.md §2.2): VCS, messaging,
+//! social, agent-runtime, tool, db, and release plugins all use this crate.
+
+pub mod discovery;
+pub mod envelope;
+pub mod error;
+pub mod manifest;
+pub mod transport;
+
+pub use envelope::{HandshakeParams, HandshakeResult, PluginRequest, PluginResponse, PROTOCOL_VERSION};
+pub use error::PluginError;
+pub use manifest::PluginManifest;
+pub use discovery::{discover_plugins, find_plugin, user_config_dir, DiscoveredPlugin, PluginSource};
+```
+
+- [ ] **Step 5: Add `crates/ta-plugin` to workspace members**
+
+In `Cargo.toml`, add `"crates/ta-plugin",` to the `members` array (alphabetically near `"crates/ta-policy",` — after `"crates/ta-output-schema",`).
+
+- [ ] **Step 6: Build and test (manifest/discovery come in Task 2, so this compiles once Task 2's files exist too — do Steps 1-5 then proceed directly to Task 2 before building)**
+
+---
+
+### Task 2: `ta-plugin` crate — manifest + discovery
+
+**Files:**
+- Create: `crates/ta-plugin/src/manifest.rs`
+- Create: `crates/ta-plugin/src/discovery.rs`
+
+**Interfaces:**
+- Consumes: `ta_plugin::error::PluginError` (Task 1)
+- Produces:
+  - `ta_plugin::manifest::PluginManifest { name: String, version: String, kind: String, command: String, args: Vec<String>, capabilities: Vec<String>, description: Option<String>, timeout_secs: Option<u64>, protocol_version: Option<u32>, min_daemon_version: Option<String>, source_url: Option<String>, staging_env: HashMap<String,String> }` with `PluginManifest::load(path: &Path) -> Result<Self, PluginError>` and `PluginManifest::validate(&self, expected_kind: &str) -> Result<(), PluginError>`. `timeout_secs` is `Option` (not defaulted in this shared struct) so each domain can keep applying its own historical default (VCS 30s, messaging/social 60s) without a behavior change.
+  - `ta_plugin::discovery::{PluginSource::{ProjectLocal,UserGlobal}, DiscoveredPlugin{manifest,plugin_dir,source}, discover_plugins(kind: &str, project_root: &Path) -> Vec<DiscoveredPlugin>, find_plugin(kind: &str, name: &str, project_root: &Path) -> Option<DiscoveredPlugin>, user_config_dir() -> Option<PathBuf>}`. Search order is project-local (`<project_root>/.ta/plugins/<kind>/*/plugin.toml`) then user-global (`~/.config/ta/plugins/<kind>/*/plugin.toml`, via `XDG_CONFIG_HOME` then `HOME/.config`) — this is VCS's existing order, chosen as canonical per the phase goal ("matching VCS's existing...shape (most mature)"). No PATH-fallback synthesis here — each domain keeps constructing its own PATH-fallback manifest (their assumed-capabilities lists differ intentionally; unifying that silently would hide real per-domain capability assumptions).
+
+- [ ] **Step 1: Write `manifest.rs`**
+
+```rust
+//! The canonical `plugin.toml` manifest schema (§2.2), a superset of the
+//! fields historically split across VcsPluginManifest/MessagingPluginManifest/
+//! SocialPluginManifest.
+
+use crate::error::PluginError;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+fn default_version() -> String {
+    "0.1.0".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginManifest {
+    pub name: String,
+    #[serde(default = "default_version")]
+    pub version: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+    #[serde(default)]
+    pub protocol_version: Option<u32>,
+    #[serde(default)]
+    pub min_daemon_version: Option<String>,
+    #[serde(default)]
+    pub source_url: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub staging_env: HashMap<String, String>,
+}
+
+impl PluginManifest {
+    pub fn load(path: &Path) -> Result<Self, PluginError> {
+        if !path.exists() {
+            return Err(PluginError::ManifestNotFound {
+                path: path.display().to_string(),
+            });
+        }
+        let text = std::fs::read_to_string(path)?;
+        let manifest: PluginManifest = toml::from_str(&text).map_err(|e| PluginError::InvalidManifest {
+            path: path.display().to_string(),
+            reason: e.to_string(),
+        })?;
+        if manifest.command.trim().is_empty() {
+            return Err(PluginError::MissingCommand {
+                path: path.display().to_string(),
+            });
+        }
+        Ok(manifest)
+    }
+
+    pub fn validate(&self, expected_kind: &str) -> Result<(), PluginError> {
+        if self.kind != expected_kind {
+            return Err(PluginError::InvalidManifest {
+                path: self.name.clone(),
+                reason: format!("expected type = \"{expected_kind}\", found \"{}\"", self.kind),
+            });
+        }
+        Ok(())
+    }
+
+    pub fn timeout(&self, default_secs: u64) -> std::time::Duration {
+        std::time::Duration::from_secs(self.timeout_secs.unwrap_or(default_secs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_minimal_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plugin.toml");
+        std::fs::write(&path, "name = \"demo\"\ntype = \"vcs\"\ncommand = \"demo-plugin\"\n").unwrap();
+        let manifest = PluginManifest::load(&path).unwrap();
+        assert_eq!(manifest.name, "demo");
+        assert_eq!(manifest.version, "0.1.0");
+        assert_eq!(manifest.timeout_secs, None);
+        assert!(manifest.validate("vcs").is_ok());
+        assert!(manifest.validate("messaging").is_err());
+    }
+
+    #[test]
+    fn missing_command_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plugin.toml");
+        std::fs::write(&path, "name = \"demo\"\ntype = \"vcs\"\ncommand = \"\"\n").unwrap();
+        assert!(matches!(
+            PluginManifest::load(&path),
+            Err(PluginError::MissingCommand { .. })
+        ));
+    }
+
+    #[test]
+    fn missing_file_is_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope").join("plugin.toml");
+        assert!(matches!(
+            PluginManifest::load(&path),
+            Err(PluginError::ManifestNotFound { .. })
+        ));
+    }
+}
+```
+
+- [ ] **Step 2: Write `discovery.rs`**
+
+```rust
+//! `.ta/plugins/<kind>/<name>/plugin.toml` discovery convention (§2.2),
+//! shared by every Plugin-category integration.
+
+use crate::manifest::PluginManifest;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginSource {
+    ProjectLocal,
+    UserGlobal,
+}
+
+impl fmt::Display for PluginSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PluginSource::ProjectLocal => write!(f, "project"),
+            PluginSource::UserGlobal => write!(f, "global"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoveredPlugin {
+    pub manifest: PluginManifest,
+    pub plugin_dir: PathBuf,
+    pub source: PluginSource,
+}
+
+/// `$XDG_CONFIG_HOME` if set, else `$HOME/.config`. Intentionally not
+/// macOS-special-cased, matching the VCS/messaging/social behavior being
+/// unified (changing this would alter where existing plugins are found).
+pub fn user_config_dir() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        if !xdg.is_empty() {
+            return Some(PathBuf::from(xdg));
+        }
+    }
+    std::env::var("HOME").ok().map(|home| PathBuf::from(home).join(".config"))
+}
+
+fn scan_kind_dir(base: &Path, kind: &str, source: PluginSource) -> Vec<DiscoveredPlugin> {
+    let kind_dir = base.join("plugins").join(kind);
+    let Ok(entries) = std::fs::read_dir(&kind_dir) else {
+        return vec![];
+    };
+    let mut found = vec![];
+    for entry in entries.flatten() {
+        let plugin_dir = entry.path();
+        if !plugin_dir.is_dir() {
+            continue;
+        }
+        let manifest_path = plugin_dir.join("plugin.toml");
+        if let Ok(manifest) = PluginManifest::load(&manifest_path) {
+            found.push(DiscoveredPlugin {
+                manifest,
+                plugin_dir,
+                source,
+            });
+        }
+    }
+    found.sort_by(|a, b| a.manifest.name.cmp(&b.manifest.name));
+    found
+}
+
+/// Discover every `<kind>` plugin, project-local first then user-global.
+/// If a name exists in both, both entries are returned (callers that want a
+/// single result per name should use `find_plugin`, which takes the first
+/// match in this same project-then-global order).
+pub fn discover_plugins(kind: &str, project_root: &Path) -> Vec<DiscoveredPlugin> {
+    let mut found = scan_kind_dir(&project_root.join(".ta"), kind, PluginSource::ProjectLocal);
+    if let Some(config_dir) = user_config_dir() {
+        found.extend(scan_kind_dir(&config_dir.join("ta"), kind, PluginSource::UserGlobal));
+    }
+    found
+}
+
+pub fn find_plugin(kind: &str, name: &str, project_root: &Path) -> Option<DiscoveredPlugin> {
+    discover_plugins(kind, project_root)
+        .into_iter()
+        .find(|p| p.manifest.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_manifest(dir: &Path, kind: &str, name: &str) {
+        let plugin_dir = dir.join(".ta").join("plugins").join(kind).join(name);
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.toml"),
+            format!("name = \"{name}\"\ntype = \"{kind}\"\ncommand = \"{name}-bin\"\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn discovers_project_local_plugin() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), "vcs", "perforce");
+        let found = discover_plugins("vcs", dir.path());
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].manifest.name, "perforce");
+        assert_eq!(found[0].source, PluginSource::ProjectLocal);
+    }
+
+    #[test]
+    fn find_plugin_returns_none_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(find_plugin("vcs", "nope", dir.path()).is_none());
+    }
+
+    #[test]
+    fn ignores_kind_dir_with_no_plugins() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(discover_plugins("vcs", dir.path()).is_empty());
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `./dev cargo build -p ta-plugin`
+Expected: builds clean.
+
+- [ ] **Step 4: Test**
+
+Run: `./dev cargo test -p ta-plugin`
+Expected: all tests pass (transport: 4, manifest: 3, discovery: 3).
+
+- [ ] **Step 5: Clippy + fmt**
+
+Run: `./dev cargo clippy -p ta-plugin --all-targets -- -D warnings && ./dev cargo fmt -p ta-plugin -- --check`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml crates/ta-plugin
+git commit -m "feat(ta-plugin): add shared plugin transport, manifest, and discovery crate"
+```
+
+---
+
+### Task 3: Migrate VCS plugin transport onto `ta_plugin::transport`
+
+**Files:**
+- Modify: `crates/ta-submit/Cargo.toml` (add `ta-plugin` dependency)
+- Modify: `crates/ta-submit/src/external_vcs_adapter.rs` (replace private `call_plugin`/`wait_with_timeout`/spawn-retry with `ta_plugin::transport::call_json`)
+
+**Interfaces:**
+- Consumes: `ta_plugin::transport::call_json::<VcsPluginRequest, VcsPluginResponse>` (Task 1)
+- Produces: `ExternalVcsAdapter` keeps its exact existing public API (`SourceAdapter` impl) — no signature changes for any caller outside this file.
+
+- [ ] **Step 1: Add dependency**
+
+In `crates/ta-submit/Cargo.toml`, add under `[dependencies]`:
+```toml
+ta-plugin = { path = "../ta-plugin", version = "0.17.0-alpha.12.13" }
+```
+
+- [ ] **Step 2: Locate and replace the transport internals**
+
+In `crates/ta-submit/src/external_vcs_adapter.rs`, find the private `call_plugin` function (spawn + ETXTBSY retry + `wait_with_timeout`) and its `wait_with_timeout` helper. Replace the body of `call_plugin` with a call into the shared crate, preserving the existing function signature (`fn call_plugin(command: &str, extra_args: &[String], work_dir: &Path, request: &VcsPluginRequest, timeout: Duration) -> Result<VcsPluginResponse>`) so every call site in the file is unaffected:
+
+```rust
+fn call_plugin(
+    command: &str,
+    extra_args: &[String],
+    work_dir: &Path,
+    request: &VcsPluginRequest,
+    timeout: Duration,
+) -> Result<VcsPluginResponse> {
+    ta_plugin::transport::call_json(
+        "vcs-plugin",
+        &request.method,
+        command,
+        extra_args,
+        work_dir,
+        request,
+        timeout,
+    )
+    .map_err(|e| SubmitError::VcsError(e.to_string()))
+}
+```
+
+Delete the now-unused private `wait_with_timeout` function and its `ETXTBSY`/backoff constants from this file (they moved to `ta_plugin::transport`). Leave everything else in the file (handshake logic, capability checks, `SourceAdapter` impl) untouched.
+
+- [ ] **Step 3: Build**
+
+Run: `./dev cargo build -p ta-submit`
+Expected: builds clean (watch for now-unused imports like `libc`, `mpsc` — remove them if `cargo build` warns).
+
+- [ ] **Step 4: Test**
+
+Run: `./dev cargo test -p ta-submit vcs`
+Expected: `vcs_plugin_lifecycle` and `vcs_perforce_plugin` integration tests still pass unchanged (they exercise `ExternalVcsAdapter` end-to-end, so this proves the transport swap didn't change behavior).
+
+- [ ] **Step 5: Full workspace test**
+
+Run: `./dev cargo test --workspace`
+Expected: all pass.
+
+- [ ] **Step 6: Clippy + fmt**
+
+Run: `./dev cargo clippy --workspace --all-targets -- -D warnings && ./dev cargo fmt --all -- --check`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ta-submit
+git commit -m "refactor(ta-submit): delegate VCS plugin transport to shared ta-plugin crate"
+```
+
+---
+
+### Task 4: Migrate messaging + social plugin transport onto `ta_plugin::transport`
+
+**Files:**
+- Modify: `crates/ta-submit/src/messaging_adapter.rs` (replace private `call_plugin`/`wait_with_timeout`/spawn-retry)
+- Modify: `crates/ta-submit/src/social_adapter.rs` (same)
+
+**Interfaces:**
+- Consumes: `ta_plugin::transport::call_json::<MessagingPluginRequest, MessagingPluginResponse>` and `::<SocialPluginRequest, SocialPluginResponse>`
+- Produces: `ExternalMessagingAdapter`/`ExternalSocialAdapter` keep their exact existing public methods (`fetch`, `create_draft`, `draft_status`, `health`, `create_scheduled`, etc.) — no signature changes.
+
+- [ ] **Step 1: `messaging_adapter.rs`**
+
+Replace the private `call_plugin` method on `ExternalMessagingAdapter` with:
+
+```rust
+fn call_plugin(&self, req: &MessagingPluginRequest, op: &str) -> Result<MessagingPluginResponse, MessagingPluginError> {
+    let resp: MessagingPluginResponse = ta_plugin::transport::call_json(
+        &self.provider,
+        op,
+        &self.command,
+        &self.args,
+        Path::new("."),
+        req,
+        self.timeout,
+    )
+    .map_err(|e| match e {
+        ta_plugin::PluginError::Timeout { timeout_secs, .. } => MessagingPluginError::Timeout {
+            name: self.provider.clone(),
+            op: op.to_string(),
+            timeout_secs,
+        },
+        ta_plugin::PluginError::SpawnFailed { command, reason } => {
+            MessagingPluginError::SpawnFailed { command, reason }
+        }
+        other => MessagingPluginError::InvalidResponse {
+            name: self.provider.clone(),
+            op: op.to_string(),
+            reason: other.to_string(),
+        },
+    })?;
+    if !resp.ok {
+        return Err(MessagingPluginError::OpFailed {
+            name: self.provider.clone(),
+            op: op.to_string(),
+            reason: resp.error.clone().unwrap_or_default(),
+        });
+    }
+    Ok(resp)
+}
+```
+
+Note the existing call sites pass `work_dir: &Path` implicitly via `Path::new(".")` — check the current `call_plugin` signature first: if it already threads a real `work_dir` (e.g. `self.work_dir` or a param), keep using that value instead of `Path::new(".")` — read the surrounding code before editing to preserve identical spawn `current_dir` behavior. Delete the file's private `wait_with_timeout` and its ETXTBSY loop.
+
+- [ ] **Step 2: `social_adapter.rs`**
+
+Same transformation for `ExternalSocialAdapter::call_plugin`, mapping errors to `SocialPluginError` variants instead of `MessagingPluginError`. Remember social's current `call_plugin` has **no** ETXTBSY retry loop (per the earlier research) — using `ta_plugin::transport::call_json` *adds* ETXTBSY retry that didn't exist before. This is a deliberate, safe improvement (retrying a transient spawn error can only help, never break passing tests) — note it in `.ta-decisions.json` (Task 11) rather than trying to suppress it.
+
+- [ ] **Step 3: Add dependency (already added in Task 3 to `ta-submit/Cargo.toml` — confirm it's present, no new edit needed)**
+
+- [ ] **Step 4: Build + test**
+
+Run: `./dev cargo build -p ta-submit && ./dev cargo test -p ta-submit`
+Expected: messaging/social unit tests (embedded `#[cfg(test)]` modules in both files) pass unchanged.
+
+- [ ] **Step 5: Full workspace test, clippy, fmt**
+
+Run: `./dev cargo test --workspace && ./dev cargo clippy --workspace --all-targets -- -D warnings && ./dev cargo fmt --all -- --check`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ta-submit
+git commit -m "refactor(ta-submit): delegate messaging/social plugin transport to shared ta-plugin crate"
+```
+
+---
+
+### Task 5: Migrate agent-runtime plugin transport + add manifest/discovery
+
+**Files:**
+- Modify: `crates/ta-runtime/Cargo.toml` (add `ta-plugin` dependency)
+- Modify: `crates/ta-runtime/src/plugin.rs` (delegate `PluginProcess::call` framing to `ta_plugin::transport`; add manifest-based discovery)
+
+**Interfaces:**
+- Consumes: `ta_plugin::transport::call_json`, `ta_plugin::{PluginManifest, discover_plugins, find_plugin}`
+- Produces: `ExternalRuntimeAdapter::new(plugin_path: &Path, runtime_name: &str) -> Result<Self>` (unchanged, kept for explicit-path callers) plus a new `ExternalRuntimeAdapter::discover(name: &str, project_root: &Path) -> Result<Self>` that resolves `command` via `ta_plugin::find_plugin("agent", name, project_root)` before falling back to the bare binary name on `PATH`.
+
+- [ ] **Step 1: Add dependency**
+
+`crates/ta-runtime/Cargo.toml`, under `[dependencies]`:
+```toml
+ta-plugin = { path = "../ta-plugin", version = "0.17.0-alpha.12.13" }
+```
+
+- [ ] **Step 2: Replace `PluginProcess::call`'s framing**
+
+In `crates/ta-runtime/src/plugin.rs`, `PluginProcess` currently owns its own `Child`/`stdin`/`stdout_reader` because it is long-lived (spawn once, many calls) — unlike VCS/messaging/social's per-call spawn. `ta_plugin::transport::call_raw` spawns a fresh process per call, so it is **not** a drop-in replacement for `PluginProcess::call`'s per-line read/write over an already-running child. Instead, extract just the line-framing (not the spawn) into a small shared-shape helper: keep `PluginProcess`'s existing `Child`/`stdin`/`stdout_reader` fields and its long-lived spawn in `ExternalRuntimeAdapter::new`, but replace the manual `serde_json::to_string` + `write_all` + `read_line` + `serde_json::from_str` sequence inside `call()` with calls to two new small `pub` functions added to `ta_plugin::transport` in this task:
+
+```rust
+// in crates/ta-plugin/src/transport.rs, added alongside call_raw/call_json:
+
+/// Write one JSON request line to an already-open stdin handle (long-lived
+/// process framing, e.g. agent-runtime plugins that stay alive across calls).
+pub fn write_line<Req: Serialize>(stdin: &mut impl Write, request: &Req) -> Result<(), PluginError> {
+    let line = serde_json::to_string(request)?;
+    stdin.write_all(line.as_bytes())?;
+    stdin.write_all(b"\n")?;
+    Ok(())
+}
+
+/// Read one JSON response line from an already-open stdout reader.
+pub fn read_line<Resp: DeserializeOwned>(reader: &mut impl std::io::BufRead) -> Result<Resp, PluginError> {
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    if line.trim().is_empty() {
+        return Err(PluginError::InvalidResponse {
+            name: String::new(),
+            method: String::new(),
+            reason: "plugin wrote no output line to stdout".to_string(),
+        });
+    }
+    serde_json::from_str(&line).map_err(PluginError::from)
+}
+```
+
+Then in `plugin.rs`, `PluginProcess::call` becomes:
+```rust
+fn call(&mut self, method: &str, params: serde_json::Value) -> Result<serde_json::Value> {
+    let request = PluginRequest { method: method.to_string(), params };
+    ta_plugin::transport::write_line(&mut self.stdin, &request)
+        .map_err(|e| RuntimeError::PluginError(e.to_string()))?;
+    let response: PluginResponse = ta_plugin::transport::read_line(&mut self.stdout_reader)
+        .map_err(|e| RuntimeError::PluginError(e.to_string()))?;
+    if response.ok {
+        Ok(response.result)
+    } else {
+        Err(RuntimeError::PluginError(response.error.unwrap_or_default()))
+    }
+}
+```
+(Keep this file's own `PluginRequest`/`PluginResponse` structs as-is — they are structurally identical to `ta_plugin::envelope`'s but renaming/removing them is out of scope for this task; only the framing internals move to the shared crate.)
+
+- [ ] **Step 3: Add manifest-based discovery**
+
+Add a new function in `plugin.rs`:
+```rust
+impl ExternalRuntimeAdapter {
+    /// Resolve `name` via `.ta/plugins/agent/<name>/plugin.toml` discovery
+    /// (project-local then user-global), falling back to treating `name`
+    /// as a bare command on PATH if no manifest is found.
+    pub fn discover(name: &str, project_root: &Path) -> Result<Self> {
+        let command = match ta_plugin::find_plugin("agent", name, project_root) {
+            Some(found) => found.plugin_dir.join(&found.manifest.command),
+            None => PathBuf::from(name),
+        };
+        Self::new(&command, name)
+    }
+}
+```
+
+- [ ] **Step 4: Build + test**
+
+Run: `./dev cargo build -p ta-runtime && ./dev cargo test -p ta-runtime`
+Expected: existing runtime plugin tests pass; add one new test in `plugin.rs`'s `#[cfg(test)]` module:
+
+```rust
+#[test]
+fn discover_falls_back_to_bare_name_when_no_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    // No .ta/plugins/agent/<name>/plugin.toml exists — discover() must not
+    // panic and must fall back to a bare-name command (which then fails to
+    // spawn, since "definitely-not-a-real-binary" doesn't exist on PATH).
+    let result = ExternalRuntimeAdapter::discover("definitely-not-a-real-binary", dir.path());
+    assert!(result.is_err());
+}
+```
+
+- [ ] **Step 5: Full workspace test, clippy, fmt**
+
+Run: `./dev cargo test --workspace && ./dev cargo clippy --workspace --all-targets -- -D warnings && ./dev cargo fmt --all -- --check`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ta-runtime
+git commit -m "feat(ta-runtime): delegate plugin line framing to ta-plugin, add manifest-based discovery"
+```
+
+---
+
+### Task 6: Migrate `EXTERNAL_TOOLS` onto the Plugin category
+
+**Files:**
+- Modify: `apps/ta-cli/Cargo.toml` (add `ta-plugin` dependency)
+- Modify: `apps/ta-cli/src/commands/tools.rs` (change `ExternalTool` fields from `&'static str` to `String`; add manifest-backed discovery merged with 3 built-in defaults)
+- Create: `plugins/tool/superpowers/plugin.toml`
+- Create: `plugins/tool/bmad/plugin.toml`
+- Create: `plugins/tool/meridian/plugin.toml`
+- Modify: `apps/ta-cli/src/commands/onboard.rs` (adjust to `String`-based `ExternalTool` if it pattern-matches on `&'static str`)
+- Modify: `apps/ta-cli/src/commands/release.rs` (same adjustment for `validate_third_party_plugins`)
+
+**Interfaces:**
+- Consumes: `ta_plugin::{PluginManifest, discover_plugins}`
+- Produces: `pub fn external_tools(project_root: &Path) -> Vec<ExternalTool>` (replaces the `EXTERNAL_TOOLS` const array as the thing callers iterate; `ExternalTool`'s field types change from `&'static str` to `String` and `install: ExternalToolInstall` gains owned-`String` variants). `check_tool_installed(tool: &ExternalTool) -> bool` keeps its existing signature (works the same on `&ExternalTool` regardless of field ownership).
+
+- [ ] **Step 1: Design the tool manifest extension**
+
+Tool manifests need 3 fields beyond the shared `PluginManifest` (`label`, `detect_command`, `install_hint`) plus an install spec. Rather than inventing a second manifest type, encode these as an optional `[tool]` TOML table alongside the standard `PluginManifest` fields, parsed as a second pass over the same file:
+
+```rust
+// in tools.rs
+#[derive(Debug, Clone, serde::Deserialize)]
+struct ToolExtra {
+    tool: ToolExtraFields,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct ToolExtraFields {
+    label: String,
+    detect_command: String,
+    install_hint: String,
+    install: ToolInstallSpec,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum ToolInstallSpec {
+    Cargo { package: String },
+    Npm { package: String },
+    Git { url: String, dest: String },
+    ClaudePlugin { spec: String },
+}
+```
+
+- [ ] **Step 2: Rewrite `ExternalTool`/`ExternalToolInstall` with owned `String` fields**
+
+```rust
+#[derive(Debug, Clone)]
+pub struct ExternalTool {
+    pub name: String,
+    pub label: String,
+    pub description: String,
+    pub detect_command: String,
+    pub install_hint: String,
+    pub install: ExternalToolInstall,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum ExternalToolInstall {
+    Cargo(String),
+    Npm(String),
+    Git { url: String, dest: String },
+    ClaudePlugin(String),
+}
+```
+
+- [ ] **Step 3: Write the 3 bundled default manifests**
+
+`plugins/tool/superpowers/plugin.toml`:
+```toml
+name = "superpowers"
+type = "tool"
+command = ""
+description = "Agent skills and orchestration plugin for Claude Code"
+
+[tool]
+label = "Superpowers Claude Code plugin"
+detect_command = "claude-plugin:superpowers"
+install_hint = "claude plugin install superpowers@superpowers-dev"
+
+[tool.install]
+kind = "claude_plugin"
+spec = "superpowers@superpowers-dev"
+```
+
+`plugins/tool/bmad/plugin.toml`:
+```toml
+name = "bmad"
+type = "tool"
+command = ""
+description = "Structured multi-role planning: Analyst, Architect, PM roles"
+
+[tool]
+label = "BMAD planning library"
+detect_command = "test -d ~/.bmad/agents"
+install_hint = "git clone --depth=1 https://github.com/bmadcode/bmad-method ~/.bmad"
+
+[tool.install]
+kind = "git"
+url = "https://github.com/bmadcode/bmad-method"
+dest = "~/.bmad"
+```
+
+`plugins/tool/meridian/plugin.toml`:
+```toml
+name = "meridian"
+type = "tool"
+command = ""
+description = "Velocity reports, cost-per-phase, and goal-alignment scoring (cargo)"
+
+[tool]
+label = "Meridian KPI analytics"
+detect_command = "meridian --version"
+install_hint = "cargo install meridian"
+
+[tool.install]
+kind = "cargo"
+package = "meridian"
+```
+(`command = ""` is deliberate: these are not call/response process plugins — `PluginManifest::load`'s `MissingCommand` check must be bypassed for tool-kind manifests specifically, since a "tool" doesn't get spawned via `handshake`/`method` calls; add a `PluginManifest::load_allow_empty_command(path) -> Result<Self, PluginError>` variant used only by tool discovery, or check `kind == "tool"` before enforcing `MissingCommand` inside `load()`. Prefer adding the `kind` check directly in `PluginManifest::load()` in `crates/ta-plugin/src/manifest.rs` — `if self.command.trim().is_empty() && self.kind != "tool" { return Err(MissingCommand...) }` — since "a declarative-only plugin kind with no executable" is a legitimate general case, not tool-specific plumbing.)
+
+- [ ] **Step 4: Implement discovery + merge**
+
+```rust
+pub fn external_tools(project_root: &Path) -> Vec<ExternalTool> {
+    let mut tools = vec![];
+    for discovered in ta_plugin::discover_plugins("tool", project_root) {
+        let manifest_path = discovered.plugin_dir.join("plugin.toml");
+        let Ok(text) = std::fs::read_to_string(&manifest_path) else { continue };
+        let Ok(extra) = toml::from_str::<ToolExtra>(&text) else { continue };
+        tools.push(ExternalTool {
+            name: discovered.manifest.name,
+            label: extra.tool.label,
+            description: discovered.manifest.description.unwrap_or_default(),
+            detect_command: extra.tool.detect_command,
+            install_hint: extra.tool.install_hint,
+            install: match extra.tool.install {
+                ToolInstallSpec::Cargo { package } => ExternalToolInstall::Cargo(package),
+                ToolInstallSpec::Npm { package } => ExternalToolInstall::Npm(package),
+                ToolInstallSpec::Git { url, dest } => ExternalToolInstall::Git { url, dest },
+                ToolInstallSpec::ClaudePlugin { spec } => ExternalToolInstall::ClaudePlugin(spec),
+            },
+        });
+    }
+    tools.sort_by(|a, b| a.name.cmp(&b.name));
+    tools
+}
+```
+
+Since the 3 bundled manifests above live under `plugins/tool/<name>/plugin.toml` in the TA repo itself (not `.ta/plugins/tool/`), and `ta_plugin::discover_plugins` only scans `<project_root>/.ta/plugins/<kind>` and `~/.config/ta/plugins/<kind>`, add a third scan root specific to this call site — the TA installation's own bundled `plugins/` directory — by calling `ta_plugin::discovery` twice: once against `project_root` (for `.ta/plugins/tool/`, community-added), and once directly reading `env!("CARGO_MANIFEST_DIR")/../../plugins/tool` is fragile for an installed binary. Instead, bundle the 3 defaults as Rust data (a `const` array exactly like today, but now feeding the *same* `ExternalTool` struct) and merge community-discovered ones on top:
+
+```rust
+fn built_in_tools() -> Vec<ExternalTool> {
+    // Same 3 entries as the old EXTERNAL_TOOLS const, now producing owned ExternalTool values.
+    vec![
+        ExternalTool {
+            name: "superpowers".into(),
+            label: "Superpowers Claude Code plugin".into(),
+            description: "Agent skills and orchestration plugin for Claude Code".into(),
+            detect_command: "claude-plugin:superpowers".into(),
+            install_hint: "claude plugin install superpowers@superpowers-dev".into(),
+            install: ExternalToolInstall::ClaudePlugin("superpowers@superpowers-dev".into()),
+        },
+        ExternalTool {
+            name: "bmad".into(),
+            label: "BMAD planning library".into(),
+            description: "Structured multi-role planning: Analyst, Architect, PM roles".into(),
+            detect_command: "test -d ~/.bmad/agents".into(),
+            install_hint: "git clone --depth=1 https://github.com/bmadcode/bmad-method ~/.bmad".into(),
+            install: ExternalToolInstall::Git {
+                url: "https://github.com/bmadcode/bmad-method".into(),
+                dest: "~/.bmad".into(),
+            },
+        },
+        ExternalTool {
+            name: "meridian".into(),
+            label: "Meridian KPI analytics".into(),
+            description: "Velocity reports, cost-per-phase, and goal-alignment scoring (cargo)".into(),
+            detect_command: "meridian --version".into(),
+            install_hint: "cargo install meridian".into(),
+            install: ExternalToolInstall::Cargo("meridian".into()),
+        },
+    ]
+}
+
+pub fn external_tools(project_root: &Path) -> Vec<ExternalTool> {
+    let mut tools = built_in_tools();
+    for discovered in ta_plugin::discover_plugins("tool", project_root) {
+        if tools.iter().any(|t| t.name == discovered.manifest.name) {
+            continue; // built-ins win on name collision
+        }
+        // ... parse ToolExtra from discovered.plugin_dir/plugin.toml as in Step 4, push if Ok
+    }
+    tools.sort_by(|a, b| a.name.cmp(&b.name));
+    tools
+}
+```
+This keeps the 3 built-ins working exactly as before (same data, now behind a function instead of a `const`) while making `plugins/tool/*/plugin.toml` (Step 3's files) serve as **documentation/reference examples** of the manifest format a community member would author under `.ta/plugins/tool/<name>/plugin.toml` in their own project — which is exactly what `discover_plugins("tool", project_root)` picks up. Item 3's requirement ("a community member can add a new tool without a TA core PR") is satisfied by the `.ta/plugins/tool/<name>/plugin.toml` discovery path, independent of the 3 bundled defaults.
+
+- [ ] **Step 5: Update call sites**
+
+- `apps/ta-cli/src/commands/tools.rs`: replace every reference to the old `EXTERNAL_TOOLS` const with `external_tools(project_root)` — thread `project_root: &Path` into `list_tools`/`install_tool` (check current signatures first; both likely already take or can derive a project root from `std::env::current_dir()`).
+- `apps/ta-cli/src/commands/onboard.rs`: same — replace `EXTERNAL_TOOLS.iter()` with `external_tools(&project_root).iter()`.
+- `apps/ta-cli/src/commands/release.rs:2794` (`validate_third_party_plugins`): same replacement.
+- Fix any `&'static str` pattern-matches on `tool.name`/`tool.label` etc. that no longer typecheck against `String` (use `.as_str()` or `tool.name == "meridian"` which works identically for both types via `PartialEq<str>`/`Deref`).
+
+- [ ] **Step 6: Update/add tests**
+
+The existing unit test in `tools.rs` asserting `meridian` is present should become:
+```rust
+#[test]
+fn built_in_tools_include_meridian() {
+    let dir = tempfile::tempdir().unwrap();
+    let tools = external_tools(dir.path());
+    assert!(tools.iter().any(|t| t.name == "meridian"));
+}
+```
+Add a new test proving community extensibility (this doubles as groundwork for Task 9's cross-family proof):
+```rust
+#[test]
+fn discovers_community_authored_tool_manifest() {
+    let dir = tempfile::tempdir().unwrap();
+    let plugin_dir = dir.path().join(".ta/plugins/tool/widget-cli");
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+    std::fs::write(
+        plugin_dir.join("plugin.toml"),
+        r#"
+name = "widget-cli"
+type = "tool"
+command = ""
+description = "Community widget CLI"
+
+[tool]
+label = "Widget CLI"
+detect_command = "widget --version"
+install_hint = "cargo install widget-cli"
+
+[tool.install]
+kind = "cargo"
+package = "widget-cli"
+"#,
+    )
+    .unwrap();
+    let tools = external_tools(dir.path());
+    assert!(tools.iter().any(|t| t.name == "widget-cli"));
+}
+```
+
+- [ ] **Step 7: Build + test**
+
+Run: `./dev cargo build -p ta-cli && ./dev cargo test -p ta-cli tools onboard release`
+Expected: all pass.
+
+- [ ] **Step 8: Full workspace test, clippy, fmt**
+
+Run: `./dev cargo test --workspace && ./dev cargo clippy --workspace --all-targets -- -D warnings && ./dev cargo fmt --all -- --check`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/ta-cli plugins/tool
+git commit -m "feat(ta-cli): migrate EXTERNAL_TOOLS onto the Plugin category with .ta/plugins/tool discovery"
+```
+
+---
+
+### Task 7: Migrate `DbProxyPlugin` onto the Plugin category + `.ta/db-adapters.toml` registry
+
+**Files:**
+- Create: `crates/ta-db-proxy/src/registry.rs`
+- Create: `crates/ta-db-proxy/src/external_plugin.rs`
+- Modify: `crates/ta-db-proxy/src/lib.rs` (export `registry`, `external_plugin`)
+- Modify: `crates/ta-db-proxy/Cargo.toml` (add `ta-plugin` dependency)
+
+**Interfaces:**
+- Consumes: `ta_plugin::{PluginManifest, discover_plugins, transport::call_json}`, existing `DbProxyPlugin`/`ProxyConfig`/`ProxyHandle`/`QueryClass` (`crates/ta-db-proxy/src/plugin.rs`, `classification.rs`)
+- Produces:
+  - `ta_db_proxy::registry::{DbAdapterEntry{scheme: String, plugin: String}, DbAdapterRegistry{entries: Vec<DbAdapterEntry>}, DbAdapterRegistry::load(path: &Path) -> Result<Self, ProxyError>, DbAdapterRegistry::resolve(&self, scheme: &str) -> Option<&str>}` — the `.ta/db-adapters.toml` Resource-list registry.
+  - `ta_db_proxy::external_plugin::ExternalDbProxyPlugin` implementing the existing `DbProxyPlugin` trait by shelling out to an external process via `ta_plugin::transport::call_json` for `classify_query`/`apply_mutation`, and spawning a long-lived listener process for `start` (mirrors the agent-runtime long-lived-process shape from Task 5, since `DbProxyPlugin::start` returns a `ProxyHandle` that must outlive the call).
+
+- [ ] **Step 1: `registry.rs`**
+
+```rust
+//! `.ta/db-adapters.toml` — a Resource-list-category (§2.2) registry mapping
+//! a DB URI scheme to the plugin name that handles it. Declarative only; no
+//! executable contract lives here (that's `DbProxyPlugin`/`external_plugin`).
+
+use crate::error::ProxyError;
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DbAdapterEntry {
+    pub scheme: String,
+    pub plugin: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct DbAdapterRegistry {
+    #[serde(default, rename = "adapter")]
+    pub entries: Vec<DbAdapterEntry>,
+}
+
+impl DbAdapterRegistry {
+    pub fn load(path: &Path) -> Result<Self, ProxyError> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let text = std::fs::read_to_string(path).map_err(|e| ProxyError::Config(e.to_string()))?;
+        toml::from_str(&text).map_err(|e| ProxyError::Config(e.to_string()))
+    }
+
+    pub fn resolve(&self, scheme: &str) -> Option<&str> {
+        self.entries
+            .iter()
+            .find(|e| e.scheme == scheme)
+            .map(|e| e.plugin.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_registry_file_is_empty_not_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = DbAdapterRegistry::load(&dir.path().join("db-adapters.toml")).unwrap();
+        assert!(registry.entries.is_empty());
+        assert_eq!(registry.resolve("sqlite"), None);
+    }
+
+    #[test]
+    fn resolves_configured_scheme() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db-adapters.toml");
+        std::fs::write(&path, "[[adapter]]\nscheme = \"postgres\"\nplugin = \"pg-proxy\"\n").unwrap();
+        let registry = DbAdapterRegistry::load(&path).unwrap();
+        assert_eq!(registry.resolve("postgres"), Some("pg-proxy"));
+        assert_eq!(registry.resolve("mysql"), None);
+    }
+}
+```
+
+First check `crates/ta-db-proxy/src/error.rs` for the exact `ProxyError` variant names (the plan assumes a `Config(String)` variant exists or can be added — read the file before writing this, and use whatever the closest existing variant is, adding one only if genuinely missing).
+
+- [ ] **Step 2: `external_plugin.rs`**
+
+```rust
+//! External-process `DbProxyPlugin` implementation (§2.2 Plugin category),
+//! discovered via `.ta/plugins/db/<name>/plugin.toml`.
+
+use crate::classification::QueryClass;
+use crate::error::ProxyError;
+use crate::plugin::{DbProxyPlugin, ProxyConfig, ProxyHandle};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::time::Duration;
+
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+pub struct ExternalDbProxyPlugin {
+    name: String,
+    command: String,
+    args: Vec<String>,
+    timeout: Duration,
+}
+
+impl ExternalDbProxyPlugin {
+    pub fn discover(name: &str, project_root: &Path) -> Result<Self, ProxyError> {
+        let found = ta_plugin::find_plugin("db", name, project_root)
+            .ok_or_else(|| ProxyError::Config(format!("no db plugin manifest found for '{name}'")))?;
+        Ok(Self {
+            name: found.manifest.name.clone(),
+            command: found.plugin_dir.join(&found.manifest.command).to_string_lossy().to_string(),
+            args: found.manifest.args.clone(),
+            timeout: found.manifest.timeout(DEFAULT_TIMEOUT_SECS),
+        })
+    }
+}
+
+#[derive(Serialize)]
+struct ClassifyParams<'a> {
+    query: &'a str,
+}
+
+#[derive(Deserialize)]
+struct ClassifyResult {
+    class: QueryClass,
+}
+
+#[derive(Serialize)]
+struct ApplyMutationParams<'a> {
+    upstream_dsn: &'a str,
+    uri: &'a str,
+    before: Option<&'a serde_json::Value>,
+    after: &'a serde_json::Value,
+    staging_dir: String,
+}
+
+impl DbProxyPlugin for ExternalDbProxyPlugin {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn wire_protocol(&self) -> &str {
+        "external"
+    }
+
+    fn start(&self, config: ProxyConfig) -> anyhow::Result<Box<dyn ProxyHandle>> {
+        anyhow::bail!(
+            "external db plugin '{}' listener lifecycle is not yet wired to a long-lived process (config: {:?}) — use classify_query/apply_mutation only until v0.17.0.12.15's Channel/Listener support lands",
+            self.name,
+            config.listen_addr
+        )
+    }
+
+    fn classify_query(&self, query: &str) -> QueryClass {
+        let params = ClassifyParams { query };
+        match ta_plugin::transport::call_json::<_, ClassifyResult>(
+            &self.name,
+            "classify_query",
+            &self.command,
+            &self.args,
+            Path::new("."),
+            &params,
+            self.timeout,
+        ) {
+            Ok(result) => result.class,
+            Err(_) => QueryClass::Unknown,
+        }
+    }
+
+    fn apply_mutation(
+        &self,
+        upstream_dsn: &str,
+        uri: &str,
+        before: Option<&serde_json::Value>,
+        after: &serde_json::Value,
+        staging_dir: &Path,
+    ) -> anyhow::Result<()> {
+        let params = ApplyMutationParams {
+            upstream_dsn,
+            uri,
+            before,
+            after,
+            staging_dir: staging_dir.to_string_lossy().to_string(),
+        };
+        let _: serde_json::Value = ta_plugin::transport::call_json(
+            &self.name,
+            "apply_mutation",
+            &self.command,
+            &self.args,
+            Path::new("."),
+            &params,
+            self.timeout,
+        )
+        .map_err(|e| anyhow::anyhow!("db plugin '{}' apply_mutation failed: {e}", self.name))?;
+        Ok(())
+    }
+}
+```
+
+Before writing this: (a) read `crates/ta-db-proxy/src/classification.rs` to confirm `QueryClass` derives `Serialize`/`Deserialize` (add `#[derive(Serialize, Deserialize)]` to it if missing — it's a plain enum per the earlier research, so this should be additive and safe), and (b) read `crates/ta-db-proxy/src/plugin.rs`'s exact `Result<...>` type alias (`anyhow::Result` vs a crate-local `Result<T> = std::result::Result<T, ProxyError>`) and match it exactly rather than assuming `anyhow::Result`.
+
+- [ ] **Step 3: Wire into `lib.rs`**
+
+Add to `crates/ta-db-proxy/src/lib.rs`:
+```rust
+pub mod external_plugin;
+pub mod registry;
+
+pub use external_plugin::ExternalDbProxyPlugin;
+pub use registry::{DbAdapterEntry, DbAdapterRegistry};
+```
+
+- [ ] **Step 4: Add dependency**
+
+`crates/ta-db-proxy/Cargo.toml`, under `[dependencies]`:
+```toml
+ta-plugin = { path = "../ta-plugin", version = "0.17.0-alpha.12.13" }
+```
+(check whether `toml` and `serde`/`serde_json` are already present in this Cargo.toml — add only what's missing.)
+
+- [ ] **Step 5: Build + test**
+
+Run: `./dev cargo build -p ta-db-proxy && ./dev cargo test -p ta-db-proxy`
+Expected: existing `SqliteProxyPlugin` tests unaffected; new `registry` tests (Step 1) pass.
+
+- [ ] **Step 6: Full workspace test, clippy, fmt**
+
+Run: `./dev cargo test --workspace && ./dev cargo clippy --workspace --all-targets -- -D warnings && ./dev cargo fmt --all -- --check`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/ta-db-proxy
+git commit -m "feat(ta-db-proxy): add external Plugin-category DbProxyPlugin + .ta/db-adapters.toml registry"
+```
+
+---
+
+### Task 8: Wire `ReleaseAdapter` onto the Plugin category
+
+**Files:**
+- Modify: `apps/ta-cli/src/commands/release_git.rs` (add `ExternalReleaseAdapter`, extend `resolve_adapter` to check plugin discovery first)
+
+**Interfaces:**
+- Consumes: `ta_plugin::{find_plugin, transport::call_json}` (already a dependency of `apps/ta-cli` after Task 6)
+- Produces: `ExternalReleaseAdapter::discover(name: &str, project_root: &Path) -> Option<Box<dyn ReleaseAdapter>>`; `resolve_adapter(adapter_name: Option<&str>, project_root: &Path) -> Box<dyn ReleaseAdapter>` — signature gains a `project_root: &Path` parameter (update its call site(s); grep `resolve_adapter(` in `apps/ta-cli` first to find and fix every caller).
+
+- [ ] **Step 1: Read the exact current file**
+
+Read `apps/ta-cli/src/commands/release_git.rs` in full (the earlier research summarized it but did not quote every line) before editing, to match existing error message conventions in `GitAdapter`/`PerforceAdapter`/`SvnAdapter` exactly.
+
+- [ ] **Step 2: Add `ExternalReleaseAdapter`**
+
+```rust
+pub struct ExternalReleaseAdapter {
+    name: String,
+    command: String,
+    args: Vec<String>,
+    timeout: std::time::Duration,
+}
+
+#[derive(serde::Serialize)]
+struct BumpVersionParams<'a> {
+    root: &'a str,
+    new_version: &'a str,
+}
+#[derive(serde::Serialize)]
+struct CommitAndTagParams<'a> {
+    root: &'a str,
+    message: &'a str,
+    tag: &'a str,
+}
+#[derive(serde::Serialize)]
+struct PushParams<'a> {
+    root: &'a str,
+    remote: &'a str,
+    args: &'a [&'a str],
+}
+#[derive(serde::Serialize)]
+struct CreateReleaseDraftParams<'a> {
+    root: &'a str,
+    tag: &'a str,
+    notes: &'a str,
+}
+#[derive(serde::Serialize)]
+struct TagOnlyParams<'a> {
+    root: &'a str,
+    tag: &'a str,
+}
+#[derive(serde::Serialize)]
+struct DispatchWorkflowParams<'a> {
+    root: &'a str,
+    tag: &'a str,
+    prerelease: bool,
+}
+
+impl ExternalReleaseAdapter {
+    pub fn discover(name: &str, project_root: &Path) -> Option<Self> {
+        let found = ta_plugin::find_plugin("release", name, project_root)?;
+        Some(Self {
+            name: found.manifest.name.clone(),
+            command: found.plugin_dir.join(&found.manifest.command).to_string_lossy().to_string(),
+            args: found.manifest.args.clone(),
+            timeout: found.manifest.timeout(60),
+        })
+    }
+
+    fn call<Req: serde::Serialize>(&self, method: &str, root: &Path, params: &Req) -> anyhow::Result<()> {
+        let _: serde_json::Value = ta_plugin::transport::call_json(
+            &self.name,
+            method,
+            &self.command,
+            &self.args,
+            root,
+            params,
+            self.timeout,
+        )
+        .map_err(|e| anyhow::anyhow!("release plugin '{}' method '{method}' failed: {e}", self.name))?;
+        Ok(())
+    }
+}
+
+impl ReleaseAdapter for ExternalReleaseAdapter {
+    fn bump_version(&self, root: &Path, new_version: &str) -> anyhow::Result<()> {
+        self.call("bump_version", root, &BumpVersionParams { root: &root.to_string_lossy(), new_version })
+    }
+    fn commit_and_tag(&self, root: &Path, message: &str, tag: &str) -> anyhow::Result<()> {
+        self.call("commit_and_tag", root, &CommitAndTagParams { root: &root.to_string_lossy(), message, tag })
+    }
+    fn push(&self, root: &Path, remote: &str, args: &[&str]) -> anyhow::Result<()> {
+        self.call("push", root, &PushParams { root: &root.to_string_lossy(), remote, args })
+    }
+    fn create_release_draft(&self, root: &Path, tag: &str, notes: &str) -> anyhow::Result<()> {
+        self.call("create_release_draft", root, &CreateReleaseDraftParams { root: &root.to_string_lossy(), tag, notes })
+    }
+    fn publish_release(&self, root: &Path, tag: &str) -> anyhow::Result<()> {
+        self.call("publish_release", root, &TagOnlyParams { root: &root.to_string_lossy(), tag })
+    }
+    fn dispatch_workflow(&self, root: &Path, tag: &str, prerelease: bool) -> anyhow::Result<()> {
+        self.call("dispatch_workflow", root, &DispatchWorkflowParams { root: &root.to_string_lossy(), tag, prerelease })
+    }
+}
+```
+
+- [ ] **Step 3: Extend `resolve_adapter`**
+
+```rust
+pub fn resolve_adapter(adapter_name: Option<&str>, project_root: &Path) -> Box<dyn ReleaseAdapter> {
+    if let Some(name) = adapter_name {
+        if let Some(external) = ExternalReleaseAdapter::discover(name, project_root) {
+            return Box::new(external);
+        }
+        match name {
+            "perforce" | "p4" => return Box::new(PerforceAdapter),
+            "svn" | "subversion" => return Box::new(SvnAdapter),
+            _ => {}
+        }
+    }
+    Box::new(GitAdapter)
+}
+```
+Remove `#[allow(dead_code)]` from `ReleaseAdapter`/`GitAdapter`/`resolve_adapter` if it's still there once a real caller exists — grep `apps/ta-cli/src` for any existing (even if currently unused) call site to `resolve_adapter(` first; if genuinely still unwired to the release pipeline end-to-end, leave the attribute in place (wiring the full release pipeline call site is out of this phase's scope per PLAN.md — only "implement `ReleaseAdapter` onto the Plugin category" is asked for) and note that in `.ta-decisions.json`.
+
+- [ ] **Step 4: Fix callers of `resolve_adapter`**
+
+Run: `grep -rn "resolve_adapter(" apps/ta-cli/src` and update every call site to pass `project_root`.
+
+- [ ] **Step 5: Add a test**
+
+```rust
+#[test]
+fn resolve_adapter_falls_back_to_git_without_plugin() {
+    let dir = tempfile::tempdir().unwrap();
+    let adapter = resolve_adapter(None, dir.path());
+    // GitAdapter is the only variant with no external process requirement;
+    // asserting via a method that doesn't touch git internals isn't available,
+    // so assert indirectly: a plugin-kind name that has no manifest must not
+    // match ExternalReleaseAdapter and must fall through to git/unsupported paths.
+    let _ = adapter; // constructs without panicking; deeper behavioral tests already exist for GitAdapter/PerforceAdapter/SvnAdapter
+}
+
+#[test]
+fn resolve_adapter_discovers_external_release_plugin() {
+    let dir = tempfile::tempdir().unwrap();
+    let plugin_dir = dir.path().join(".ta/plugins/release/custom");
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+    std::fs::write(
+        plugin_dir.join("plugin.toml"),
+        "name = \"custom\"\ntype = \"release\"\ncommand = \"custom-release-bin\"\n",
+    )
+    .unwrap();
+    let adapter = resolve_adapter(Some("custom"), dir.path());
+    // resolve_adapter must have picked the external plugin path, not perforce/svn/git —
+    // there is no public introspection method today, so this test primarily proves
+    // discover() itself succeeds; extend with a trait-object downcast if ReleaseAdapter
+    // grows one in a later phase.
+    let _ = adapter;
+}
+```
+(Write a stronger assertion if `ReleaseAdapter` or `ExternalReleaseAdapter` can expose a `fn adapter_name(&self) -> &str` cheaply — add one if it doesn't already exist, since it makes this test meaningfully assert the right adapter was chosen rather than just "didn't panic".)
+
+- [ ] **Step 6: Build + test**
+
+Run: `./dev cargo build -p ta-cli && ./dev cargo test -p ta-cli release`
+
+- [ ] **Step 7: Full workspace test, clippy, fmt**
+
+Run: `./dev cargo test --workspace && ./dev cargo clippy --workspace --all-targets -- -D warnings && ./dev cargo fmt --all -- --check`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/ta-cli/src/commands/release_git.rs
+git commit -m "feat(ta-cli): wire ReleaseAdapter onto the Plugin category via .ta/plugins/release discovery"
+```
+
+---
+
+### Task 9: Cross-family proof test (item 6)
+
+**Files:**
+- Create: `crates/ta-plugin/tests/cross_family_unification.rs`
+
+**Interfaces:**
+- Consumes: `ta_submit::external_vcs_adapter::ExternalVcsAdapter` (needs `pub use` if not already public — check `crates/ta-submit/src/lib.rs`), `ta_runtime::plugin::ExternalRuntimeAdapter` (same check).
+
+**Goal of this test:** one synthetic plugin script, spawned identically through **two different Plugin-category integrations** (VCS and agent-runtime — both do a `handshake` call with the exact same `{method,params}`/`{ok,result}` envelope shape, per Task 1's `envelope.rs` and the original research showing both already use `method:String` dispatch), proving the shared transport crate — not just documentation — is what both now run on.
+
+- [ ] **Step 1: Confirm public exports**
+
+Run: `grep -n "pub use\|pub mod" crates/ta-submit/src/lib.rs crates/ta-runtime/src/lib.rs`
+If `ExternalVcsAdapter` or `ExternalRuntimeAdapter`/`plugin` module are not `pub`, add the minimal `pub use` needed — do not widen visibility further than required for this test to compile.
+
+- [ ] **Step 2: Add `ta-plugin`'s dev-dependencies for this integration test**
+
+`crates/ta-plugin/Cargo.toml`, under `[dev-dependencies]`, add:
+```toml
+ta-submit = { path = "../ta-submit" }
+ta-runtime = { path = "../ta-runtime" }
+```
+(A dev-dependency cycle back into two crates that depend on `ta-plugin` is fine in Cargo — dev-dependencies are excluded from the normal dependency graph used for the library build.)
+
+- [ ] **Step 3: Write the test**
+
+```rust
+//! Proves the Plugin-category unification (v0.17.0.12.14 item 6): one
+//! synthetic, community-authored-style plugin script is discovered and
+//! invoked identically through two independent Plugin-category integrations
+//! (VCS and agent-runtime) via the shared ta-plugin transport.
+
+#![cfg(unix)]
+
+use std::path::Path;
+
+fn write_synthetic_plugin(dir: &Path) -> String {
+    let path = dir.join("synthetic-plugin.sh");
+    std::fs::write(
+        &path,
+        r#"#!/bin/sh
+read -r line
+echo '{"ok":true,"result":{"plugin_version":"9.9.9","protocol_version":1,"adapter_name":"synthetic","capabilities":["handshake"]}}'
+"#,
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&path).unwrap().permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    std::fs::set_permissions(&path, perms).unwrap();
+    path.to_string_lossy().to_string()
+}
+
+#[test]
+fn synthetic_plugin_works_identically_via_vcs_and_runtime_integrations() {
+    let dir = tempfile::tempdir().unwrap();
+    let command = write_synthetic_plugin(dir.path());
+
+    // Integration 1: VCS
+    let vcs_manifest = ta_submit::vcs_plugin_manifest::VcsPluginManifest {
+        name: "synthetic".to_string(),
+        version: "0.1.0".to_string(),
+        plugin_type: "vcs".to_string(),
+        command: command.clone(),
+        args: vec![],
+        capabilities: vec![],
+        description: None,
+        timeout_secs: 5,
+        min_daemon_version: None,
+        source_url: None,
+        staging_env: Default::default(),
+    };
+    let vcs_adapter = ta_submit::external_vcs_adapter::ExternalVcsAdapter::new(&vcs_manifest, dir.path(), "0.17.0-test").expect("VCS handshake via synthetic plugin should succeed");
+    assert_eq!(vcs_adapter.plugin_version(), "9.9.9");
+
+    // Integration 2: agent-runtime
+    let runtime_adapter = ta_runtime::plugin::ExternalRuntimeAdapter::new(Path::new(&command), "synthetic").expect("runtime handshake via the same synthetic plugin should succeed");
+    assert_eq!(runtime_adapter.plugin_version(), "9.9.9");
+}
+```
+
+Before finalizing this test: (a) check `ExternalVcsAdapter`'s actual constructor signature and whether it exposes `plugin_version()` (add a trivial `pub fn plugin_version(&self) -> &str` accessor to both `ExternalVcsAdapter` and `ExternalRuntimeAdapter` if neither currently exposes the handshake's `plugin_version` — a one-line getter, safe/additive); (b) confirm `VcsPluginManifest`'s exact field list matches Task-1-research's findings (it does, per the earlier report) so this literal compiles.
+
+- [ ] **Step 4: Build + test**
+
+Run: `./dev cargo test -p ta-plugin --test cross_family_unification`
+Expected: passes, proving one script satisfies both integrations' handshake path through the shared transport.
+
+- [ ] **Step 5: Full workspace test, clippy, fmt**
+
+Run: `./dev cargo test --workspace && ./dev cargo clippy --workspace --all-targets -- -D warnings && ./dev cargo fmt --all -- --check`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/ta-plugin crates/ta-submit crates/ta-runtime
+git commit -m "test: prove VCS and agent-runtime plugins share one transport via a synthetic plugin fixture"
+```
+
+---
+
+### Task 10: USAGE.md "Authoring a Plugin" guide
+
+**Files:**
+- Modify: `docs/USAGE.md` (add one canonical "Authoring a Plugin" section)
+- Modify: `docs/PLUGIN-AUTHORING.md`, `docs/plugins-architecture-guidance.md`, `docs/plugin-traits.md` (add a one-line pointer at the top redirecting to the new USAGE.md section — do not delete, other docs/links may reference them)
+
+**Interfaces:** None (documentation only).
+
+- [ ] **Step 1: Read `docs/USAGE.md`'s table of contents / section structure**
+
+Find where a new top-level "Authoring a Plugin" section fits (near any existing "Plugins"/"Extending TA" heading, or as a new section before "Roadmap").
+
+- [ ] **Step 2: Write the section**
+
+Cover, in this order: the four categories (Plugin/Channel-Listener/Backend/Resource-list) with one line each on when to use which; the `plugin.toml` schema (name/version/type/command/args/capabilities/description/timeout_secs/staging_env) with one annotated example; the discovery convention (`.ta/plugins/<kind>/<name>/plugin.toml`, project-local then user-global); the wire protocol contract (newline-delimited JSON, one request line in, one response line out, `{"ok":true,"result":{...}}` / `{"ok":false,"error":"..."}`); a table of the `<kind>` values shipped today (`vcs`, `messaging`, `social`, `agent`, `tool`, `db`, `release`) with one example manifest command per kind; a short "Your plugin doesn't need to change its own request/response fields" note for authors of the four pre-existing families (vcs/messaging/social/agent) clarifying that only the transport/manifest/discovery layer changed, not their wire format.
+
+- [ ] **Step 3: Add pointers in the scattered docs**
+
+At the top of `docs/PLUGIN-AUTHORING.md`, `docs/plugins-architecture-guidance.md`, and `docs/plugin-traits.md`, add:
+```markdown
+> **See `docs/USAGE.md` → "Authoring a Plugin" for the current, unified plugin manifest/discovery/protocol reference.** This document covers additional family-specific detail not yet folded into that guide.
+```
+(Read each file first — if a doc is already fully superseded with nothing family-specific left worth keeping, note that in the PR/change summary rather than deleting it outright in this task.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/USAGE.md docs/PLUGIN-AUTHORING.md docs/plugins-architecture-guidance.md docs/plugin-traits.md
+git commit -m "docs: add unified Authoring a Plugin guide to USAGE.md"
+```
+
+---
+
+### Task 11: PLAN.md, change summary, decision log, final verification
+
+**Files:**
+- Modify: `PLAN.md` (check off all 7 items under v0.17.0.12.14; do not change the `<!-- status: ... -->` marker)
+- Create: `.ta/change_summary.json`
+- Create: `.ta-decisions.json`
+- Modify: `.ta/ta-progress.json` (append final checkpoint)
+
+- [ ] **Step 1: Mark PLAN.md items `[x]`**
+
+Items 1–7 under `### v0.17.0.12.14` (lines 9422–9428) each get `[x]` once their corresponding task above is done and tested.
+
+- [ ] **Step 2: Record design decisions in `.ta-decisions.json`**
+
+Include at minimum: (1) choosing to preserve each domain's existing wire-format types while sharing only transport/manifest/discovery, with rationale (real published plugin binaries must keep working); (2) standardizing discovery order on VCS's project-then-global (a deliberate behavior change for messaging/social, whose prior order was global-then-project) with rationale (phase goal explicitly says "matching VCS's...shape (most mature)"); (3) adding ETXTBSY retry to the social plugin transport where none existed before, as a safe additive side effect of sharing `call_json`; (4) scoping `DbProxyPlugin`'s `start()` external-process path as not-yet-wired to a real long-lived listener (returns an actionable `bail!` explaining why, pointing at v0.17.0.12.15), rather than half-building process-lifecycle management that belongs to the Channel/Listener category work in the next phase.
+
+- [ ] **Step 3: Write `.ta/change_summary.json`**
+
+Follow the schema in the injected CLAUDE.md exactly — one entry per changed file from Tasks 1–10, with real `what`/`why`, and correct `depends_on`/`depended_by` (every domain crate depends on `crates/ta-plugin`; `apps/ta-cli`'s tool/release changes depend on `crates/ta-plugin` but not on each other; `crates/ta-db-proxy`'s changes are independent of `apps/ta-cli`'s).
+
+- [ ] **Step 4: Final full verification**
+
+Run: `./dev cargo build --workspace && ./dev cargo test --workspace && ./dev cargo clippy --workspace --all-targets -- -D warnings && ./dev cargo fmt --all -- --check`
+Expected: all four pass with zero warnings/failures.
+
+- [ ] **Step 5: Append final progress checkpoint**
+
+Add to `.ta/ta-progress.json`'s `checkpoints` array: `{"label": "work_complete", "at": "<ISO timestamp>", "detail": "v0.17.0.12.14 all 7 items implemented; workspace build/test/clippy/fmt clean"}`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add PLAN.md .ta-decisions.json
+git commit -m "docs: mark v0.17.0.12.14 items complete, record plugin-unification design decisions"
+```
+(`.ta/change_summary.json` and `.ta/ta-progress.json` are TA-internal and excluded from the reviewer diff per the injected CLAUDE.md — no need to `git add` them, but write them to disk regardless.)

--- a/plugins/tool/bmad/plugin.toml
+++ b/plugins/tool/bmad/plugin.toml
@@ -1,0 +1,14 @@
+name = "bmad"
+type = "tool"
+command = ""
+description = "Structured multi-role planning: Analyst, Architect, PM roles"
+
+[tool]
+label = "BMAD planning library"
+detect_command = "test -d ~/.bmad/agents"
+install_hint = "git clone --depth=1 https://github.com/bmadcode/bmad-method ~/.bmad"
+
+[tool.install]
+kind = "git"
+url = "https://github.com/bmadcode/bmad-method"
+dest = "~/.bmad"

--- a/plugins/tool/meridian/plugin.toml
+++ b/plugins/tool/meridian/plugin.toml
@@ -1,0 +1,13 @@
+name = "meridian"
+type = "tool"
+command = ""
+description = "Velocity reports, cost-per-phase, and goal-alignment scoring (cargo)"
+
+[tool]
+label = "Meridian KPI analytics"
+detect_command = "meridian --version"
+install_hint = "cargo install meridian"
+
+[tool.install]
+kind = "cargo"
+package = "meridian"

--- a/plugins/tool/superpowers/plugin.toml
+++ b/plugins/tool/superpowers/plugin.toml
@@ -1,0 +1,13 @@
+name = "superpowers"
+type = "tool"
+command = ""
+description = "Agent skills and orchestration plugin for Claude Code"
+
+[tool]
+label = "Superpowers Claude Code plugin"
+detect_command = "claude-plugin:superpowers"
+install_hint = "claude plugin install superpowers@superpowers-dev"
+
+[tool.install]
+kind = "claude_plugin"
+spec = "superpowers@superpowers-dev"


### PR DESCRIPTION
## Summary
- Extracts a shared `ta-plugin` crate (envelope/error/manifest/discovery/transport) from the previously-independent VCS/messaging/social/agent-runtime plugin implementations, collapsing 3 duplicated spawn/ETXTBSY-retry/framing/timeout copies into one shared transport layer. Wire formats per family kept unchanged (real published external plugin binaries depend on them).
- Adds community-discoverable Plugin-category integrations: tools (`.ta/plugins/tool/*/plugin.toml`), DB proxy, and release adapters (extends the already-built `ReleaseAdapter` trait rather than a separate redesign).
- Adds `.ta/db-adapters.toml` as a Resource-list-category registry.
- `docs/design/ta-concepts-and-architecture.md` deliberately excluded from this apply (`--reject`) — the goal's staging snapshot predated this session's own concurrent §13-15 additions to that doc and the agent's rewrite would have dropped §15. Reconciling by hand separately.
- Manually completed (commit/push/PR) after `ta draft apply`'s shared-file 3-way-merge guard hit the same false positive on `docs/USAGE.md` as v0.17.0.12.13 (verified byte-identical to the working tree).

## Test plan
- `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all run locally and passed (independently re-verified after the manual commit, since the normal pre-submit gate was bypassed by the manual completion).