### PR TITLE
fix: redesign nightly releases around never-reused dated tags (immutable-releases-compatible)

### DIFF
--- a/.github/workflows/nightly-validate.yml
+++ b/.github/workflows/nightly-validate.yml
@@ -19,13 +19,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # Must match NIGHTLY_TAG in .github/workflows/nightly.yml. Renamed twice
-  # now ("nightly" -> "nightly-latest" -> "nightly-build") after each prior
-  # tag got permanently locked by GitHub's Immutable Releases feature -- see
-  # nightly.yml for the full incident note and the tracked follow-up.
-  NIGHTLY_TAG: nightly-build
-
 jobs:
   validate:
     name: Validate badges + nightly release
@@ -38,6 +31,26 @@ jobs:
           # Pin to the exact commit nightly.yml built, in case main advanced
           # between nightly running and this validation running.
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Resolve the newest nightly release
+        # nightly.yml (2026-07-13 redesign) creates a brand-new, never-reused
+        # dated release every run (nightly-YYYYMMDD-<shortsha>) instead of
+        # clobbering one stable tag -- immutable-releases-compatible by
+        # design, since nothing is ever re-edited. There is no fixed tag name
+        # to check anymore; find whichever nightly-* release is newest.
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(gh release list --repo "${{ github.repository }}" --limit 200 --json tagName,createdAt \
+            --jq '[.[] | select(.tagName | startswith("nightly-"))] | sort_by(.createdAt) | last | .tagName' 2>/dev/null || true)
+          if [ -z "$TAG" ]; then
+            echo "ERROR: no nightly-* release found via the GitHub API."
+            echo "  Run manually: gh release list --repo ${{ github.repository }}"
+            exit 1
+          fi
+          echo "Newest nightly release: $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Validate stable release badge renders
         run: |
@@ -67,6 +80,7 @@ jobs:
       - name: Validate nightly release is published (not draft)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NIGHTLY_TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           IS_DRAFT=$(gh api "repos/${{ github.repository }}/releases/tags/${NIGHTLY_TAG}" --jq '.draft' 2>/dev/null || echo "unknown")
           if [ "$IS_DRAFT" = "unknown" ]; then
@@ -76,10 +90,10 @@ jobs:
           fi
           if [ "$IS_DRAFT" = "true" ]; then
             echo "ERROR: $NIGHTLY_TAG release is still a draft — it is invisible to anonymous/public"
-            echo "  viewers (the badge and releases/tag/${NIGHTLY_TAG} link both 404 for them)."
-            echo "  Fix: check the 'Create or update nightly GitHub release' step in"
-            echo "  .github/workflows/nightly.yml — it must end with"
-            echo "  'gh release edit \$NIGHTLY_TAG --draft=false' after uploading assets."
+            echo "  viewers (releases/tag/${NIGHTLY_TAG} 404s for them). Each nightly.yml run"
+            echo "  creates a fresh release directly via 'gh release create ... artifacts/*',"
+            echo "  which publishes immediately -- this should not be reachable; check the"
+            echo "  'Create nightly GitHub release' step in nightly.yml for a regression."
             exit 1
           fi
           echo "OK: $NIGHTLY_TAG release is published (draft=false)."
@@ -87,6 +101,7 @@ jobs:
       - name: Validate nightly asset version matches workspace version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NIGHTLY_TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           CARGO_VER=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           echo "Workspace version (Cargo.toml, source of truth): $CARGO_VER"

--- a/.github/workflows/nightly-validate.yml
+++ b/.github/workflows/nightly-validate.yml
@@ -20,10 +20,11 @@ permissions:
   contents: read
 
 env:
-  # Must match NIGHTLY_TAG in .github/workflows/nightly.yml. Renamed from
-  # "nightly" (2026-07-08) after that tag got permanently locked by GitHub's
-  # Immutable Releases feature -- see nightly.yml for the full incident note.
-  NIGHTLY_TAG: nightly-latest
+  # Must match NIGHTLY_TAG in .github/workflows/nightly.yml. Renamed twice
+  # now ("nightly" -> "nightly-latest" -> "nightly-build") after each prior
+  # tag got permanently locked by GitHub's Immutable Releases feature -- see
+  # nightly.yml for the full incident note and the tracked follow-up.
+  NIGHTLY_TAG: nightly-build
 
 jobs:
   validate:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,17 +18,17 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   BINARY_NAME: ta
