### PR TITLE
fix: rename nightly release tag to escape immutable-release lock

### DIFF
--- a/.github/workflows/nightly-validate.yml
+++ b/.github/workflows/nightly-validate.yml
@@ -19,6 +19,12 @@ on:
 permissions:
   contents: read
 
+env:
+  # Must match NIGHTLY_TAG in .github/workflows/nightly.yml. Renamed from
+  # "nightly" (2026-07-08) after that tag got permanently locked by GitHub's
+  # Immutable Releases feature -- see nightly.yml for the full incident note.
+  NIGHTLY_TAG: nightly-latest
+
 jobs:
   validate:
     name: Validate badges + nightly release
@@ -61,21 +67,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          IS_DRAFT=$(gh api "repos/${{ github.repository }}/releases/tags/nightly" --jq '.draft' 2>/dev/null || echo "unknown")
+          IS_DRAFT=$(gh api "repos/${{ github.repository }}/releases/tags/${NIGHTLY_TAG}" --jq '.draft' 2>/dev/null || echo "unknown")
           if [ "$IS_DRAFT" = "unknown" ]; then
-            echo "ERROR: could not fetch the nightly release from the GitHub API."
-            echo "  Run manually: gh api repos/${{ github.repository }}/releases/tags/nightly"
+            echo "ERROR: could not fetch the $NIGHTLY_TAG release from the GitHub API."
+            echo "  Run manually: gh api repos/${{ github.repository }}/releases/tags/${NIGHTLY_TAG}"
             exit 1
           fi
           if [ "$IS_DRAFT" = "true" ]; then
-            echo "ERROR: nightly release is still a draft — it is invisible to anonymous/public"
-            echo "  viewers (the badge and releases/tag/nightly link both 404 for them)."
+            echo "ERROR: $NIGHTLY_TAG release is still a draft — it is invisible to anonymous/public"
+            echo "  viewers (the badge and releases/tag/${NIGHTLY_TAG} link both 404 for them)."
             echo "  Fix: check the 'Create or update nightly GitHub release' step in"
             echo "  .github/workflows/nightly.yml — it must end with"
-            echo "  'gh release edit nightly --draft=false' after uploading assets."
+            echo "  'gh release edit \$NIGHTLY_TAG --draft=false' after uploading assets."
             exit 1
           fi
-          echo "OK: nightly release is published (draft=false)."
+          echo "OK: $NIGHTLY_TAG release is published (draft=false)."
 
       - name: Validate nightly asset version matches workspace version
         env:
@@ -85,7 +91,7 @@ jobs:
           echo "Workspace version (Cargo.toml, source of truth): $CARGO_VER"
 
           ASSET="ta-nightly-x86_64-unknown-linux-musl.tar.gz"
-          gh release download nightly --repo "${{ github.repository }}" --pattern "$ASSET" --output "$ASSET" --clobber
+          gh release download "$NIGHTLY_TAG" --repo "${{ github.repository }}" --pattern "$ASSET" --output "$ASSET" --clobber
 
           mkdir -p nightly-extract
           tar xzf "$ASSET" -C nightly-extract

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,12 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   BINARY_NAME: ta
-  NIGHTLY_TAG: nightly
+  # Renamed from "nightly" (2026-07-08): that tag got permanently locked by
+  # GitHub's Immutable Releases feature (GA 2025-10-28) -- once a release
+  # under a tag is published immutable, the tag name is blocked from reuse
+  # forever (422 "tag_name was used by an immutable release"), even after
+  # deleting the release and the tag. Do not reuse the old "nightly" tag name.
+  NIGHTLY_TAG: nightly-latest
   NIGHTLY_HISTORY_LIMIT: 60
 
 jobs:
@@ -337,7 +342,7 @@ jobs:
           BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
           # Asset URL base for this nightly release
-          ASSET_BASE="https://github.com/${REPO}/releases/download/nightly"
+          ASSET_BASE="https://github.com/${REPO}/releases/download/${NIGHTLY_TAG}"
 
           # New row for the history table
           NEW_ROW="| ${BUILD_DATE} | [${HEAD_SHA_SHORT}](https://github.com/${REPO}/commit/${HEAD_SHA}) | ${TRIGGER_TYPE} | [Linux x86](${ASSET_BASE}/ta-nightly-x86_64-unknown-linux-musl.tar.gz) [Linux ARM](${ASSET_BASE}/ta-nightly-aarch64-unknown-linux-musl.tar.gz) [macOS Intel](${ASSET_BASE}/ta-nightly-x86_64-apple-darwin.tar.gz) [macOS ARM](${ASSET_BASE}/ta-nightly-aarch64-apple-darwin.tar.gz) [Windows MSI](${ASSET_BASE}/ta-nightly-x86_64-pc-windows-msvc.msi) [Windows zip](${ASSET_BASE}/ta-nightly-x86_64-pc-windows-msvc.zip) |"
