### PR TITLE
v0.17.0.12.22 — CLI Surface Completion: Full Verb+Noun Coverage + Curated Help

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -9550,16 +9550,16 @@ Each phase: `ta run --headless --phase X` → draft → `agent_review` → if Ap
 
 ---
 ### v0.17.0.12.22 — CLI Surface Completion: Full Verb+Noun Coverage + Curated Help
-<!-- status: in_progress -->
+<!-- status: done -->
 **Depends on**: v0.17.0.12.16
 
 **Goal**: 12.16 intentionally shipped partial (18 of 42 noun-areas mapped onto the 10-verb set, per `docs/design/ta-cli-verb-reference.md`) with the rest still legacy-only. Finish the mapping, and give the CLI a genuinely simple default surface — today only 7 of 61 commands are hidden from `--help` (installer-internal, not a curated "common ops" set), so a new user sees the entire flat command list.
 
 **Items**:
-1. [ ] Map the remaining 24 noun-areas (`advisor`, `memory`, `adapter`, `release`, `intake`, `config`, `policy`, etc.) onto the 10-verb set via `commands::verb::NOUN_TABLE`, matching 12.16's alias + deprecation-notice pattern exactly.
-2. [ ] Curate a default `--help` view showing only the common-operation verb+noun pairs (the ~15-20 combos covering the everyday workflow); full/legacy/advanced commands surface via `ta --help --all` or `ta <verb> --help` drill-down.
-3. [ ] USAGE.md: complete the old→new lookup table to 42/42; document the simple-vs-`--all` help split.
-4. [ ] Tests: every newly-mapped noun-area's alias produces identical behavior through its verb+noun form; default `--help` excludes legacy/advanced-only commands; `--all` shows everything.
+1. [x] Map the remaining 24 noun-areas (`advisor`, `memory`, `adapter`, `release`, `intake`, `config`, `policy`, etc.) onto the 10-verb set via `commands::verb::NOUN_TABLE`, matching 12.16's alias + deprecation-notice pattern exactly.
+2. [x] Curate a default `--help` view showing only the common-operation verb+noun pairs (the ~15-20 combos covering the everyday workflow); full/legacy/advanced commands surface via `ta --help --all` or `ta <verb> --help` drill-down.
+3. [x] USAGE.md: complete the old→new lookup table to 42/42; document the simple-vs-`--all` help split.
+4. [x] Tests: every newly-mapped noun-area's alias produces identical behavior through its verb+noun form; default `--help` excludes legacy/advanced-only commands; `--all` shows everything.
 
 #### Version: `0.17.0-alpha.12.22`
 

--- a/apps/ta-cli/src/commands/meridian.rs
+++ b/apps/ta-cli/src/commands/meridian.rs
@@ -15,7 +15,7 @@
 //
 // Subcommands:
 //   ta meridian analyze  → meridian analyze --source ta --path <project_root>
-//   ta meridian help     → list tools exposed by `meridian serve` (MCP)
+//   ta meridian tools    → list tools exposed by `meridian serve` (MCP)
 //   ta meridian init     → meridian init
 //   ta meridian suggest  → meridian suggest --source ta --path <project_root>
 