-  # Renamed from "nightly" (2026-07-08), then "nightly-latest" (2026-07-13):
-  # BOTH got permanently locked by GitHub's Immutable Releases feature, now
-  # GA for all repos as of 2025-10-28 -- publishing (un-drafting) a release
-  # makes it immutable unconditionally, so any single stable tag that gets
-  # its assets clobbered nightly will eventually hit this wall again. This
-  # rename is a temporary reprieve, not a real fix -- see PLAN.md /
-  # docs/design (or ask in the team channel) for the tracked follow-up to
-  # redesign this around per-run dated tags + a separately-mutable "latest
-  # nightly" pointer, which is immutable-releases-compatible by design.
-  # Do not reuse "nightly" or "nightly-latest".
-  NIGHTLY_TAG: nightly-build
+  # Per-run dated tags (nightly-YYYYMMDD-<shortsha>), never reused --
+  # immutable-releases-compatible by design. History: a single stable tag
+  # ("nightly", then "nightly-latest", then "nightly-build") got permanently
+  # locked by GitHub's Immutable Releases feature (GA for all repos since
+  # 2025-10-28: publishing/un-drafting a release makes it immutable
+  # unconditionally -- confirmed via GitHub's docs and community discussions,
+  # not a toggleable-away-the-symptom fix since the toggle itself is a real
+  # supply-chain protection, not something to disable). Never marked --latest
+  # (that slot must stay pointed at real stable releases); browse nightlies
+  # via the GitHub-native releases search instead of a fixed tag/URL — see
+  # README.md / docs/USAGE.md.
   NIGHTLY_HISTORY_LIMIT: 60
 
 jobs:
@@ -40,6 +40,7 @@ jobs:
       head_sha: ${{ steps.check.outputs.head_sha }}
       head_sha_short: ${{ steps.check.outputs.head_sha_short }}
       trigger_type: ${{ steps.check.outputs.trigger_type }}