@@ -345,8 +350,8 @@ jobs:
           # Fetch existing release body to extract and update the history table.
           # On first run, start fresh.
           EXISTING_BODY=""
-          if gh release view nightly --json body 2>/dev/null | grep -q '"body"'; then
-            EXISTING_BODY=$(gh release view nightly --json body --jq '.body')
+          if gh release view "$NIGHTLY_TAG" --json body 2>/dev/null | grep -q '"body"'; then
+            EXISTING_BODY=$(gh release view "$NIGHTLY_TAG" --json body --jq '.body')
           fi
 
           # Extract existing history rows (lines starting with "| 20") from the body.
@@ -448,39 +453,54 @@ jobs:
           # workflow previously only ever called `--draft` and never un-set it —
           # there was no publish step at all, not an auth/ID/ordering bug. A draft
           # release is invisible to anonymous/public viewers (the badge and the
-          # `releases/tag/nightly` link both 404 for non-collaborators), so it must
-          # be un-drafted after each successful run.
-          if [ "$(gh release view nightly --json isDraft --jq '.isDraft' 2>/dev/null)" = "false" ]; then
-            echo "Existing nightly release is published — reverting to draft so assets can be replaced..."
-            gh release edit nightly --draft
+          # `releases/tag/$NIGHTLY_TAG` link both 404 for non-collaborators), so it
+          # must be un-drafted after each successful run.
+          if [ "$(gh release view "$NIGHTLY_TAG" --json isDraft --jq '.isDraft' 2>/dev/null)" = "false" ]; then
+            echo "Existing $NIGHTLY_TAG release is published — reverting to draft so assets can be replaced..."
+            if ! gh release edit "$NIGHTLY_TAG" --draft; then
+              echo ""
+              echo "ERROR: could not revert '$NIGHTLY_TAG' back to draft. If this is a"
+              echo "'tag_name was used by an immutable release' error, the tag is"
+              echo "permanently locked by GitHub's Immutable Releases feature -- delete"
+              echo "and recreate is NOT a valid recovery (the lock survives tag deletion)."
+              echo "Fix: pick a new NIGHTLY_TAG value in .github/workflows/nightly.yml"
+              echo "and .github/workflows/nightly-validate.yml, and update README.md +"
+              echo "docs/USAGE.md's badge/download URLs to match."
+              exit 1
+            fi
           fi
 
-          if gh release view nightly 2>/dev/null; then
-            echo "Updating existing nightly release..."
-            gh release edit nightly \
+          if gh release view "$NIGHTLY_TAG" 2>/dev/null; then
+            echo "Updating existing $NIGHTLY_TAG release..."
+            gh release edit "$NIGHTLY_TAG" \
               --title "$RELEASE_TITLE" \
               --notes-file nightly-body.md \
               --prerelease \
               --draft
             # Replace all assets (clobber existing ones)