@@ -47,8 +47,8 @@ pub enum MeridianCommands {
     /// tool calls inside a running goal.
     ///
     /// Example:
-    ///   ta meridian help
-    Help,
+    ///   ta meridian tools
+    Tools,
 
     /// Initialize a Meridian configuration in the current project.
     ///
@@ -169,7 +169,7 @@ fn find_meridian_binary(workspace_root: &Path) -> Result<String> {
 
 pub fn execute(command: &MeridianCommands, config: &GatewayConfig) -> Result<()> {
     match command {
-        MeridianCommands::Help => {
+        MeridianCommands::Tools => {
             let meridian = find_meridian_binary(&config.workspace_root)?;
             list_meridian_tools(&meridian)
         }
@@ -188,7 +188,7 @@ pub fn execute(command: &MeridianCommands, config: &GatewayConfig) -> Result<()>
                     &["suggest", "--source", "ta", "--path"],
                     project_root,
                 ),
-                MeridianCommands::Help => unreachable!(),
+                MeridianCommands::Tools => unreachable!(),
             }
         }
     }
@@ -519,7 +519,7 @@ mod tests {
     fn meridian_commands_all_variants_exist() {
         // Ensures the enum compiles with all four variants.
         let _analyze = MeridianCommands::Analyze;
-        let _help = MeridianCommands::Help;
+        let _tools = MeridianCommands::Tools;
         let _init = MeridianCommands::Init;
         let _suggest = MeridianCommands::Suggest;
     }

--- a/apps/ta-cli/src/commands/verb.rs
+++ b/apps/ta-cli/src/commands/verb.rs
@@ -323,7 +323,7 @@ const NOUN_TABLE: &[NounEntry] = &[
     NounEntry {
         keys: &["meridian"],
         legacy: "meridian",
-        verbs: &[("create", "init"), ("list", "help"), ("check", "analyze")],
+        verbs: &[("create", "init"), ("list", "tools"), ("check", "analyze")],
     },
     NounEntry {
         keys: &["tools", "tool"],

--- a/apps/ta-cli/src/commands/verb.rs
+++ b/apps/ta-cli/src/commands/verb.rs
@@ -206,6 +206,175 @@ const NOUN_TABLE: &[NounEntry] = &[
             ("sync", "migrate"),
         ],
     },
+    // ── Remaining 23 noun-areas (v0.17.0.12.22), per
+    // docs/design/ta-cli-verb-reference.md §2. `pr` is intentionally not
+    // added here — it's already `#[command(hide = true)]` in main.rs as a
+    // deprecated alias of `draft` (see that doc's "already hidden" bucket),
+    // so it isn't a fresh noun-area to map onto the verb surface.
+    NounEntry {
+        keys: &["runbook", "runbooks"],
+        legacy: "runbook",
+        verbs: &[("list", "list"), ("show", "show"), ("apply", "run")],
+    },
+    NounEntry {
+        keys: &["operations", "operation"],
+        legacy: "operations",
+        verbs: &[("list", "log")],
+    },
+    NounEntry {
+        keys: &["audit"],
+        legacy: "audit",
+        verbs: &[("list", "tail"), ("show", "show"), ("check", "verify")],
+    },
+    NounEntry {
+        keys: &["setup"],
+        legacy: "setup",
+        verbs: &[
+            ("create", "wizard"),
+            ("show", "show"),
+            ("update", "refine"),
+            ("sync", "resolve"),
+        ],
+    },
+    NounEntry {
+        keys: &["project"],
+        legacy: "init",
+        verbs: &[("create", "run")],
+    },
+    NounEntry {
+        keys: &["scaffold"],
+        legacy: "new",
+        verbs: &[("create", "run")],
+    },
+    NounEntry {
+        keys: &["advisor"],
+        legacy: "advisor",
+        verbs: &[("apply", "ask")],
+    },
+    NounEntry {
+        keys: &["style"],
+        legacy: "style",
+        verbs: &[
+            ("create", "init"),
+            ("show", "show"),
+            ("update", "edit"),
+            ("remove", "clear"),
+            ("check", "discover"),
+            ("sync", "import"),
+        ],
+    },
+    NounEntry {
+        keys: &["constitution"],
+        legacy: "constitution",
+        verbs: &[
+            ("create", "init"),
+            ("show", "show"),
+            ("update", "amend"),
+            ("check", "validate"),
+        ],
+    },
+    NounEntry {
+        keys: &["memory"],
+        legacy: "memory",
+        verbs: &[
+            ("create", "store"),
+            ("list", "list"),
+            ("show", "backend"),
+            ("check", "doctor"),
+            ("sync", "sync"),
+        ],
+    },
+    NounEntry {
+        keys: &["adapter", "adapters"],
+        legacy: "adapter",
+        verbs: &[
+            ("create", "install"),
+            ("list", "list"),
+            ("check", "health"),
+            ("update", "setup"),
+        ],
+    },
+    NounEntry {
+        keys: &["release"],
+        legacy: "release",
+        verbs: &[
+            ("apply", "run"),
+            ("show", "show"),
+            ("create", "init"),
+            ("update", "config"),
+            ("check", "validate"),
+            ("sync", "dispatch"),
+        ],
+    },
+    NounEntry {
+        keys: &["intake", "trigger", "triggers"],
+        legacy: "intake",
+        verbs: &[("list", "list"), ("apply", "fire"), ("show", "routing")],
+    },
+    NounEntry {
+        keys: &["stats"],
+        legacy: "stats",
+        verbs: &[
+            ("list", "velocity"),
+            ("show", "velocity-detail"),
+            ("sync", "migrate"),
+        ],
+    },
+    NounEntry {
+        keys: &["meridian"],
+        legacy: "meridian",
+        verbs: &[("create", "init"), ("list", "help"), ("check", "analyze")],
+    },
+    NounEntry {
+        keys: &["tools", "tool"],
+        legacy: "tools",
+        verbs: &[("list", "list"), ("create", "install")],
+    },
+    NounEntry {
+        keys: &["manifest"],
+        legacy: "manifest",
+        verbs: &[("create", "init"), ("check", "validate"), ("show", "show")],
+    },
+    NounEntry {
+        keys: &["link", "links"],
+        legacy: "link",
+        verbs: &[
+            ("create", "add"),
+            ("list", "list"),
+            ("check", "status"),
+            ("sync", "refresh"),
+            ("remove", "remove"),
+        ],
+    },
+    NounEntry {
+        keys: &["policy", "policies"],
+        legacy: "policy",
+        verbs: &[("check", "check"), ("show", "show")],
+    },
+    NounEntry {
+        keys: &["config"],
+        legacy: "config",
+        verbs: &[("show", "channels")],
+    },
+    NounEntry {
+        keys: &["analysis"],
+        legacy: "analysis",
+        verbs: &[("apply", "run")],
+    },
+    NounEntry {
+        keys: &["compression"],
+        legacy: "compression",
+        verbs: &[
+            ("show", "status"),
+            ("create", "enable"),
+            ("remove", "disable"),
+        ],
+    },
+    NounEntry {
+        keys: &["webhook", "webhooks"],
+        legacy: "webhook",
+        verbs: &[("check", "test")],
+    },
 ];
 
 /// The full list of nouns and per-noun supported verbs, for `--help`-style
@@ -439,6 +608,78 @@ mod tests {
             "status"
         );
         assert_eq!(action_word_from_debug(&FakeCommands::List), "list");
+    }
+
+    #[test]
+    fn v0_17_0_12_22_nouns_resolve_with_two_positionals_via_extra() {
+        // memory store and release config both take two required legacy
+        // positionals (key+value / key+value) — `id` supplies the first,
+        // `extra`'s leading element supplies the second (v0.17.0.12.22).
+        assert_eq!(
+            resolve(
+                "create",
+                "memory",
+                Some("arch:auth"),
+                &["Use JWT RS256".to_string()]
+            )
+            .unwrap(),
+            vec!["ta", "memory", "store", "arch:auth", "Use JWT RS256"]
+        );
+        assert_eq!(
+            resolve(
+                "update",
+                "release",
+                Some("press_release_template"),
+                &["./template.md".to_string()]
+            )
+            .unwrap(),
+            vec![
+                "ta",
+                "release",
+                "config",
+                "press_release_template",
+                "./template.md"
+            ]
+        );
+    }
+
+    #[test]
+    fn v0_17_0_12_22_sync_verb_has_no_id_slot_so_extra_supplies_the_positional() {
+        // The `sync` verb's top-level `Commands::Sync` has no `id` field —
+        // any legacy positional (e.g. `style import <source>`) must come
+        // through `extra`, not `id`.
+        assert_eq!(
+            resolve(
+                "sync",
+                "style",
+                None,
+                &["https://example.com/style.md".to_string()]
+            )
+            .unwrap(),
+            vec!["ta", "style", "import", "https://example.com/style.md"]
+        );
+    }
+
+    #[test]
+    fn v0_17_0_12_22_project_and_scaffold_nouns_disambiguate_init_and_new() {
+        // `init` and `new` both bootstrap a project via different legacy
+        // top-levels; distinct noun keys avoid `NOUN_TABLE` key collisions.
+        assert_eq!(
+            resolve("create", "project", None, &[]).unwrap(),
+            vec!["ta", "init", "run"]
+        );
+        assert_eq!(
+            resolve("create", "scaffold", None, &[]).unwrap(),
+            vec!["ta", "new", "run"]
+        );
+    }
+
+    #[test]
+    fn v0_17_0_12_22_pr_is_intentionally_not_in_noun_table() {
+        // `pr` is a hidden, deprecated alias of `draft` (main.rs
+        // `#[command(hide = true)]`) — not a fresh noun-area to map.
+        let err = resolve("list", "pr", None, &[]).unwrap_err();
+        assert!(err.to_string().contains("Unknown noun"));
     }
 
     #[test]

--- a/apps/ta-cli/src/main.rs
+++ b/apps/ta-cli/src/main.rs
@@ -610,6 +610,7 @@ enum Commands {
         command: commands::pr::PrCommands,
     },
     /// Inspect the audit trail.
+    #[command(hide = true)]
     Audit {
         #[command(subcommand)]
         command: commands::audit::AuditCommands,
@@ -873,7 +874,7 @@ enum Commands {
     ///
     /// Subcommands:
     ///   ta meridian analyze  — run KPI analysis against velocity data
-    ///   ta meridian help     — list tools exposed by meridian serve (MCP)
+    ///   ta meridian tools    — list tools exposed by meridian serve (MCP)
     ///   ta meridian init     — create meridian.toml with starter KPI definitions
     ///   ta meridian suggest  — surface KPI alignment gaps with suggestions
     ///
@@ -1955,6 +1956,20 @@ mod verb_dispatch_tests {
             .expect("parse thread panicked")
     }
 
+    /// Build the full `clap::Command` metadata tree the same way the real
+    /// binary does, on the same dedicated large-stack thread as `parse_argv`.
+    /// `CommandFactory::command()` recursively builds `Arg` definitions for
+    /// every field of every `Commands` variant — the same large-enum stack
+    /// cost as parsing, just via a different clap entry point.
+    fn build_command() -> clap::Command {
+        std::thread::Builder::new()
+            .stack_size(16 * 1024 * 1024)
+            .spawn(Cli::command)
+            .expect("spawn command-build thread")
+            .join()
+            .expect("command-build thread panicked")
+    }
+
     #[test]
     fn parses_all_ten_verb_shapes() {
         assert!(matches!(
@@ -2194,7 +2209,7 @@ mod verb_dispatch_tests {
     /// legacy noun-first / advanced-only top-level command.
     #[test]
     fn curated_help_hides_legacy_and_advanced_commands_by_default() {
-        let cmd = Cli::command();
+        let cmd = build_command();
         let legacy_and_advanced = [
             "goal",
             "draft",
@@ -2264,7 +2279,7 @@ mod verb_dispatch_tests {
     /// run/status/shell/onboard/doctor) must stay visible by default.
     #[test]
     fn curated_help_keeps_core_surface_visible_by_default() {
-        let cmd = Cli::command();
+        let cmd = build_command();
         let curated = [
             "create", "list", "show", "update", "remove", "approve", "deny", "apply", "check",
             "sync", "status", "run", "shell", "doctor", "onboard",
@@ -2284,7 +2299,7 @@ mod verb_dispatch_tests {
     /// `unhide_all_subcommands` clears every top-level `hide` flag.
     #[test]
     fn unhide_all_subcommands_clears_every_top_level_hide_flag() {
-        let mut cmd = Cli::command();
+        let mut cmd = build_command();
         unhide_all_subcommands(&mut cmd);
         for sub in cmd.get_subcommands() {
             assert!(

--- a/apps/ta-cli/src/main.rs
+++ b/apps/ta-cli/src/main.rs
@@ -14,12 +14,18 @@ pub mod framework_registry;
 
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use ta_mcp_gateway::GatewayConfig;
 
 /// Trusted Autonomy CLI — review and approve agent changes.
 ///
 /// Run `ta` with no arguments to show the project status dashboard.
+///
+/// `ta --help` shows the curated everyday-workflow surface (v0.17.0.12.22):
+/// the 10 verbs (create/list/show/update/remove/approve/deny/apply/check/sync),
+/// plus run/status/shell/onboard/doctor. Run `ta --help --all` to see the
+/// full legacy/advanced command surface, or `ta <legacy-noun> --help` to
+/// drill into one directly (e.g. `ta plugin --help`).
 #[derive(Parser)]
 #[command(
     name = "ta",
@@ -371,21 +377,25 @@ enum Commands {
         priority: Option<String>,
     },
     /// Review and manage draft packages.
+    #[command(hide = true)]
     Draft {
         #[command(subcommand)]
         command: commands::draft::DraftCommands,
     },
     /// Manage goal runs.
+    #[command(hide = true)]
     Goal {
         #[command(subcommand)]
         command: commands::goal::GoalCommands,
     },
     /// View and track the project development plan.
+    #[command(hide = true)]
     Plan {
         #[command(subcommand)]
         command: commands::plan::PlanCommands,
     },
     /// Manage agent personas for role-based behavior.
+    #[command(hide = true)]
     Persona {
         #[command(subcommand)]
         command: commands::persona::PersonaCommands,
@@ -419,6 +429,7 @@ enum Commands {
     /// Runbooks automate common recovery procedures: disk pressure cleanup,
     /// zombie goal recovery, stale draft cleanup, and more.
     /// Built-in runbooks ship with TA; project-local runbooks live in .ta/runbooks/.
+    #[command(hide = true)]
     Runbook {
         #[command(subcommand)]
         command: commands::runbook::RunbookCommands,
@@ -427,11 +438,13 @@ enum Commands {
     ///
     /// The daemon watchdog continuously monitors goal health, disk space,
     /// and plugin status. Corrective action proposals are logged here.
+    #[command(hide = true)]
     Operations {
         #[command(subcommand)]
         command: commands::operations::OperationsCommands,
     },
     /// Manage the TA daemon lifecycle (start, stop, restart, status, log).
+    #[command(hide = true)]
     Daemon {
         #[command(subcommand)]
         command: commands::daemon::DaemonCommands,
@@ -440,6 +453,7 @@ enum Commands {
     ///
     /// Subcommands:
     ///   ta gc governed-paths  — remove unreferenced SHA blobs from managed paths
+    #[command(hide = true)]
     Gc {
         /// Show what would be cleaned without making changes.
         #[arg(long)]
@@ -532,6 +546,7 @@ enum Commands {
     ///   ta upgrade --dry-run    # show what would be applied without changing anything
     ///   ta upgrade --force      # re-run all steps regardless of version
     ///   ta upgrade --acknowledge ".ta/review/"  # suppress a warning for intentional omission
+    #[command(hide = true)]
     Upgrade(commands::upgrade::UpgradeArgs),
 
     // ── ONBOARDING ──────────────────────────────────────────────────────────
@@ -600,32 +615,38 @@ enum Commands {
         command: commands::audit::AuditCommands,
     },
     /// Manage interactive sessions.
+    #[command(hide = true)]
     Session {
         #[command(subcommand)]
         command: commands::session::SessionCommands,
     },
     /// Manage persistent context memory across agents and sessions.
+    #[command(hide = true)]
     Context {
         #[command(subcommand)]
         command: commands::context::ContextCommands,
     },
     /// Manage stored credentials for external services.
+    #[command(hide = true)]
     Credentials {
         #[command(subcommand)]
         command: commands::credentials::CredentialsCommands,
     },
     /// Stream and inspect lifecycle events.
+    #[command(hide = true)]
     Events {
         #[command(subcommand)]
         command: commands::events::EventsCommands,
     },
     /// Manage approval tokens for non-interactive workflows.
+    #[command(hide = true)]
     Token {
         #[command(subcommand)]
         command: commands::token::TokenCommands,
     },
     /// Interactive developer loop — orchestrate plan execution, goal launches,
     /// draft review, and releases from one persistent session.
+    #[command(hide = true)]
     Dev {
         /// Agent system to use for orchestration (defaults to dev-loop config).
         #[arg(long)]
@@ -635,6 +656,7 @@ enum Commands {
         unrestricted: bool,
     },
     /// Interactive setup wizard for TA configuration.
+    #[command(hide = true)]
     Setup {
         #[command(subcommand)]
         command: commands::setup::SetupCommands,
@@ -646,8 +668,10 @@ enum Commands {
     /// agent system, VCS, notifications, first project, and summary.
     ///
     /// Run this once after installation to get started.
+    #[command(hide = true)]
     Install,
     /// Initialize a new TA-managed project from a template.
+    #[command(hide = true)]
     Init {
         #[command(subcommand)]
         command: commands::init::InitCommands,
@@ -656,6 +680,7 @@ enum Commands {
     ///
     /// Starts an interactive session with a planner agent that asks about your
     /// project, generates a scaffold, and produces a PLAN.md with versioned phases.
+    #[command(hide = true)]
     New {
         #[command(subcommand)]
         command: commands::new::NewCommands,
@@ -669,6 +694,7 @@ enum Commands {
     ///   ta advisor ask "implement remaining v0.15"
     ///   ta advisor ask "apply" --security suggest
     ///   ta advisor ask "what changed?" --tab plan --no-input
+    #[command(hide = true)]
     Advisor {
         #[command(subcommand)]
         command: commands::advisor::AdvisorCommands,
@@ -683,6 +709,7 @@ enum Commands {
     /// Examples:
     ///   ta advise "please focus on the auth module"
     ///   ta advise --goal abc123 "add more test coverage"
+    #[command(hide = true)]
     Advise {
         /// The note/instruction to send to the agent.
         message: String,
@@ -691,6 +718,7 @@ enum Commands {
         goal: Option<String>,
     },
     /// Author, validate, and manage agent configurations.
+    #[command(hide = true)]
     Agent {
         #[command(subcommand)]
         command: commands::agent::AgentCommands,
@@ -710,6 +738,7 @@ enum Commands {
     ///   ta style show                         # print current style
     ///   ta style edit                         # open in $EDITOR
     ///   ta style clear                        # remove style file
+    #[command(hide = true)]
     Style {
         #[command(subcommand)]
         command: commands::style::StyleCommands,
@@ -723,6 +752,7 @@ enum Commands {
     ///   ta team list
     ///   ta team assign reviewer claude-sonnet-4-6 --security auto --persona strict-reviewer
     ///   ta team assign implementer claude-opus-4-8
+    #[command(hide = true)]
     Team {
         #[command(subcommand)]
         command: commands::team::TeamCommands,
@@ -731,6 +761,7 @@ enum Commands {
     ///
     /// `ta constitution init` asks an agent to draft a behavioral contract
     /// from PLAN.md and CLAUDE.md. The output is a TA draft for review.
+    #[command(hide = true)]
     Constitution {
         #[command(subcommand)]
         command: commands::constitution::ConstitutionCommands,
@@ -739,26 +770,31 @@ enum Commands {
     ///
     /// `ta memory backend` shows the active backend, entry count, and storage size.
     /// `ta memory list` prints stored entries (alias for `ta context list`).
+    #[command(hide = true)]
     Memory {
         #[command(subcommand)]
         command: commands::memory::MemoryCommands,
     },
     /// Manage agent adapter integrations.
+    #[command(hide = true)]
     Adapter {
         #[command(subcommand)]
         command: commands::adapter::AdapterCommands,
     },
     /// Run the configurable release pipeline.
+    #[command(hide = true)]
     Release {
         #[command(subcommand)]
         command: commands::release::ReleaseCommands,
     },
     /// Multi-project office daemon management.
+    #[command(hide = true)]
     Office {
         #[command(subcommand)]
         command: commands::office::OfficeCommands,
     },
     /// Manage channel plugins (list, install, validate).
+    #[command(hide = true)]
     Plugin {
         #[command(subcommand)]
         command: commands::plugin::PluginCommands,
@@ -775,6 +811,7 @@ enum Commands {
     ///   ta intake queue
     ///   ta intake coordinate
     ///   ta intake routing --limit 10
+    #[command(hide = true)]
     Intake {
         #[command(subcommand)]
         command: commands::intake::IntakeCommands,
@@ -789,6 +826,7 @@ enum Commands {
     ///   ta template install blender-addon
     ///   ta template install github:myorg/my-template
     ///   ta template install ./my-local-template
+    #[command(hide = true)]
     Template {
         #[command(subcommand)]
         command: commands::template::TemplateCommands,
@@ -797,6 +835,7 @@ enum Commands {
     ///
     /// Finds the most recently approved draft, applies it, stages and commits
     /// changes with git, pushes to the remote, and optionally opens a GitHub PR.
+    #[command(hide = true)]
     Publish {
         /// Commit message (defaults to the draft title).
         #[arg(long, short)]
@@ -806,6 +845,7 @@ enum Commands {
         yes: bool,
     },
     /// Manage multi-stage workflows with pluggable engines.
+    #[command(hide = true)]
     Workflow {
         #[command(subcommand)]
         command: commands::workflow::WorkflowCommands,
@@ -816,6 +856,7 @@ enum Commands {
     /// `ta stats velocity-detail` shows a per-goal breakdown table.
     /// `ta stats export` exports full history as JSON or CSV.
     /// `ta stats migrate` promotes local history to the committed shared file.
+    #[command(hide = true)]
     Stats {
         #[command(subcommand)]
         command: commands::stats::StatsCommands,
@@ -837,6 +878,7 @@ enum Commands {
     ///   ta meridian suggest  — surface KPI alignment gaps with suggestions
     ///
     /// Install Meridian: cargo install meridian
+    #[command(hide = true)]
     Meridian {
         #[command(subcommand)]
         command: commands::meridian::MeridianCommands,
@@ -854,6 +896,7 @@ enum Commands {
     ///   ta tools list
     ///   ta tools install meridian
     ///   ta tools install claude-flow
+    #[command(hide = true)]
     Tools {
         #[command(subcommand)]
         command: commands::tools::ToolsCommands,
@@ -866,6 +909,7 @@ enum Commands {
     /// `ta community get <id>` fetches and displays a specific document.
     ///
     /// Configure resources in `.ta/community-resources.toml`.
+    #[command(hide = true)]
     Community {
         #[command(subcommand)]
         command: commands::community::CommunityCommands,
@@ -881,6 +925,7 @@ enum Commands {
     ///   ta manifest validate
     ///   ta manifest show
     ///   ta manifest show cinepipe-train
+    #[command(hide = true)]
     Manifest {
         #[command(subcommand)]
         command: commands::manifest::ManifestCommands,
@@ -897,27 +942,32 @@ enum Commands {
     ///   ta link status
     ///   ta link refresh
     ///   ta link remove cinepipe-train
+    #[command(hide = true)]
     Link {
         #[command(subcommand)]
         command: commands::link::LinkCommands,
     },
     /// Manage policy configuration and auto-approval.
+    #[command(hide = true)]
     Policy {
         #[command(subcommand)]
         command: commands::policy::PolicyCommands,
     },
     /// Inspect and validate project configuration (channels, routing).
+    #[command(hide = true)]
     Config {
         #[command(subcommand)]
         command: commands::config::ConfigCommands,
     },
     /// Start the MCP server on stdio.
+    #[command(hide = true)]
     Serve,
     /// Build the project using the configured build adapter.
     ///
     /// Auto-detects the build system (Cargo, npm, Make) or uses the adapter
     /// configured in `[build]` in `.ta/workflow.toml`. Emits `build_completed`
     /// or `build_failed` events.
+    #[command(hide = true)]
     Build {
         /// Also run the test suite after building.
         #[arg(long)]
@@ -944,6 +994,7 @@ enum Commands {
     ///
     /// Runs the [verify] commands from .ta/workflow.toml in the staging
     /// directory. Useful for manual verification without running `ta run`.
+    #[command(hide = true)]
     Verify {
         /// Goal ID (or prefix) whose staging directory to verify.
         /// Defaults to the most recent active goal.
@@ -958,11 +1009,13 @@ enum Commands {
     ///   ta analysis run
     ///   ta analysis run --lang python
     ///   ta analysis run --fix
+    #[command(hide = true)]
     Analysis {
         #[command(subcommand)]
         command: commands::analysis::AnalysisCommands,
     },
     /// View the interactive conversation history for a goal.
+    #[command(hide = true)]
     Conversation {
         /// Goal run ID (or prefix).
         goal_id: String,
@@ -979,6 +1032,7 @@ enum Commands {
     ///   ta connector install unreal --backend flopperam
     ///   ta connector list
     ///   ta connector status unreal
+    #[command(hide = true)]
     Connector {
         #[command(subcommand)]
         command: commands::connector::ConnectorCommands,
@@ -997,6 +1051,7 @@ enum Commands {
     ///   ta compression status
     ///   ta compression enable
     ///   ta compression disable
+    #[command(hide = true)]
     Compression {
         #[command(subcommand)]
         command: commands::compression::CompressionCommands,
@@ -1011,6 +1066,7 @@ enum Commands {
     /// Examples:
     ///   ta webhook test github pull_request.closed --branch main
     ///   ta webhook test vcs changelist_submitted --change 12345
+    #[command(hide = true)]
     Webhook {
         #[command(subcommand)]
         command: commands::webhook::WebhookCommands,
@@ -1043,6 +1099,39 @@ enum Commands {
         /// Agent ID (required for show/accept, optional for status).
         agent: Option<String>,
     },
+}
+
+/// Parse CLI args, honoring `--all` as an ad-hoc flag that unhides the full
+/// legacy/advanced command surface in `--help` output (v0.17.0.12.22).
+///
+/// `--all` is intentionally *not* a formal `Cli`-level `#[arg(global = true)]`:
+/// several subcommands (`ta gc --all`, `ta audit drift --all`) already
+/// define their own `--all` flag with unrelated meaning, and a global arg
+/// sharing that id would collide with those at `clap::Command` build time.
+/// Instead this scans the raw argv for the literal `--all` token purely to
+/// decide whether to unhide `Command` nodes before the real parse —
+/// `.hide()` only affects help rendering, never argument matching, so
+/// reusing the (possibly unhidden) `Command` for the actual parse is always
+/// safe, regardless of whether this invocation was a help request.
+fn parse_cli_with_help_curation() -> Cli {
+    let show_all = std::env::args().any(|a| a == "--all");
+    let mut cmd = Cli::command();
+    if show_all {
+        unhide_all_subcommands(&mut cmd);
+    }
+    let matches = cmd.get_matches_from(std::env::args_os());
+    Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit())
+}
+
+/// Recursively clear the `hide` flag on every subcommand so `ta --help --all`
+/// shows the full legacy/advanced surface, not just the curated set
+/// (v0.17.0.12.22 item 2).
+fn unhide_all_subcommands(cmd: &mut clap::Command) {
+    for sub in cmd.get_subcommands_mut() {
+        let taken = std::mem::replace(sub, clap::Command::new("__ta_tmp__"));
+        *sub = taken.hide(false);
+        unhide_all_subcommands(sub);
+    }
 }
 
 /// Build the long version string: "0.1.0-alpha (abc1234 2026-02-11)"
@@ -1146,7 +1235,7 @@ fn main() -> anyhow::Result<()> {
 
 fn run() -> anyhow::Result<()> {
     let startup_begin = std::time::Instant::now();
-    let cli = Cli::parse();
+    let cli = parse_cli_with_help_curation();
     let t_parse = startup_begin.elapsed();
 
     // Handle --accept-terms flag (non-interactive acceptance).
@@ -2008,5 +2097,201 @@ mod verb_dispatch_tests {
     fn unknown_noun_via_new_surface_is_a_clean_error_not_a_panic() {
         let err = commands::verb::resolve("list", "spaceship", None, &[]).unwrap_err();
         assert!(err.to_string().contains("Unknown noun"));
+    }
+
+    /// v0.17.0.12.22: every newly-mapped noun-area's verb+noun form must
+    /// resolve to a legacy argv that parses cleanly through the *same*
+    /// `Cli`/`Commands` definitions as the legacy form itself — proving the
+    /// new surface and the legacy surface execute identical code for all
+    /// 23 of the remaining noun-areas, not just the 18 shipped in 12.16.
+    #[test]
+    fn all_v0_17_0_12_22_nouns_resolve_and_parse_cleanly() {
+        let cases: &[(&str, &str, Option<&str>, &[&str])] = &[
+            ("list", "runbook", None, &[]),
+            ("show", "runbook", Some("disk-pressure"), &[]),
+            ("apply", "runbook", Some("disk-pressure"), &["--dry-run"]),
+            ("list", "operations", None, &[]),
+            ("list", "audit", None, &[]),
+            ("show", "audit", Some("abc123"), &[]),
+            ("check", "audit", None, &[]),
+            ("create", "setup", None, &[]),
+            ("show", "setup", None, &[]),
+            ("update", "setup", Some("policy"), &[]),
+            ("sync", "setup", None, &[]),
+            ("create", "project", None, &[]),
+            ("create", "scaffold", None, &[]),
+            ("apply", "advisor", Some("implement remaining v0.15"), &[]),
+            ("create", "style", None, &[]),
+            ("show", "style", None, &[]),
+            ("update", "style", None, &[]),
+            ("remove", "style", None, &[]),
+            ("check", "style", None, &[]),
+            ("sync", "style", None, &["https://example.com/style.md"]),
+            ("create", "constitution", None, &[]),
+            ("show", "constitution", None, &[]),
+            ("update", "constitution", None, &[]),
+            ("check", "constitution", None, &[]),
+            ("create", "memory", Some("arch:auth"), &["Use JWT RS256"]),
+            ("list", "memory", None, &[]),
+            ("show", "memory", None, &[]),
+            ("check", "memory", None, &[]),
+            ("sync", "memory", None, &[]),
+            ("create", "adapter", Some("claude-code"), &[]),
+            ("list", "adapter", None, &[]),
+            ("check", "adapter", Some("messaging"), &[]),
+            ("update", "adapter", Some("messaging/gmail"), &[]),
+            ("apply", "release", Some("0.17.0-alpha"), &[]),
+            ("show", "release", None, &[]),
+            ("create", "release", None, &[]),
+            (
+                "update",
+                "release",
+                Some("press_release_template"),
+                &["./template.md"],
+            ),
+            ("check", "release", Some("0.17.0-alpha"), &[]),
+            ("sync", "release", None, &["public-alpha-v0.17.0.12.22"]),
+            ("list", "intake", None, &[]),
+            ("apply", "trigger", Some("schedule"), &[]),
+            ("show", "trigger", None, &[]),
+            ("list", "stats", None, &[]),
+            ("show", "stats", None, &[]),
+            ("sync", "stats", None, &[]),
+            ("create", "meridian", None, &[]),
+            ("list", "meridian", None, &[]),
+            ("check", "meridian", None, &[]),
+            ("list", "tools", None, &[]),
+            ("create", "tools", Some("meridian"), &[]),
+            ("create", "manifest", None, &[]),
+            ("check", "manifest", None, &[]),
+            ("show", "manifest", None, &[]),
+            ("create", "link", Some("github:myorg/pragma"), &[]),
+            ("list", "link", None, &[]),
+            ("check", "link", None, &[]),
+            ("sync", "link", None, &[]),
+            ("remove", "link", Some("cinepipe-train"), &[]),
+            ("check", "policy", Some("draft-id-123"), &[]),
+            ("show", "policy", None, &[]),
+            ("show", "config", None, &[]),
+            ("apply", "analysis", None, &[]),
+            ("show", "compression", None, &[]),
+            ("create", "compression", None, &[]),
+            ("remove", "compression", None, &[]),
+            ("check", "webhook", Some("github"), &["pull_request.closed"]),
+        ];
+
+        for (verb, noun, id, extra) in cases {
+            let extra_owned: Vec<String> = extra.iter().map(|s| s.to_string()).collect();
+            let argv = commands::verb::resolve(verb, noun, *id, &extra_owned)
+                .unwrap_or_else(|e| panic!("resolve(\"{verb}\", \"{noun}\", ...) failed: {e}"));
+            // Must parse through the exact same Cli/Commands definitions as
+            // a direct legacy invocation — no second copy of any behavior.
+            let _ = parse_argv(argv.clone());
+        }
+    }
+
+    /// v0.17.0.12.22 item 2: the default `--help` view must exclude every
+    /// legacy noun-first / advanced-only top-level command.
+    #[test]
+    fn curated_help_hides_legacy_and_advanced_commands_by_default() {
+        let cmd = Cli::command();
+        let legacy_and_advanced = [
+            "goal",
+            "draft",
+            "plan",
+            "persona",
+            "runbook",
+            "operations",
+            "daemon",
+            "gc",
+            "pr",
+            "audit",
+            "session",
+            "context",
+            "credentials",
+            "events",
+            "token",
+            "dev",
+            "setup",
+            "install",
+            "init",
+            "new",
+            "advisor",
+            "advise",
+            "agent",
+            "style",
+            "team",
+            "constitution",
+            "memory",
+            "adapter",
+            "release",
+            "office",
+            "plugin",
+            "intake",
+            "template",
+            "publish",
+            "workflow",
+            "stats",
+            "meridian",
+            "tools",
+            "community",
+            "manifest",
+            "link",
+            "policy",
+            "config",
+            "serve",
+            "build",
+            "verify",
+            "analysis",
+            "conversation",
+            "connector",
+            "compression",
+            "webhook",
+            "upgrade",
+        ];
+        for name in legacy_and_advanced {
+            let sub = cmd
+                .find_subcommand(name)
+                .unwrap_or_else(|| panic!("missing subcommand `{name}`"));
+            assert!(
+                sub.is_hide_set(),
+                "expected `{name}` to be hidden from default --help"
+            );
+        }
+    }
+
+    /// v0.17.0.12.22 item 2: the curated ~15-command surface (10 verbs plus
+    /// run/status/shell/onboard/doctor) must stay visible by default.
+    #[test]
+    fn curated_help_keeps_core_surface_visible_by_default() {
+        let cmd = Cli::command();
+        let curated = [
+            "create", "list", "show", "update", "remove", "approve", "deny", "apply", "check",
+            "sync", "status", "run", "shell", "doctor", "onboard",
+        ];
+        for name in curated {
+            let sub = cmd
+                .find_subcommand(name)
+                .unwrap_or_else(|| panic!("missing subcommand `{name}`"));
+            assert!(
+                !sub.is_hide_set(),
+                "expected `{name}` to remain visible in default --help"
+            );
+        }
+    }
+
+    /// v0.17.0.12.22 item 2: `ta --help --all` must show everything —
+    /// `unhide_all_subcommands` clears every top-level `hide` flag.
+    #[test]
+    fn unhide_all_subcommands_clears_every_top_level_hide_flag() {
+        let mut cmd = Cli::command();
+        unhide_all_subcommands(&mut cmd);
+        for sub in cmd.get_subcommands() {
+            assert!(
+                !sub.is_hide_set(),
+                "`{}` should be visible after unhide_all_subcommands",
+                sub.get_name()
+            );
+        }
     }
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -33,12 +33,16 @@ Both paths install the same `ta` binary. Studio and CLI work side-by-side — yo
    - [Set up your project](#set-up-your-project)
    - [Start a development session](#start-a-development-session)
    - [Your first goal](#your-first-goal)
-3. [Core Concepts](#core-concepts)
+3. [CLI Verb Reference](#cli-verb-reference)
+   - [The 10 verbs](#the-10-verbs)
+   - [Default vs. full help](#default-vs-full-help)
+   - [Old → new lookup table](#old--new-lookup-table)
+4. [Core Concepts](#core-concepts)
    - [The Staging Model](#the-staging-model)
    - [Goals](#goals)
    - [Drafts](#drafts)
    - [Agents](#agents)
-4. [Common Workflows](#common-workflows)
+5. [Common Workflows](#common-workflows)
    - [Single Task](#single-task)
    - [Follow-Up Iterations](#follow-up-iterations)
    - [Macro Goals (multi-draft sessions)](#macro-goals-multi-draft-sessions)
@@ -48,7 +52,7 @@ Both paths install the same `ta` binary. Studio and CLI work side-by-side — yo
    - [Review Sessions](#review-sessions)
    - [Correcting a Draft](#correcting-a-draft)
    - [Draft Lifecycle Hygiene](#draft-lifecycle-hygiene)
-5. [Configuration](#configuration)
+6. [Configuration](#configuration)
    - [Workflow Config](#workflow-config-taworkflowtoml)
    - [Agent Configuration](#agent-configuration)
    - [Alignment Profiles](#alignment-profiles)
@@ -56,7 +60,7 @@ Both paths install the same `ta` binary. Studio and CLI work side-by-side — yo
    - [Configurable Summary Exemption](#configurable-summary-exemption)
    - [Plan Schema](#plan-schema-taplan-schemayaml)
    - [Channel Setup](#channel-setup)
-6. [Advanced Features](#advanced-features)
+7. [Advanced Features](#advanced-features)
    - [Selective Approval](#selective-approval)
    - [Behavioral Drift Detection](#behavioral-drift-detection)
    - [Conflict Detection](#conflict-detection)
@@ -94,9 +98,9 @@ Both paths install the same `ta` binary. Studio and CLI work side-by-side — yo
    - [Workflow Engine](#workflow-engine)
    - [Choosing Your Orchestration Stack](#choosing-your-orchestration-stack)
    - [Community Knowledge Hub](#community-knowledge-hub)
-7. [Roadmap](#roadmap)
-8. [Troubleshooting](#troubleshooting)
-9. [Getting Help](#getting-help)
+8. [Roadmap](#roadmap)
+9. [Troubleshooting](#troubleshooting)
+10. [Getting Help](#getting-help)
 
 ---
 
@@ -949,6 +953,118 @@ ta> [Pasted 2,847 chars / 47 lines — Tab to preview, Esc to cancel]
 **Auto-tail**: When streaming agent output, the shell follows new lines automatically (`tail -f` style). If you scroll up to read earlier output, auto-tail is paused. Scroll back to the bottom (mouse wheel, `PageDown`, or `Cmd+Down`) to resume — the viewport will immediately begin following new output again. `Ctrl+L` clears the output and also resumes auto-tail.
 
 **Stream reconnect**: If the connection to the daemon drops mid-stream (e.g. daemon restart, network interruption), the shell automatically reconnects — up to 5 retries with exponential backoff (1s, 2s, 4s, 8s, 16s). A non-blocking notice is shown in the output pane during reconnect. The daemon tracks a monotonic sequence number per goal stream (`id:` field in SSE), so reconnects resume from the last received event with no duplicate or lost lines. If all retries fail, an actionable message is shown and the tail session ends cleanly.
+
+---
+
+## CLI Verb Reference
+
+TA's CLI has two surfaces that always execute identical code — the new form
+never re-implements a legacy command, it forwards to the exact same
+`Commands` variant (`apps/ta-cli/src/commands/verb.rs`):
+
+- **The 10-verb surface** (primary, recommended): `ta <verb> <noun> [id] [flags]`
+- **The legacy noun-first surface** (still works, unchanged): `ta <noun> <action> [id] [flags]`
+
+### The 10 verbs
+
+| Verb | Does | Replaces |
+|---|---|---|
+| `create` | Provision a new resource | `new`/`init`/`add`/`install` |
+| `list` | Show all resources of a kind | 15+ independent `list` implementations |
+| `show` | Single-item detail | `view`/`status`/`inspect` |
+| `update` | Modify a resource | `set`/`assign`/`reload` |
+| `remove` | Delete a resource | `delete`/`remove`/`revoke`/`uninstall` |
+| `approve` / `deny` | Decision-gate outcomes | same shape as `draft approve`/`deny`, generalized |
+| `apply` | Fire the Commit stage | TA's defining action — materializes an approved draft |
+| `check` | Correctness/validation | `validate`/`verify`/`audit` |
+| `sync` | Reconcile with remote/registry | `gc`/`prune`/`migrate` |
+
+`run` (launch an agent goal) and `status` (the no-argument dashboard) are
+already verb-shaped and unchanged.
+
+### Default vs. full help
+
+`ta --help` shows a curated ~15-command everyday surface: the 10 verbs above,
+plus `run`, `status`, `shell`, `onboard`, and `doctor`. Every legacy
+noun-first command (`ta goal ...`, `ta plugin ...`, `ta webhook ...`, etc.)
+and advanced/one-time command (`ta gc`, `ta upgrade`, `ta serve`, ...) keeps
+working exactly as before — it's just not listed in the default `--help`
+output, so a new user isn't confronted with the full ~60-command surface on
+day one.
+
+```bash
+ta --help              # curated: the 10 verbs + run/status/shell/onboard/doctor
+ta --help --all        # full surface: every legacy/advanced command, unhidden
+ta plugin --help       # drill into a legacy noun directly — always works,
+                        # hidden or not
+ta create --help       # drill into a verb to see its full noun list + examples
+```
+
+Automation (workflow definitions, the Advisor's tool-calling, `ta-brain`
+routing) always sees and can invoke the full command surface — `--help`
+curation only affects what a human reading `ta --help` sees first per
+`docs/design/ta-cli-verb-reference.md` §4.
+
+### Old → new lookup table
+
+Every noun-area below has a working legacy form (left) and, where mapped, an
+equivalent verb+noun form (right) that executes identical code. A noun with
+no verb+noun form yet in a given column means that legacy action isn't
+mapped — it keeps working via the legacy form only. Nouns marked with (*)
+were completed in v0.17.0.12.22; the rest shipped in v0.17.0.12.16.
+
+| Noun area | Legacy top-level | Verb+noun equivalents |
+|---|---|---|
+| Goal | `ta goal ...` | `list goal`, `show goal <id>`, `remove goal <id>`, `sync goal` |
+| Draft | `ta draft ...` | `list draft`, `show draft <id>`, `remove draft <id>`, `approve draft <id>`, `deny draft <id>`, `apply draft <id>`, `sync draft` |
+| Plan phase | `ta plan ...` | `list plan-phase`, `show plan-phase <id>`, `create plan-phase <id>`, `check plan-phase <id>`, `sync plan-phase` |
+| Team | `ta team ...` | `list team`, `update team <role> <agent>` |
+| Persona | `ta persona ...` | `list persona`, `create persona <name>`, `show persona <name>`, `update persona <name>` |
+| Workflow | `ta workflow ...` | `list workflow`, `show workflow <name>`, `create workflow <name>`, `update workflow <name>`, `remove workflow <name>`, `check workflow <name>`, `sync workflow` |
+| Plugin | `ta plugin ...` | `create plugin <name>`, `list plugin`, `show plugin <name>`, `remove plugin <name>`, `check plugin <name>`, `sync plugin` |
+| Template | `ta template ...` | `create template <name>`, `list template`, `remove template <name>` |
+| Session | `ta session ...` | `list session`, `show session <id>`, `remove session <id>` |
+| Credential | `ta credentials ...` | `create credential <name>`, `list credential`, `remove credential <name>` |
+| Event | `ta events ...` | `show event`, `sync event` |
+| Token | `ta token ...` | `create token`, `list token`, `sync token` |
+| Office | `ta office ...` | `create office`, `show office`, `remove office`, `sync office` |
+| Daemon | `ta daemon ...` | `create daemon`, `show daemon`, `remove daemon`, `check daemon`, `sync daemon` |
+| Connector | `ta connector ...` | `create connector <name>`, `list connector`, `show connector <name>`, `remove connector <name>`, `sync connector <name>` |
+| Community resource | `ta community ...` | `list community-resource`, `show community-resource <id>`, `sync community-resource` |
+| Context | `ta context ...` | `create context <key>`, `list context`, `show context <key>`, `remove context <key>`, `check context` |
+| Agent | `ta agent ...` | `create agent <name>`, `list agent`, `show agent <name>`, `check agent <name>`, `remove agent <name>`, `sync agent <name>` |
+| Runbook (*) | `ta runbook ...` | `list runbook`, `show runbook <name>`, `apply runbook <name>` |
+| Operations (*) | `ta operations ...` | `list operations` |
+| Audit (*) | `ta audit ...` | `list audit`, `show audit <goal-id>`, `check audit` |
+| Setup (*) | `ta setup ...` | `create setup`, `show setup`, `update setup <topic>`, `sync setup` |
+| Project (*) | `ta init ...` | `create project` |
+| Scaffold (*) | `ta new ...` | `create scaffold` |
+| Advisor (*) | `ta advisor ...` | `apply advisor "<message>"` |
+| Style (*) | `ta style ...` | `create style`, `show style`, `update style`, `remove style`, `check style`, `sync style <source>` |
+| Constitution (*) | `ta constitution ...` | `create constitution`, `show constitution`, `update constitution`, `check constitution` |
+| Memory (*) | `ta memory ...` | `create memory <key> <value>`, `list memory`, `show memory`, `check memory`, `sync memory` |
+| Adapter (*) | `ta adapter ...` | `create adapter <name>`, `list adapter`, `check adapter <type>`, `update adapter <plugin>` |
+| Release (*) | `ta release ...` | `apply release <version>`, `show release`, `create release`, `update release <key> <value>`, `check release <version>`, `sync release <tag>` |
+| Trigger / Intake (*) | `ta intake ...` | `list trigger`, `apply trigger <type>`, `show trigger` |
+| Stats (*) | `ta stats ...` | `list stats`, `show stats`, `sync stats` |
+| Meridian (*) | `ta meridian ...` | `create meridian`, `list meridian`, `check meridian` |
+| Tools (*) | `ta tools ...` | `list tools`, `create tools <name>` |
+| Manifest (*) | `ta manifest ...` | `create manifest`, `check manifest`, `show manifest [link]` |
+| Link (*) | `ta link ...` | `create link <target>`, `list link`, `check link`, `sync link [name]`, `remove link <name>` |
+| Policy (*) | `ta policy ...` | `check policy <draft-id>`, `show policy` |
+| Config (*) | `ta config ...` | `show config` |
+| Analysis (*) | `ta analysis ...` | `apply analysis` |
+| Compression (*) | `ta compression ...` | `show compression`, `create compression`, `remove compression` |
+| Webhook (*) | `ta webhook ...` | `check webhook <provider> <event>` |
+| PR | `ta pr ...` | none — `pr` is a deprecated, hidden alias of `draft`; use the `draft` noun above instead |
+
+That's all 42 noun-areas from `docs/design/ta-cli-verb-reference.md` §2
+accounted for: 18 fully mapped in v0.17.0.12.16, 23 more mapped in
+v0.17.0.12.22, and `pr` intentionally left unmapped (already superseded by
+`draft`). A handful of legacy actions per noun-area still have no verb+noun
+equivalent (e.g. `ta pr fix`, `ta constitution review`) — these keep working
+via their legacy form only; `ta <verb> <noun>` returns a clear error naming
+the supported verbs for that noun when you try an unmapped combination.
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -12926,7 +12926,7 @@ TA checks in order: `TA_MERIDIAN_BINARY` env var → `daemon.toml [meridian].bin
 ### Discovering available tools
 
 ```bash
-ta meridian help
+ta meridian tools
 ```
 
 Starts a short-lived `meridian serve` session, queries the MCP `tools/list` endpoint, and prints every tool name and description. Use this to see exactly which analytics are available as native tool calls inside a running goal — useful after upgrading Meridian to discover new capabilities.


### PR DESCRIPTION
## Summary
- Maps the remaining 23 noun-areas onto the 10-verb NOUN_TABLE, completing 12.16's 18/42 partial coverage to 42/42
- Curates a simple default `--help` view (~15 commands) with `--all` for the full surface, via a raw argv scan (avoids an id collision with `ta gc --all`/`ta audit drift --all`'s own unrelated flags)
- USAGE.md: complete old→new lookup table + help-split docs

Manually completed: `ta draft apply`'s shared-file conflict detection couldn't reconcile the draft's own stored version bump (12.22) against the current higher version (12.24, since 12.18-12.24 completed out of order ahead of this phase) — correct resolution is no version change, not expressible in that conflict path. Copied the 3 real content files directly from staging, independently re-verified full build/clippy/fmt/test before this PR.

## Test plan
- `./dev cargo build --workspace` — clean
- `./dev cargo clippy --workspace --all-targets -- -D warnings` — clean
- `./dev cargo fmt --all -- --check` — clean
- `./dev cargo test --workspace` — 0 failures