+      nightly_tag: ${{ steps.check.outputs.nightly_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -54,6 +55,7 @@ jobs:
           HEAD_SHA_SHORT=$(git rev-parse --short HEAD)
           echo "head_sha=${HEAD_SHA}" >> $GITHUB_OUTPUT
           echo "head_sha_short=${HEAD_SHA_SHORT}" >> $GITHUB_OUTPUT
+          echo "nightly_tag=nightly-$(date -u +%Y%m%d)-${HEAD_SHA_SHORT}" >> $GITHUB_OUTPUT
 
           # Determine trigger type for history table
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -69,11 +71,15 @@ jobs:
             exit 0
           fi
 
-          # Download last-sha.txt from the existing nightly release (if any).
-          # On first ever run (no nightly release yet), proceed unconditionally.
+          # Find the most recent nightly-* release (dated tags, never reused --
+          # there is no single "the nightly release" to look up by fixed name
+          # anymore) and check its last-sha.txt asset against HEAD.
+          LATEST_NIGHTLY_TAG=$(gh release list --limit 200 --json tagName,createdAt \
+            --jq '[.[] | select(.tagName | startswith("nightly-"))] | sort_by(.createdAt) | last | .tagName' 2>/dev/null || true)
+
           LAST_SHA=""
-          if gh release view "$NIGHTLY_TAG" --json assets 2>/dev/null | grep -q 'last-sha.txt'; then
-            LAST_SHA=$(gh release download "$NIGHTLY_TAG" --pattern "last-sha.txt" --output - 2>/dev/null | tr -d '[:space:]') || true
+          if [ -n "$LATEST_NIGHTLY_TAG" ]; then
+            LAST_SHA=$(gh release download "$LATEST_NIGHTLY_TAG" --pattern "last-sha.txt" --output - 2>/dev/null | tr -d '[:space:]') || true
           fi
 
           if [ -z "$LAST_SHA" ]; then
@@ -341,6 +347,7 @@ jobs:
           HEAD_SHA: ${{ needs.check-for-changes.outputs.head_sha }}
           HEAD_SHA_SHORT: ${{ needs.check-for-changes.outputs.head_sha_short }}
           TRIGGER_TYPE: ${{ needs.check-for-changes.outputs.trigger_type }}
+          NIGHTLY_TAG: ${{ needs.check-for-changes.outputs.nightly_tag }}
           REPO: ${{ github.repository }}
         run: |
           BUILD_DATE=$(date -u +"%Y-%m-%d")
@@ -349,36 +356,27 @@ jobs:
           # Asset URL base for this nightly release
           ASSET_BASE="https://github.com/${REPO}/releases/download/${NIGHTLY_TAG}"
 
-          # New row for the history table
-          NEW_ROW="| ${BUILD_DATE} | [${HEAD_SHA_SHORT}](https://github.com/${REPO}/commit/${HEAD_SHA}) | ${TRIGGER_TYPE} | [Linux x86](${ASSET_BASE}/ta-nightly-x86_64-unknown-linux-musl.tar.gz) [Linux ARM](${ASSET_BASE}/ta-nightly-aarch64-unknown-linux-musl.tar.gz) [macOS Intel](${ASSET_BASE}/ta-nightly-x86_64-apple-darwin.tar.gz) [macOS ARM](${ASSET_BASE}/ta-nightly-aarch64-apple-darwin.tar.gz) [Windows MSI](${ASSET_BASE}/ta-nightly-x86_64-pc-windows-msvc.msi) [Windows zip](${ASSET_BASE}/ta-nightly-x86_64-pc-windows-msvc.zip) |"
-
-          # Fetch existing release body to extract and update the history table.
-          # On first run, start fresh.
-          EXISTING_BODY=""
-          if gh release view "$NIGHTLY_TAG" --json body 2>/dev/null | grep -q '"body"'; then
-            EXISTING_BODY=$(gh release view "$NIGHTLY_TAG" --json body --jq '.body')
-          fi
-
-          # Extract existing history rows (lines starting with "| 20") from the body.
-          HISTORY_ROWS=""
-          if [ -n "$EXISTING_BODY" ]; then
-            HISTORY_ROWS=$(echo "$EXISTING_BODY" | grep -E '^\| 20[0-9]{2}-' || true)
-          fi
-
-          # Prepend the new row, keep up to NIGHTLY_HISTORY_LIMIT rows.
-          ALL_ROWS="${NEW_ROW}"
-          if [ -n "$HISTORY_ROWS" ]; then
-            ALL_ROWS="$(printf '%s\n%s' "${NEW_ROW}" "${HISTORY_ROWS}")"
-          fi
-          # Trim to limit
-          ALL_ROWS=$(echo "$ALL_ROWS" | head -n "${NIGHTLY_HISTORY_LIMIT}")
-
           # Determine what's new since the last stable (non-prerelease) release.
           LAST_STABLE_TAG=$(gh release list --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || true)
           WHATS_NEW=""
           if [ -n "${LAST_STABLE_TAG}" ]; then
             WHATS_NEW=$(git log "${LAST_STABLE_TAG}..HEAD" --oneline --no-merges 2>/dev/null | head -30 || true)
           fi
+
+          # Recent nightly history, built directly from real past releases --
+          # each dated-tag release is a permanent object now (never reused/
+          # edited), so there's no need to hand-maintain a growing table
+          # inside one body string across runs the way the old single-tag
+          # design did. The release being created *this* run doesn't exist
+          # yet when this step runs, so prepend it manually.
+          THIS_ROW="| ${BUILD_DATE} | [${NIGHTLY_TAG}](https://github.com/${REPO}/releases/tag/${NIGHTLY_TAG}) |"
+          PAST_ROWS=$(gh release list --limit 200 --json tagName,createdAt \
+            --jq --arg repo "${REPO}" '
+              [.[] | select(.tagName | startswith("nightly-"))]
+              | sort_by(.createdAt) | reverse | .[0:14]
+              | .[] | "| \(.createdAt[0:10]) | [\(.tagName)](https://github.com/\($repo)/releases/tag/\(.tagName)) |"
+            ' 2>/dev/null || true)
+          HISTORY_ROWS="$(printf '%s\n%s' "${THIS_ROW}" "${PAST_ROWS}")"
 
           # Build the full release body (avoid heredoc — unindented content breaks YAML block scalars)
           {
@@ -387,7 +385,10 @@ jobs:
             printf '**Built**: %s (%s)\n' "${BUILD_TIMESTAMP}" "${TRIGGER_TYPE}"
             printf '**Branch**: main\n\n'
             printf '> This is an automated nightly pre-release built from the latest commit on `main`.\n'
-            printf '> For stable releases, see the [latest release](https://github.com/%s/releases/latest).\n\n' "${REPO}"
+            printf '> Each night gets its own permanent release (tags are never reused, so this\n'
+            printf '> page will always be here) -- browse all nightlies on the\n'
+            printf '> [nightly releases page](https://github.com/%s/releases?q=nightly&expanded=true),\n' "${REPO}"
+            printf '> or see the [latest stable release](https://github.com/%s/releases/latest) instead.\n\n' "${REPO}"
             printf '### Download\n\n'
             printf '| Platform | Archive | Installer |\n'
             printf '|----------|---------|------------|\n'
@@ -405,10 +406,10 @@ jobs:
               printf '```\n\n'
             fi
             printf '%s\n\n' '---'
-            printf '## Nightly History {#nightly-history}\n\n'
-            printf '| Date | Commit | Trigger | Downloads |\n'
-            printf '|------|--------|---------|------------|\n'
-            printf '%s\n' "${ALL_ROWS}"
+            printf '## Recent Nightly Builds {#nightly-history}\n\n'
+            printf '| Date | Release |\n'
+            printf '|------|--------|\n'
+            printf '%s\n' "${HISTORY_ROWS}"
           } > nightly-body.md
 
           echo "body_file=nightly-body.md" >> $GITHUB_OUTPUT
@@ -438,74 +439,64 @@ jobs:
           fi
           echo "All ${#REQUIRED[@]} required nightly artifacts present."
 
-      - name: Create or update nightly GitHub release
+      - name: Create nightly GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA_SHORT: ${{ needs.check-for-changes.outputs.head_sha_short }}
-          BUILD_DATE: ${{ env.BUILD_DATE }}
+          NIGHTLY_TAG: ${{ needs.check-for-changes.outputs.nightly_tag }}
         run: |
           BUILD_DATE=$(date -u +"%Y-%m-%d")
           RELEASE_TITLE="Nightly ${BUILD_DATE} (${HEAD_SHA_SHORT})"
 
-          # GitHub's "Immutable releases" restriction blocks replacing assets on a
-          # *published* release, but not on a draft one. The nightly release needs
-          # its assets clobbered on every run, so we do a draft -> upload -> publish
-          # dance: if a published nightly release exists from a previous run, flip
-          # it back to draft first so assets can be replaced, upload the new
-          # assets, then un-draft at the end.
+          # Every run creates a brand-new release under a never-reused dated
+          # tag (nightly-YYYYMMDD-<shortsha>) -- nothing is ever edited or
+          # re-uploaded to an existing release, so GitHub's Immutable Releases
+          # feature (unconditional GA for all repos since 2025-10-28: any
+          # published release becomes immutable, confirmed not a toggleable
+          # per-repo setting worth disabling since it's a real supply-chain
+          # protection) simply never applies. No draft/undraft dance needed --
+          # `gh release create` with assets attached publishes immediately.
           #
-          # Root cause of the nightly release staying stuck as draft forever: this
-          # workflow previously only ever called `--draft` and never un-set it —
-          # there was no publish step at all, not an auth/ID/ordering bug. A draft
-          # release is invisible to anonymous/public viewers (the badge and the
-          # `releases/tag/$NIGHTLY_TAG` link both 404 for non-collaborators), so it
-          # must be un-drafted after each successful run.
-          if [ "$(gh release view "$NIGHTLY_TAG" --json isDraft --jq '.isDraft' 2>/dev/null)" = "false" ]; then
-            echo "Existing $NIGHTLY_TAG release is published — reverting to draft so assets can be replaced..."
-            if ! gh release edit "$NIGHTLY_TAG" --draft; then
-              echo ""
-              echo "ERROR: could not revert '$NIGHTLY_TAG' back to draft. If this is a"
-              echo "'tag_name was used by an immutable release' error, the tag is"
-              echo "permanently locked by GitHub's Immutable Releases feature -- delete"
-              echo "and recreate is NOT a valid recovery (the lock survives tag deletion)."
-              echo "Fix: pick a new NIGHTLY_TAG value in .github/workflows/nightly.yml"
-              echo "and .github/workflows/nightly-validate.yml, and update README.md +"
-              echo "docs/USAGE.md's badge/download URLs to match."
-              exit 1
-            fi
-          fi
-
-          if gh release view "$NIGHTLY_TAG" 2>/dev/null; then
-            echo "Updating existing $NIGHTLY_TAG release..."
-            gh release edit "$NIGHTLY_TAG" \
-              --title "$RELEASE_TITLE" \
-              --notes-file nightly-body.md \
-              --prerelease \
-              --draft
-            # Replace all assets (clobber existing ones)
-            gh release upload "$NIGHTLY_TAG" artifacts/* --clobber
-          else
-            echo "Creating first $NIGHTLY_TAG release..."
-            gh release create "$NIGHTLY_TAG" \
-              --title "$RELEASE_TITLE" \
-              --notes-file nightly-body.md \
-              --prerelease \
-              --draft
-            gh release upload "$NIGHTLY_TAG" artifacts/* --clobber
-          fi
-
-          # Publish (un-draft) now that all assets are uploaded — this is the step
-          # that was missing before, leaving nightly permanently draft.
-          echo "Publishing $NIGHTLY_TAG release (un-drafting)..."
-          if ! gh release edit "$NIGHTLY_TAG" --draft=false; then
-            echo ""
-            echo "ERROR: could not publish '$NIGHTLY_TAG'. See the guidance above if this"
-            echo "is an immutable-release tag lock."
-            exit 1
-          fi
+          # --latest=false is deliberate: nightlies must never claim the
+          # repo's single "latest release" slot, which needs to stay pointed
+          # at the actual latest stable release for `/releases/latest` and
+          # `/releases/latest/download/...` to work correctly for users who
+          # want stable, not nightly, builds.
+          echo "Creating nightly release ${NIGHTLY_TAG}..."
+          gh release create "$NIGHTLY_TAG" \
+            --title "$RELEASE_TITLE" \
+            --notes-file nightly-body.md \
+            --prerelease \
+            --latest=false \
+            artifacts/*
 
           echo ""
           echo "Nightly release published:"
           echo "  Title: ${RELEASE_TITLE}"
           echo "  SHA: ${{ needs.check-for-changes.outputs.head_sha }}"
           echo "  URL: https://github.com/${{ github.repository }}/releases/tag/${NIGHTLY_TAG}"
+
+      - name: Clean up old nightly releases (retention)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Dated tags accumulate one new release per run forever unless
+          # pruned. Deletion (unlike editing/re-uploading assets) still works
+          # fine on immutable releases -- only in-place mutation is blocked --
+          # so this keeps working regardless of the immutable-releases toggle.
+          OLD_TAGS=$(gh release list --limit 500 --json tagName,createdAt \
+            --jq --argjson limit "${NIGHTLY_HISTORY_LIMIT}" '
+              [.[] | select(.tagName | startswith("nightly-"))]
+              | sort_by(.createdAt) | reverse | .[$limit:] | .[].tagName
+            ' 2>/dev/null || true)
+
+          if [ -n "$OLD_TAGS" ]; then
+            echo "Deleting nightly releases beyond the retention limit (${NIGHTLY_HISTORY_LIMIT}):"
+            echo "$OLD_TAGS" | while IFS= read -r tag; do
+              [ -z "$tag" ] && continue
+              echo "  - $tag"
+              gh release delete "$tag" --yes --cleanup-tag || echo "    (failed to delete $tag, continuing)"
+            done
+          else
+            echo "No old nightly releases to clean up (retention limit: ${NIGHTLY_HISTORY_LIMIT})."
+          fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,12 +18,17 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   BINARY_NAME: ta
-  # Renamed from "nightly" (2026-07-08): that tag got permanently locked by
-  # GitHub's Immutable Releases feature (GA 2025-10-28) -- once a release
-  # under a tag is published immutable, the tag name is blocked from reuse
-  # forever (422 "tag_name was used by an immutable release"), even after
-  # deleting the release and the tag. Do not reuse the old "nightly" tag name.
-  NIGHTLY_TAG: nightly-latest
+  # Renamed from "nightly" (2026-07-08), then "nightly-latest" (2026-07-13):
+  # BOTH got permanently locked by GitHub's Immutable Releases feature, now
+  # GA for all repos as of 2025-10-28 -- publishing (un-drafting) a release
+  # makes it immutable unconditionally, so any single stable tag that gets
+  # its assets clobbered nightly will eventually hit this wall again. This
+  # rename is a temporary reprieve, not a real fix -- see PLAN.md /
+  # docs/design (or ask in the team channel) for the tracked follow-up to
+  # redesign this around per-run dated tags + a separately-mutable "latest
+  # nightly" pointer, which is immutable-releases-compatible by design.
+  # Do not reuse "nightly" or "nightly-latest".
+  NIGHTLY_TAG: nightly-build
   NIGHTLY_HISTORY_LIMIT: 60
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/latest">
     <img src="https://img.shields.io/github/v/release/Trusted-Autonomy/TrustedAutonomy?label=stable&color=blue&display_name=tag" alt="Latest stable release">
   </a>
-  <a href="https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-build">
+  <a href="https://github.com/Trusted-Autonomy/TrustedAutonomy/releases?q=nightly&expanded=true">
     <img src="https://img.shields.io/badge/nightly-latest-orange" alt="Latest nightly build">
   </a>
   <img src="https://img.shields.io/badge/license-Apache--2.0-lightgrey" alt="License">
@@ -139,7 +139,7 @@ The two questions governance and orchestration each answer:
 | Channel | Version | Downloads |
 |---------|---------|-----------|
 | **Stable** | [![stable](https://img.shields.io/github/v/release/Trusted-Autonomy/TrustedAutonomy?label=&color=blue&display_name=tag)](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/latest) | [macOS · Linux · Windows](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/latest) |
-| **Nightly** | [![nightly](https://img.shields.io/badge/nightly-latest-orange)](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-build) | [macOS · Linux · Windows](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-build) · [History](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-build#nightly-history) |
+| **Nightly** | [![nightly](https://img.shields.io/badge/nightly-latest-orange)](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases?q=nightly&expanded=true) | [Browse all nightly builds](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases?q=nightly&expanded=true) (each build is its own dated release — see the newest one's "Recent Nightly Builds" section for history) |
 
 **Build from source:**
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/latest">
     <img src="https://img.shields.io/github/v/release/Trusted-Autonomy/TrustedAutonomy?label=stable&color=blue&display_name=tag" alt="Latest stable release">
   </a>
-  <a href="https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-latest">
+  <a href="https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-build">
     <img src="https://img.shields.io/badge/nightly-latest-orange" alt="Latest nightly build">
   </a>
   <img src="https://img.shields.io/badge/license-Apache--2.0-lightgrey" alt="License">
@@ -139,7 +139,7 @@ The two questions governance and orchestration each answer:
 | Channel | Version | Downloads |
 |---------|---------|-----------|
 | **Stable** | [![stable](https://img.shields.io/github/v/release/Trusted-Autonomy/TrustedAutonomy?label=&color=blue&display_name=tag)](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/latest) | [macOS · Linux · Windows](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/latest) |
-| **Nightly** | [![nightly](https://img.shields.io/badge/nightly-latest-orange)](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-latest) | [macOS · Linux · Windows](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-latest) · [History](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-latest#nightly-history) |
+| **Nightly** | [![nightly](https://img.shields.io/badge/nightly-latest-orange)](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-build) | [macOS · Linux · Windows](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-build) · [History](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-build#nightly-history) |
 
 **Build from source:**
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -546,17 +546,17 @@ Nightly pre-releases are built automatically from the latest commit on `main`. T
 
 ```bash
 # macOS (Apple Silicon) — nightly
-curl -LO https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/download/nightly-latest/ta-nightly-aarch64-apple-darwin.tar.gz
+curl -LO https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/download/nightly-build/ta-nightly-aarch64-apple-darwin.tar.gz
 tar xzf ta-nightly-aarch64-apple-darwin.tar.gz
 sudo cp ta ta-daemon /usr/local/bin/
 
 # Linux (x86_64) — nightly
-curl -LO https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/download/nightly-latest/ta-nightly-x86_64-unknown-linux-musl.tar.gz
+curl -LO https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/download/nightly-build/ta-nightly-x86_64-unknown-linux-musl.tar.gz
 tar xzf ta-nightly-x86_64-unknown-linux-musl.tar.gz
 sudo cp ta ta-daemon /usr/local/bin/
 ```
 
-Each nightly archive contains both `ta` and `ta-daemon`. See the [nightly release page](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-latest) for all platforms and the build history.
+Each nightly archive contains both `ta` and `ta-daemon`. See the [nightly release page](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-build) for all platforms and the build history.
 
 **Option D -- Docker** *(Coming Soon)*
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -542,21 +542,25 @@ ta draft apply <id>
 
 **Nightly builds**
 
-Nightly pre-releases are built automatically from the latest commit on `main`. They contain the newest features but are not stability-guaranteed.
+Nightly pre-releases are built automatically from the latest commit on `main`. They contain the newest features but are not stability-guaranteed. Each night's build is its own permanently-numbered release (`nightly-YYYYMMDD-<sha>`) rather than one fixed tag, so grab the newest one dynamically:
 
 ```bash
+# Resolve the newest nightly release tag via the GitHub API
+NIGHTLY_TAG=$(curl -sf https://api.github.com/repos/Trusted-Autonomy/TrustedAutonomy/releases \
+  | grep -o '"tag_name": *"nightly-[^"]*"' | head -1 | cut -d'"' -f4)
+
 # macOS (Apple Silicon) — nightly
-curl -LO https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/download/nightly-build/ta-nightly-aarch64-apple-darwin.tar.gz
+curl -LO "https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/download/${NIGHTLY_TAG}/ta-nightly-aarch64-apple-darwin.tar.gz"
 tar xzf ta-nightly-aarch64-apple-darwin.tar.gz
 sudo cp ta ta-daemon /usr/local/bin/
 
 # Linux (x86_64) — nightly
-curl -LO https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/download/nightly-build/ta-nightly-x86_64-unknown-linux-musl.tar.gz
+curl -LO "https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/download/${NIGHTLY_TAG}/ta-nightly-x86_64-unknown-linux-musl.tar.gz"
 tar xzf ta-nightly-x86_64-unknown-linux-musl.tar.gz
 sudo cp ta ta-daemon /usr/local/bin/
 ```
 
-Each nightly archive contains both `ta` and `ta-daemon`. See the [nightly release page](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases/tag/nightly-build) for all platforms and the build history.
+Each nightly archive contains both `ta` and `ta-daemon`. Browse all nightly builds (and each build's own build-history table) on the [nightly releases page](https://github.com/Trusted-Autonomy/TrustedAutonomy/releases?q=nightly&expanded=true).
 
 **Option D -- Docker** *(Coming Soon)*
 


### PR DESCRIPTION
## Summary
The previous fix (renaming `nightly-latest` → `nightly-build`) was only ever a one-cycle reprieve. Confirmed via GitHub's own docs and community discussions: publishing/un-drafting **any** release makes it immutable unconditionally (GA for all repos since 2025-10-28), with no prerelease exemption — GitHub staff explicitly rejected adding one, citing supply-chain-attack risk for exactly this kind of rolling-release pattern. Disabling the repo's immutable-releases toggle would "fix" this but is a real security downgrade for a project distributing executables — not done.

## The real fix
- **Every nightly run creates a brand-new release** under a tag encoding date + short SHA (`nightly-YYYYMMDD-<sha>`), never reused — nothing is ever re-edited, so immutability simply never applies. No draft/undraft dance needed at all.
- **Never marked `--latest`** — GitHub's single repo-wide "latest release" slot stays correctly pointed at real stable releases, not overshadowed by rolling nightly builds.
- **Retention**: deletes releases beyond the existing 60-release limit — confirmed deletion still works fine on immutable releases, only in-place mutation is blocked.
- **History table** rebuilt from real release metadata each run instead of hand-parsing a growing body string across edits to one release.
- **README/USAGE.md**: replaced fixed-tag badge/download links with GitHub's native releases search (`releases?q=nightly`, timeless, no custom infrastructure) plus a small dynamic one-liner for direct-download scripts.
- **nightly-validate.yml**: resolves the newest `nightly-*` release via the API instead of checking a fixed tag name.

## Test plan
- Both workflow files validated as syntactically correct YAML.
- jq filter/sort/slice logic verified against sample data (Python-simulated, since `jq` isn't available in this local shell) — confirmed newest-tag resolution, history ordering, and retention slicing all behave correctly.
- Will be confirmed by tonight's scheduled nightly run once merged.