-            gh release upload nightly artifacts/* --clobber
+            gh release upload "$NIGHTLY_TAG" artifacts/* --clobber
           else
-            echo "Creating first nightly release..."
-            gh release create nightly \
+            echo "Creating first $NIGHTLY_TAG release..."
+            gh release create "$NIGHTLY_TAG" \
               --title "$RELEASE_TITLE" \
               --notes-file nightly-body.md \
               --prerelease \
               --draft
-            gh release upload nightly artifacts/* --clobber
+            gh release upload "$NIGHTLY_TAG" artifacts/* --clobber
           fi
 
           # Publish (un-draft) now that all assets are uploaded — this is the step
           # that was missing before, leaving nightly permanently draft.
-          echo "Publishing nightly release (un-drafting)..."
-          gh release edit nightly --draft=false
+          echo "Publishing $NIGHTLY_TAG release (un-drafting)..."
+          if ! gh release edit "$NIGHTLY_TAG" --draft=false; then
+            echo ""
+            echo "ERROR: could not publish '$NIGHTLY_TAG'. See the guidance above if this"
+            echo "is an immutable-release tag lock."
+            exit 1
+          fi
 
           echo ""
           echo "Nightly release published:"
           echo "  Title: ${RELEASE_TITLE}"
           echo "  SHA: ${{ needs.check-for-changes.outputs.head_sha }}"
-          echo "  URL: https://github.com/${{ github.repository }}/releases/tag/nightly"
+          echo "  URL: https://github.com/${{ github.repository }}/releases/tag/${NIGHTLY_TAG}"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/latest">
     <img src="https://img.shields.io/github/v/release/Trusted-Autonomy/TrustedAutonomy?label=stable&color=blue&display_name=tag" alt="Latest stable release">
   </a>
-  <a href="https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly">
+  <a href="https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-latest">
     <img src="https://img.shields.io/badge/nightly-latest-orange" alt="Latest nightly build">
   </a>
   <img src="https://img.shields.io/badge/license-Apache--2.0-lightgrey" alt="License">
@@ -139,7 +139,7 @@ The two questions governance and orchestration each answer:
 | Channel | Version | Downloads |
 |---------|---------|-----------|
 | **Stable** | [![stable](https://img.shields.io/github/v/release/Trusted-Autonomy/TrustedAutonomy?label=&color=blue&display_name=tag)](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/latest) | [macOS · Linux · Windows](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/latest) |
-| **Nightly** | [![nightly](https://img.shields.io/badge/nightly-latest-orange)](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly) | [macOS · Linux · Windows](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly) · [History](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly#nightly-history) |
+| **Nightly** | [![nightly](https://img.shields.io/badge/nightly-latest-orange)](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-latest) | [macOS · Linux · Windows](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-latest) · [History](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-latest#nightly-history) |
 
 **Build from source:**
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -546,17 +546,17 @@ Nightly pre-releases are built automatically from the latest commit on `main`. T
 
 ```bash
 # macOS (Apple Silicon) — nightly
-curl -LO https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/download/nightly/ta-nightly-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/download/nightly-latest/ta-nightly-aarch64-apple-darwin.tar.gz
 tar xzf ta-nightly-aarch64-apple-darwin.tar.gz
 sudo cp ta ta-daemon /usr/local/bin/
 
 # Linux (x86_64) — nightly
-curl -LO https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/download/nightly/ta-nightly-x86_64-unknown-linux-musl.tar.gz
+curl -LO https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/download/nightly-latest/ta-nightly-x86_64-unknown-linux-musl.tar.gz
 tar xzf ta-nightly-x86_64-unknown-linux-musl.tar.gz
 sudo cp ta ta-daemon /usr/local/bin/
 ```
 
-Each nightly archive contains both `ta` and `ta-daemon`. See the [nightly release page](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly) for all platforms and the build history.
+Each nightly archive contains both `ta` and `ta-daemon`. See the [nightly release page](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-latest) for all platforms and the build history.
 
 **Option D -- Docker** *(Coming Soon)*
 


### PR DESCRIPTION
## Summary
- The `nightly` GitHub release tag got permanently locked by GitHub's Immutable Releases feature (GA 2025-10-28) -- once a release under a tag is published immutable, the tag name is blocked from reuse forever, even after deleting the release and tag. This broke `nightly.yml`'s publish step and made `Post-Nightly Validation` fail continuously.
- Renamed the tag from `nightly` to `nightly-latest` throughout `nightly.yml`, `nightly-validate.yml`, `README.md`, and `docs/USAGE.md`. Also fixed several places that had hardcoded the tag as a literal string instead of using the `NIGHTLY_TAG` variable (inconsistent even before this fix).
- Added explicit error messages if the immutable-release lock recurs on the new tag.

## Not fixed here (flagged for later)
A fully robust design would use a fresh per-night tag (`nightly-YYYYMMDD`) with a dynamically-resolved "latest" pointer, rather than ever reusing one release object night after night -- immune to this lock class entirely. The current fix (rename + keep the existing update-in-place pattern) is lower-effort and unblocks things now, but could theoretically recur if the same draft/publish toggle re-triggers the lock on the new tag.

## Test plan
- YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`).
- Grepped for any remaining stale `nightly` tag references across the touched files -- none found.
- Real validation only happens by actually running the nightly workflow (`gh workflow run nightly.yml -f force=true`) once merged.