### PR TITLE
v0.17.0.12.23 — Advisor-Driven Goal Creation: Natural-Language Intent + Clarification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,6 +3607,7 @@ dependencies = [
  "ta-goal",
  "ta-intake",
  "ta-session",
+ "ta-workflow",
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",

--- a/PLAN.md
+++ b/PLAN.md
@@ -9565,18 +9565,18 @@ Each phase: `ta run --headless --phase X` → draft → `agent_review` → if Ap
 
 ---
 ### v0.17.0.12.23 — Advisor-Driven Goal Creation: Natural-Language Intent + Clarification
-<!-- status: in_progress -->
+<!-- status: done -->
 **Depends on**: v0.17.0.12.19 (`ta-intake`), v0.17.0.12.20 (`ta-brain`)
 
 **Goal**: Two intent-handling systems exist today and don't talk to each other — `ta-workflow::intent::resolve_intent` (confidence-gated matching against known workflow *templates*, with real clarifying questions, but only reachable from `ta workflow` commands) and `ta-brain::classify`/`route` (resolves team/persona/security/priority, but requires an already-structured title/objective — it never parses raw free text itself). Neither is exposed as "hand the Advisor a sentence and get a routed goal." Unify them so a general user can do exactly that, with a real clarification question asked when confidence is low — reusing the existing `ta_ask_human`-backed headless-agent mechanism already built for draft-review conversations (`ta-session::advisor_agent::spawn_advisor_agent`) rather than building a new conversational loop from scratch.
 
 **Items**:
-1. [ ] Extend the free-text entry point to parse a raw prompt into title/objective/hints via the existing advisor-agent headless-conversation mechanism (not a new NLU component), then feed the result into `ta_brain::route()` exactly as it consumes structured requests today.
-2. [ ] Replace `ta-advisor::coordinator`'s binary `auto_eligible`/`needs_review` split with a third outcome, `needs_clarification`, that fires an actual `ta_ask_human` question (not just a flag for later human review) when routing confidence is low.
-3. [ ] New entry point (CLI verb+noun from 12.22, and/or MCP tool) that runs this pipeline end-to-end: high confidence creates the routed goal directly; low confidence asks one clarifying question first, then re-routes with the answer.
-4. [ ] Fold `ta-workflow::intent::resolve_intent`'s workflow-template matching in as one signal `ta-brain::route()` consults, rather than a second, parallel intent system.
-5. [ ] Tests: high-confidence prompt routes and creates a goal with zero clarification; low-confidence prompt triggers exactly one clarifying question and re-routes correctly after the answer.
-6. [ ] USAGE.md: document the "just tell TA what you want" entry point alongside the explicit CLI verb+noun surface from 12.16/12.22.
+1. [x] Extend the free-text entry point to parse a raw prompt into title/objective/hints via the existing advisor-agent headless-conversation mechanism (not a new NLU component), then feed the result into `ta_brain::route()` exactly as it consumes structured requests today.
+2. [x] Replace `ta-advisor::coordinator`'s binary `auto_eligible`/`needs_review` split with a third outcome, `needs_clarification`, that fires an actual `ta_ask_human` question (not just a flag for later human review) when routing confidence is low.
+3. [x] New entry point (CLI verb+noun from 12.22, and/or MCP tool) that runs this pipeline end-to-end: high confidence creates the routed goal directly; low confidence asks one clarifying question first, then re-routes with the answer.
+4. [x] Fold `ta-workflow::intent::resolve_intent`'s workflow-template matching in as one signal `ta-brain::route()` consults, rather than a second, parallel intent system.
+5. [x] Tests: high-confidence prompt routes and creates a goal with zero clarification; low-confidence prompt triggers exactly one clarifying question and re-routes correctly after the answer.
+6. [x] USAGE.md: document the "just tell TA what you want" entry point alongside the explicit CLI verb+noun surface from 12.16/12.22.
 
 #### Version: `0.17.0-alpha.12.23`
 

--- a/apps/ta-cli/src/commands/advisor.rs
+++ b/apps/ta-cli/src/commands/advisor.rs
@@ -4,6 +4,7 @@
 //   ta advisor ask "<message>"                  — classify intent and print numbered option card
 //   ta advisor advise "<message>"               — inject a mid-run note to the active goal
 //   ta advisor advise --goal <id> "<message>"   — target a specific goal
+//   ta advisor create "<prompt>"                — route a free-text prompt to a goal (v0.17.0.12.23)
 //
 // The advisor classifies your input, returns a numbered menu of actions, and
 // accepts a number from stdin to confirm. Security level is read from daemon
@@ -14,6 +15,7 @@
 // In auto mode:      high-confidence (≥80%) goals fire automatically.
 
 use std::io::{self, BufRead, Write};
+use std::time::Duration;
 
 use clap::Subcommand;
 use ta_goal::{GoalRunState, GoalRunStore};
@@ -69,6 +71,37 @@ pub enum AdvisorCommands {
         #[arg(long)]
         goal: Option<String>,
     },
+
+    /// Turn a natural-language prompt directly into a routed goal (v0.17.0.12.23).
+    ///
+    /// Routes the raw prompt through `ta-brain::route()` exactly as an
+    /// explicit `ta run` invocation is. If workload-classification confidence
+    /// is high, the goal is created (or, at read_only/suggest security,
+    /// printed as a copyable `ta run` command) with zero clarification. If
+    /// confidence is low, asks exactly one clarifying question — via the
+    /// same `ta_ask_human`-backed headless-agent mechanism used for
+    /// draft-review conversations — then re-routes with the answer.
+    ///
+    /// Examples:
+    ///   ta advisor create "also clean up the flaky login test"
+    ///   ta advisor create "fix the auth bypass" --security auto
+    ///   ta advisor create "improve onboarding" --no-input --json
+    Create {
+        /// The free-text description of what you want done.
+        prompt: String,
+        /// Security tier override fed into routing (read_only/suggest/auto).
+        /// Defaults to whatever `route()` resolves from `.ta/workflow.toml`
+        /// / `.ta/team.toml`.
+        #[arg(long)]
+        security: Option<String>,
+        /// Skip the clarifying question (accept low-confidence routing as-is)
+        /// and skip the suggest-tier run confirmation prompt.
+        #[arg(long)]
+        no_input: bool,
+        /// Output the routing result as JSON instead of creating/printing a goal.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub fn execute(cmd: &AdvisorCommands, config: &GatewayConfig) -> anyhow::Result<()> {
@@ -90,6 +123,12 @@ pub fn execute(cmd: &AdvisorCommands, config: &GatewayConfig) -> anyhow::Result<
             *json,
         ),
         AdvisorCommands::Advise { message, goal } => advise(config, message, goal.as_deref()),
+        AdvisorCommands::Create {
+            prompt,
+            security,
+            no_input,
+            json,
+        } => create(config, prompt, security.as_deref(), *no_input, *json),
     }
 }
 
@@ -248,6 +287,220 @@ pub fn advise(
     println!("Delivery:  {}", delivery);
 
     Ok(())
+}
+
+/// Clarifier that asks its one question via the real headless-agent
+/// mechanism: spawns a short-lived `ta run --headless` clarification agent
+/// (`ta_session::intent_agent`) that calls `ta_ask_human`, then polls for
+/// the answer file it writes.
+struct HeadlessClarifier<'a> {
+    workspace_root: &'a std::path::Path,
+    raw_prompt: String,
+}
+
+impl ta_advisor::Clarifier for HeadlessClarifier<'_> {
+    fn ask(&self, question: &str, _decision: &ta_brain::RoutingDecision) -> Option<String> {
+        let ta_bin = match std::env::current_exe() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!(
+                    "Could not resolve the `ta` binary path to ask a clarifying question: {}. \
+                           Skipping clarification and routing with the original prompt.",
+                    e
+                );
+                return None;
+            }
+        };
+
+        let intent_config = ta_session::IntentAgentConfig::new(
+            self.workspace_root.to_path_buf(),
+            self.raw_prompt.clone(),
+            question.to_string(),
+        )
+        .with_timeout(Duration::from_secs(600));
+
+        println!("\nAdvisor needs to ask a clarifying question:");
+        println!("  {}", question);
+
+        if let Err(e) = ta_session::spawn_intent_agent(&intent_config, &ta_bin) {
+            eprintln!(
+                "Failed to spawn the clarification agent: {}. \
+                 Routing with the original prompt instead.",
+                e
+            );
+            return None;
+        }
+
+        match ta_session::poll_intent_answer(
+            self.workspace_root,
+            intent_config.item_id,
+            intent_config.timeout,
+            Duration::from_secs(1),
+        ) {
+            ta_session::IntentAgentOutcome::Answered(answer) => Some(answer),
+            ta_session::IntentAgentOutcome::TimedOut => {
+                eprintln!(
+                    "Clarifying question timed out after {}s. \
+                     Routing with the original prompt instead.",
+                    intent_config.timeout.as_secs()
+                );
+                None
+            }
+        }
+    }
+}
+
+/// `ta advisor create "<prompt>"` — advisor-driven goal creation (v0.17.0.12.23):
+/// turn a raw natural-language prompt into a routed goal, asking at most one
+/// clarifying question when routing confidence is low.
+fn create(
+    config: &GatewayConfig,
+    prompt: &str,
+    security_override: Option<&str>,
+    no_input: bool,
+    json_output: bool,
+) -> anyhow::Result<()> {
+    let prompt = prompt.trim();
+    if prompt.is_empty() {
+        anyhow::bail!(
+            "Prompt cannot be empty. Provide a natural-language description of the goal, \
+             e.g. `ta advisor create \"fix the flaky login test\"`."
+        );
+    }
+
+    let no_op_clarifier = ta_advisor::NoClarification;
+    let headless_clarifier = HeadlessClarifier {
+        workspace_root: &config.workspace_root,
+        raw_prompt: prompt.to_string(),
+    };
+    let clarifier: &dyn ta_advisor::Clarifier = if no_input {
+        &no_op_clarifier
+    } else {
+        &headless_clarifier
+    };
+
+    let result = ta_advisor::run_pipeline_with_security(
+        prompt,
+        &config.workspace_root,
+        clarifier,
+        security_override,
+    );
+
+    if json_output {
+        #[derive(serde::Serialize)]
+        struct CreateOutput<'a> {
+            goal_title: &'a str,
+            objective: &'a str,
+            decision: &'a ta_brain::RoutingDecision,
+            clarified: bool,
+            clarification_answer: &'a Option<String>,
+        }
+        let out = CreateOutput {
+            goal_title: &result.goal_title,
+            objective: &result.objective,
+            decision: &result.decision,
+            clarified: result.clarified,
+            clarification_answer: &result.clarification_answer,
+        };
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out)
+                .unwrap_or_else(|e| format!("{{\"error\":\"{}\"}}", e))
+        );
+        return Ok(());
+    }
+
+    print_pipeline_result(&result);
+
+    let run_args = goal_run_args(&result);
+    match result.decision.security_tier {
+        AdvisorSecurity::Auto => {
+            println!("\nAuto-firing (security=auto, confidence sufficient):");
+            println!("  ta {}", run_args.join(" "));
+            run_ta_command(
+                config,
+                &run_args.iter().map(String::as_str).collect::<Vec<_>>(),
+            )
+        }
+        AdvisorSecurity::Suggest => {
+            println!("\nRun this now?");
+            println!("  ta {}", run_args.join(" "));
+            if no_input {
+                println!("(suggest mode, --no-input — not running automatically)");
+                return Ok(());
+            }
+            print!("Run this now? [y/N]: ");
+            io::stdout().flush()?;
+            let mut line = String::new();
+            io::stdin().lock().read_line(&mut line)?;
+            if line.trim().eq_ignore_ascii_case("y") {
+                run_ta_command(
+                    config,
+                    &run_args.iter().map(String::as_str).collect::<Vec<_>>(),
+                )
+            } else {
+                println!("Not run.");
+                Ok(())
+            }
+        }
+        AdvisorSecurity::ReadOnly => {
+            println!("\n(read_only mode — copy and run manually)");
+            println!("  ta {}", run_args.join(" "));
+            let _ = copy_to_clipboard(&format!("ta {}", run_args.join(" ")));
+            Ok(())
+        }
+    }
+}
+
+/// Print the routing summary (team/persona/agent/security/priority/workload)
+/// and, if a clarifying question was asked, the Q&A — Observable & Actionable.
+fn print_pipeline_result(result: &ta_advisor::PipelineResult) {
+    let decision = &result.decision;
+    println!(
+        "[routing] team={} persona={} agent={} security={} priority={} workload={} ({:.0}% confidence)",
+        decision.team,
+        decision.persona.as_deref().unwrap_or("-"),
+        decision.agent,
+        decision.security_tier,
+        decision.priority,
+        decision.workload_type,
+        decision.workload_confidence * 100.0
+    );
+    if let Some(template) = &decision.resolved_workflow_template {
+        println!("[routing] matched workflow template: {}", template);
+    }
+    if result.clarified {
+        println!(
+            "[clarified] answer: {}",
+            result.clarification_answer.as_deref().unwrap_or("")
+        );
+    }
+}
+
+/// Build the `ta run ...` argv for the routed goal — `--headless` since this
+/// entry point is meant to fire directly, not launch an interactive session.
+fn goal_run_args(result: &ta_advisor::PipelineResult) -> Vec<String> {
+    let decision = &result.decision;
+    let mut args = vec![
+        "run".to_string(),
+        result.objective.clone(),
+        "--headless".to_string(),
+        "--agent".to_string(),
+        decision.agent.clone(),
+        "--team".to_string(),
+        decision.team.to_string(),
+        "--security".to_string(),
+        decision.security_tier.to_string(),
+        "--priority".to_string(),
+        decision.priority.to_string(),
+        "--workload".to_string(),
+        decision.workload_type.clone(),
+    ];
+    if let Some(persona) = &decision.persona {
+        args.push("--persona".to_string());
+        args.push(persona.clone());
+    }
+    args
 }
 
 /// Resolve the target goal for injection.

--- a/apps/ta-cli/src/commands/intake.rs
+++ b/apps/ta-cli/src/commands/intake.rs
@@ -389,8 +389,12 @@ fn execute_routed_goal(
 ///
 /// Without `--dispatch`: read-only, prints recommendations + rationale only.
 /// With `--dispatch`: dispatches (creates a goal for, then dequeues) every
-/// recommendation whose resolved `security_tier` is `Auto`; everything else
-/// is left in the queue for a human to review/promote via `ta intake fire`.
+/// `AutoEligible` recommendation. `NeedsClarification` recommendations
+/// (v0.17.0.12.23) get exactly one clarifying question first — via the same
+/// `ta_ask_human`-backed headless-agent mechanism `ta advisor create` uses —
+/// then are dispatched if the re-routed decision clears `Auto`, or left in
+/// the queue otherwise. `NeedsReview` recommendations are always left in the
+/// queue for a human to review/promote via `ta intake fire`.
 fn coordinate(project_root: &Path, dispatch: bool) -> anyhow::Result<()> {
     let report = ta_advisor::build_report(project_root);
     if report.recommendations.is_empty() {
@@ -408,33 +412,120 @@ fn coordinate(project_root: &Path, dispatch: bool) -> anyhow::Result<()> {
     for rec in &report.recommendations {
         print_routing_decision(&rec.decision);
         println!(
-            "  event: \"{}\" (auto_dispatch_eligible={})",
-            rec.event.suggested_goal_title, rec.auto_dispatch_eligible
+            "  event: \"{}\" (outcome={:?})",
+            rec.event.suggested_goal_title, rec.outcome
         );
     }
 
     if !dispatch {
         println!(
-            "\n(read-only — pass --dispatch to create goals for auto_dispatch_eligible=true \
-             recommendations; everything else needs `ta intake fire` or manual promotion)"
+            "\n(read-only — pass --dispatch to create goals for auto-eligible recommendations; \
+             needs-clarification recommendations get one clarifying question first; \
+             everything else needs `ta intake fire` or manual promotion)"
         );
         return Ok(());
     }
 
     let mut remaining = Vec::new();
     for rec in report.recommendations {
-        if rec.auto_dispatch_eligible {
-            execute_routed_goal(&rec.event, &rec.decision)?;
-        } else {
-            println!(
-                "  left in queue: \"{}\" (security_tier={} — needs human review)",
-                rec.event.suggested_goal_title, rec.decision.security_tier
-            );
-            remaining.push(rec.event);
+        match rec.outcome {
+            ta_advisor::RecommendationOutcome::AutoEligible => {
+                execute_routed_goal(&rec.event, &rec.decision)?;
+            }
+            ta_advisor::RecommendationOutcome::NeedsReview => {
+                println!(
+                    "  left in queue: \"{}\" (security_tier={} — needs human review)",
+                    rec.event.suggested_goal_title, rec.decision.security_tier
+                );
+                remaining.push(rec.event);
+            }
+            ta_advisor::RecommendationOutcome::NeedsClarification => {
+                match clarify_and_reroute(project_root, &rec.event, &rec.decision) {
+                    Some((clarified_event, clarified_decision)) => {
+                        if clarified_decision.security_tier
+                            == ta_session::workflow_session::AdvisorSecurity::Auto
+                        {
+                            execute_routed_goal(&clarified_event, &clarified_decision)?;
+                        } else {
+                            println!(
+                                "  left in queue after clarification: \"{}\" (security_tier={} \
+                                 — needs human review)",
+                                clarified_event.suggested_goal_title,
+                                clarified_decision.security_tier
+                            );
+                            remaining.push(clarified_event);
+                        }
+                    }
+                    None => {
+                        println!(
+                            "  left in queue: \"{}\" (no clarification answer — needs human review)",
+                            rec.event.suggested_goal_title
+                        );
+                        remaining.push(rec.event);
+                    }
+                }
+            }
         }
     }
     ta_intake::write_queue(project_root, &remaining)?;
     Ok(())
+}
+
+/// Ask exactly one clarifying question for a low-confidence queued event,
+/// via the same headless-agent mechanism `ta advisor create` uses, and
+/// re-route with the answer folded into the event's suggested title.
+///
+/// Returns `None` (leave the original event queued, unmodified) when the
+/// clarification agent fails to spawn or times out — Observable & Actionable
+/// callers print why before falling back.
+fn clarify_and_reroute(
+    project_root: &Path,
+    event: &TriggerEvent,
+    decision: &ta_brain::RoutingDecision,
+) -> Option<(TriggerEvent, ta_brain::RoutingDecision)> {
+    let ta_bin = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("ta"));
+    let question = ta_advisor::clarifying_question(decision);
+    println!(
+        "  clarifying: \"{}\" — {}",
+        event.suggested_goal_title, question
+    );
+
+    let intent_config = ta_session::IntentAgentConfig::new(
+        project_root.to_path_buf(),
+        event.suggested_goal_title.clone(),
+        question,
+    );
+    if let Err(e) = ta_session::spawn_intent_agent(&intent_config, &ta_bin) {
+        eprintln!("  Failed to spawn clarification agent: {}", e);
+        return None;
+    }
+
+    let answer = match ta_session::poll_intent_answer(
+        project_root,
+        intent_config.item_id,
+        intent_config.timeout,
+        std::time::Duration::from_secs(1),
+    ) {
+        ta_session::IntentAgentOutcome::Answered(answer) => answer,
+        ta_session::IntentAgentOutcome::TimedOut => {
+            eprintln!(
+                "  Clarifying question timed out after {}s.",
+                intent_config.timeout.as_secs()
+            );
+            return None;
+        }
+    };
+
+    let mut clarified_event = event.clone();
+    clarified_event.suggested_goal_title =
+        format!("{} {}", event.suggested_goal_title, answer.trim());
+    let re_decision = ta_brain::route(
+        &ta_brain::RoutingInput::Trigger(ta_brain::TriggerRoutingInput::from_event(
+            clarified_event.clone(),
+        )),
+        project_root,
+    );
+    Some((clarified_event, re_decision))
 }
 
 fn show_queue(project_root: &Path) -> anyhow::Result<()> {

--- a/crates/ta-advisor/src/coordinator.rs
+++ b/crates/ta-advisor/src/coordinator.rs
@@ -32,16 +32,47 @@ use ta_brain::{prioritize, RoutingDecision};
 use ta_intake::TriggerEvent;
 use ta_session::workflow_session::AdvisorSecurity;
 
+use crate::classify::AMBIGUOUS_CONFIDENCE_THRESHOLD;
+
+/// What the coordinator recommends doing with one queued event.
+///
+/// Replaces the earlier binary `auto_dispatch_eligible: bool` split
+/// (v0.17.0.12.20) with a third outcome (v0.17.0.12.23): a routing decision
+/// this low-confidence isn't safe to either fire automatically *or* silently
+/// queue for later human review — it should ask a real clarifying question
+/// now, the same `ta_ask_human`-backed mechanism `ta-advisor::pipeline` uses
+/// for the free-text goal-creation entry point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecommendationOutcome {
+    /// `decision.security_tier == AdvisorSecurity::Auto` at sufficient
+    /// workload-classification confidence — the coordinator may dispatch
+    /// this one without further human review.
+    AutoEligible,
+    /// Confidently classified, but not at `Auto` security — needs a human
+    /// to review and promote via `ta intake fire`.
+    NeedsReview,
+    /// Workload-classification confidence is below
+    /// `AMBIGUOUS_CONFIDENCE_THRESHOLD` — too low to trust either an
+    /// autonomous dispatch or a silent "needs review" queue entry; the
+    /// caller should fire a clarifying question before doing anything else.
+    NeedsClarification,
+}
+
 /// One queued event, routed and ranked.
 #[derive(Debug, Clone)]
 pub struct CoordinatorRecommendation {
     pub event: TriggerEvent,
     pub decision: RoutingDecision,
-    /// `true` when `decision.security_tier == AdvisorSecurity::Auto` — the
-    /// coordinator may dispatch this one without further human review, the
-    /// same meaning `AdvisorSecurity::Auto` already carries for the
-    /// Advisor's other capabilities.
-    pub auto_dispatch_eligible: bool,
+    pub outcome: RecommendationOutcome,
+}
+
+impl CoordinatorRecommendation {
+    /// `true` when `outcome == RecommendationOutcome::AutoEligible` — kept
+    /// as a convenience accessor for callers that only care about the
+    /// auto-dispatch bit, mirroring the field this replaces.
+    pub fn auto_dispatch_eligible(&self) -> bool {
+        self.outcome == RecommendationOutcome::AutoEligible
+    }
 }
 
 /// A priority-ordered set of recommendations for `.ta/intake-queue.jsonl`'s
@@ -56,34 +87,50 @@ impl CoordinationReport {
     pub fn auto_eligible(&self) -> impl Iterator<Item = &CoordinatorRecommendation> {
         self.recommendations
             .iter()
-            .filter(|r| r.auto_dispatch_eligible)
+            .filter(|r| r.outcome == RecommendationOutcome::AutoEligible)
     }
 
     pub fn needs_review(&self) -> impl Iterator<Item = &CoordinatorRecommendation> {
         self.recommendations
             .iter()
-            .filter(|r| !r.auto_dispatch_eligible)
+            .filter(|r| r.outcome == RecommendationOutcome::NeedsReview)
+    }
+
+    pub fn needs_clarification(&self) -> impl Iterator<Item = &CoordinatorRecommendation> {
+        self.recommendations
+            .iter()
+            .filter(|r| r.outcome == RecommendationOutcome::NeedsClarification)
     }
 }
 
 /// Build a coordination report from the current `.ta/intake-queue.jsonl`
 /// contents, read-only (Observable, no side effects — see module docs for
-/// why dispatch is a separate, caller-owned step).
+/// why dispatch/clarification are separate, caller-owned steps).
 pub fn build_report(project_root: &Path) -> CoordinationReport {
     let events = ta_intake::read_queue(project_root);
     let routed = prioritize(&events, project_root);
     let recommendations = routed
         .into_iter()
         .map(|(event, decision)| {
-            let auto_dispatch_eligible = decision.security_tier == AdvisorSecurity::Auto;
+            let outcome = classify_outcome(&decision);
             CoordinatorRecommendation {
                 event,
                 decision,
-                auto_dispatch_eligible,
+                outcome,
             }
         })
         .collect();
     CoordinationReport { recommendations }
+}
+
+fn classify_outcome(decision: &RoutingDecision) -> RecommendationOutcome {
+    if decision.workload_confidence < AMBIGUOUS_CONFIDENCE_THRESHOLD {
+        RecommendationOutcome::NeedsClarification
+    } else if decision.security_tier == AdvisorSecurity::Auto {
+        RecommendationOutcome::AutoEligible
+    } else {
+        RecommendationOutcome::NeedsReview
+    }
 }
 
 #[cfg(test)]
@@ -135,5 +182,37 @@ mod tests {
         // classification both clear the auto-eligibility confidence gate.
         assert_eq!(report.auto_eligible().count(), 2);
         assert_eq!(report.needs_review().count(), 0);
+        assert_eq!(report.needs_clarification().count(), 0);
+        assert!(report
+            .recommendations
+            .iter()
+            .all(|r| r.outcome == RecommendationOutcome::AutoEligible));
+        assert!(report
+            .recommendations
+            .iter()
+            .all(|r| r.auto_dispatch_eligible()));
+    }
+
+    /// v0.17.0.12.23: a low-confidence event must not be silently folded
+    /// into `needs_review` — it needs its own `needs_clarification` outcome
+    /// so the caller knows to ask a real question rather than just queueing
+    /// it for a human to eventually notice.
+    #[test]
+    fn low_confidence_event_needs_clarification() {
+        let tmp = tempfile::tempdir().unwrap();
+        // "xyzzy plugh" classifies as "other" at 0.3 confidence — below the
+        // 0.65 threshold — regardless of default security tier.
+        write_queued_event(tmp.path(), "xyzzy plugh");
+
+        let report = build_report(tmp.path());
+        assert_eq!(report.recommendations.len(), 1);
+        assert_eq!(
+            report.recommendations[0].outcome,
+            RecommendationOutcome::NeedsClarification
+        );
+        assert_eq!(report.needs_clarification().count(), 1);
+        assert_eq!(report.auto_eligible().count(), 0);
+        assert_eq!(report.needs_review().count(), 0);
+        assert!(!report.recommendations[0].auto_dispatch_eligible());
     }
 }

--- a/crates/ta-advisor/src/lib.rs
+++ b/crates/ta-advisor/src/lib.rs
@@ -10,10 +10,17 @@
 
 pub mod classify;
 pub mod coordinator;
+pub mod pipeline;
 
 pub use classify::{
     build_confirmation_card, classify as classify_advisor_intent, next_clarify_step,
     AdvisorClassification, AdvisorIntent, ClarifyOutcome, ClarifyState, ConfirmationCard,
     DraftActionKind, AMBIGUOUS_CONFIDENCE_THRESHOLD, MAX_CLARIFY_ROUNDS,
 };
-pub use coordinator::{build_report, CoordinationReport, CoordinatorRecommendation};
+pub use coordinator::{
+    build_report, CoordinationReport, CoordinatorRecommendation, RecommendationOutcome,
+};
+pub use pipeline::{
+    clarifying_question, run_pipeline, run_pipeline_with_security, Clarifier, NoClarification,
+    PipelineResult,
+};

--- a/crates/ta-advisor/src/pipeline.rs
+++ b/crates/ta-advisor/src/pipeline.rs
@@ -1,0 +1,259 @@
+//! Advisor-driven goal creation (v0.17.0.12.23): turn a raw natural-language
+//! prompt into a routed goal request, asking at most one clarifying question
+//! when routing confidence is low.
+//!
+//! Unifies the two intent-handling systems that didn't previously talk to
+//! each other: `ta_brain::route()` (confident once given a structured
+//! title/objective, but never parses raw free text itself) and the
+//! confidence-gated clarification pattern `ta-workflow::intent::resolve_intent`
+//! already modeled for workflow templates (now folded into `route()` itself
+//! as one signal — see `ta_brain::route::resolve_workflow_template` —
+//! rather than reimplemented here as a second system).
+//!
+//! A raw prompt needs no separate NLU step to become a structured request:
+//! `ta_brain::ExplicitGoalRequest` already accepts a free-text title/objective
+//! and classifies workload from it. The only genuinely new behavior this
+//! phase adds is *asking a real clarifying question* when that classification
+//! is low-confidence, instead of silently guessing or requiring a human to
+//! review afterward — reusing the existing `ta_ask_human`-backed
+//! headless-agent mechanism (`ta_session::intent_agent`) built for exactly
+//! this kind of one-shot conversational round-trip, rather than a new
+//! conversational loop.
+
+use std::path::Path;
+
+use ta_brain::{route, ExplicitGoalRequest, RoutingDecision, RoutingInput};
+
+use crate::classify::AMBIGUOUS_CONFIDENCE_THRESHOLD;
+
+/// Ask the human exactly one clarifying question and return their answer
+/// (or `None` if they didn't answer / clarification was skipped).
+///
+/// Implemented in production by spawning the headless clarification agent
+/// (`ta_session::intent_agent::spawn_intent_agent` + `poll_intent_answer`,
+/// which calls `ta_ask_human` under the hood). Tests inject a fake to avoid
+/// spawning a real agent subprocess — see `run_pipeline`'s tests below.
+pub trait Clarifier {
+    fn ask(&self, question: &str, decision: &RoutingDecision) -> Option<String>;
+}
+
+/// A no-op clarifier: never asks, always accepts the low-confidence routing
+/// as-is. Used for `--no-input`/non-interactive callers.
+pub struct NoClarification;
+
+impl Clarifier for NoClarification {
+    fn ask(&self, _question: &str, _decision: &RoutingDecision) -> Option<String> {
+        None
+    }
+}
+
+/// Outcome of `run_pipeline`.
+#[derive(Debug, Clone)]
+pub struct PipelineResult {
+    /// The original raw prompt, used as the goal title.
+    pub goal_title: String,
+    /// The objective actually routed — equal to `goal_title` unless a
+    /// clarifying answer was folded in.
+    pub objective: String,
+    /// The (possibly re-routed) routing decision.
+    pub decision: RoutingDecision,
+    /// `true` iff a clarifying question was asked and answered.
+    pub clarified: bool,
+    /// The human's raw answer, when `clarified` is true.
+    pub clarification_answer: Option<String>,
+}
+
+impl PipelineResult {
+    /// `true` when the final decision is confident enough to have needed no
+    /// clarification, or was successfully clarified — i.e. safe to present
+    /// as a ready-to-create goal rather than still-ambiguous.
+    pub fn is_confident(&self) -> bool {
+        self.decision.workload_confidence >= AMBIGUOUS_CONFIDENCE_THRESHOLD
+    }
+}
+
+/// Run the free-text → routed-goal pipeline end-to-end (item 3):
+///
+/// 1. Route the raw prompt through `ta_brain::route()` exactly as it
+///    consumes any other explicit goal request.
+/// 2. If workload-classification confidence is at or above
+///    [`AMBIGUOUS_CONFIDENCE_THRESHOLD`], return immediately — zero
+///    clarification.
+/// 3. Otherwise, ask `clarifier` exactly one question built from the
+///    low-confidence decision, fold the answer into the objective, and
+///    re-route once. Never asks a second question, even if the re-routed
+///    decision is still low-confidence — the caller (Observable & Actionable)
+///    sees `decision.rationale` either way.
+pub fn run_pipeline(
+    raw_prompt: &str,
+    workspace_root: &Path,
+    clarifier: &dyn Clarifier,
+) -> PipelineResult {
+    run_pipeline_with_security(raw_prompt, workspace_root, clarifier, None)
+}
+
+/// Same as [`run_pipeline`], but with an explicit `--security` override fed
+/// into `route()` exactly as `ta run --security` already is (tier 1,
+/// "explicit beats everything" — see `ta_brain::route::resolve_security`).
+pub fn run_pipeline_with_security(
+    raw_prompt: &str,
+    workspace_root: &Path,
+    clarifier: &dyn Clarifier,
+    security_override: Option<&str>,
+) -> PipelineResult {
+    let prompt = raw_prompt.trim().to_string();
+    let decision = route_text(&prompt, workspace_root, security_override);
+
+    if decision.workload_confidence >= AMBIGUOUS_CONFIDENCE_THRESHOLD {
+        return PipelineResult {
+            goal_title: prompt.clone(),
+            objective: prompt,
+            decision,
+            clarified: false,
+            clarification_answer: None,
+        };
+    }
+
+    let question = clarifying_question(&decision);
+    match clarifier.ask(&question, &decision) {
+        Some(answer) if !answer.trim().is_empty() => {
+            let combined = format!("{} {}", prompt, answer.trim());
+            let re_decision = route_text(&combined, workspace_root, security_override);
+            PipelineResult {
+                goal_title: prompt,
+                objective: combined,
+                decision: re_decision,
+                clarified: true,
+                clarification_answer: Some(answer),
+            }
+        }
+        _ => PipelineResult {
+            goal_title: prompt.clone(),
+            objective: prompt,
+            decision,
+            clarified: false,
+            clarification_answer: None,
+        },
+    }
+}
+
+/// Build the single clarifying question presented for a low-confidence
+/// decision — Observable & Actionable: names the guess and its confidence
+/// rather than a bare "please clarify."
+pub fn clarifying_question(decision: &RoutingDecision) -> String {
+    format!(
+        "I'm not fully confident how to route this (best guess: \"{}\" work at {:.0}% \
+         confidence). Can you say more about what you'd like done?",
+        decision.workload_type,
+        decision.workload_confidence * 100.0
+    )
+}
+
+fn route_text(
+    text: &str,
+    workspace_root: &Path,
+    security_override: Option<&str>,
+) -> RoutingDecision {
+    let request = ExplicitGoalRequest {
+        goal_title: text.to_string(),
+        objective: text.to_string(),
+        cli_security: security_override.map(str::to_string),
+        ..ExplicitGoalRequest::new(text.to_string())
+    };
+    route(&RoutingInput::ExplicitGoal(request), workspace_root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeClarifier(Option<String>);
+    impl Clarifier for FakeClarifier {
+        fn ask(&self, _question: &str, _decision: &RoutingDecision) -> Option<String> {
+            self.0.clone()
+        }
+    }
+
+    struct PanicClarifier;
+    impl Clarifier for PanicClarifier {
+        fn ask(&self, _question: &str, _decision: &RoutingDecision) -> Option<String> {
+            panic!("clarifier must not be invoked for a high-confidence prompt");
+        }
+    }
+
+    #[test]
+    fn high_confidence_prompt_routes_with_zero_clarification() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = run_pipeline("Fix the login bug", tmp.path(), &PanicClarifier);
+        assert!(!result.clarified);
+        assert!(result.clarification_answer.is_none());
+        assert!(result.is_confident());
+        assert_eq!(result.decision.workload_type, "bugfix");
+        assert_eq!(result.objective, "Fix the login bug");
+    }
+
+    #[test]
+    fn low_confidence_prompt_asks_exactly_one_question_and_reroutes() {
+        let tmp = tempfile::tempdir().unwrap();
+        // "xyzzy plugh" classifies as "other" at 0.3 confidence (below the
+        // 0.65 threshold), so the pipeline must ask before routing.
+        let result = run_pipeline(
+            "xyzzy plugh",
+            tmp.path(),
+            &FakeClarifier(Some("It's a security fix for the login bypass".to_string())),
+        );
+        assert!(result.clarified);
+        assert_eq!(
+            result.clarification_answer.as_deref(),
+            Some("It's a security fix for the login bypass")
+        );
+        assert_eq!(result.decision.workload_type, "security");
+        assert!(result.objective.starts_with("xyzzy plugh"));
+        assert!(result.objective.contains("security fix"));
+    }
+
+    #[test]
+    fn low_confidence_prompt_with_no_answer_keeps_original_decision() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = run_pipeline("xyzzy plugh", tmp.path(), &NoClarification);
+        assert!(!result.clarified);
+        assert_eq!(result.decision.workload_type, "other");
+        assert_eq!(result.objective, "xyzzy plugh");
+    }
+
+    #[test]
+    fn low_confidence_prompt_with_blank_answer_keeps_original_decision() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = run_pipeline(
+            "xyzzy plugh",
+            tmp.path(),
+            &FakeClarifier(Some("   ".to_string())),
+        );
+        assert!(!result.clarified);
+        assert_eq!(result.decision.workload_type, "other");
+    }
+
+    #[test]
+    fn security_override_forces_explicit_tier() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = run_pipeline_with_security(
+            "Fix the login bug",
+            tmp.path(),
+            &PanicClarifier,
+            Some("auto"),
+        );
+        assert_eq!(
+            result.decision.security_tier,
+            ta_session::workflow_session::AdvisorSecurity::Auto
+        );
+    }
+
+    #[test]
+    fn clarifying_question_names_the_guess_and_confidence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let decision = route_text("xyzzy plugh", tmp.path(), None);
+        let question = clarifying_question(&decision);
+        assert!(question.contains("other"));
+        assert!(question.contains('%'));
+    }
+}

--- a/crates/ta-brain/Cargo.toml
+++ b/crates/ta-brain/Cargo.toml
@@ -21,6 +21,10 @@ thiserror = { workspace = true }
 ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.24" }
 ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.24" }
 ta-intake = { path = "../ta-intake", version = "0.17.0-alpha.12.24" }
+# Folds ta-workflow's template-matching intent resolver in as one signal
+# route() consults (v0.17.0.12.23), rather than a second, parallel intent
+# system — see route.rs's resolve_workflow_template().
+ta-workflow = { path = "../ta-workflow", version = "0.17.0-alpha.12.24" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-brain/src/decision.rs
+++ b/crates/ta-brain/src/decision.rs
@@ -31,6 +31,14 @@ pub struct RoutingDecision {
     /// Confidence in `workload_type` when it was inferred (1.0 when
     /// explicit). Gates the `security_tier = "auto"` tier — see `route()`.
     pub workload_confidence: f32,
+    /// Workflow template `ta-workflow::intent::resolve_intent` matched
+    /// against the request text at or above its own confidence threshold,
+    /// when no `workflow_name_or_path` was given explicitly (v0.17.0.12.23).
+    /// Folds workflow-template matching into `route()` as one signal among
+    /// several, rather than a second, parallel intent system a caller would
+    /// need to consult separately.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_workflow_template: Option<String>,
     /// One line per resolution step, most-specific-tier-first, e.g.
     /// `"agent: tier=persona value=claude-opus-4-8"`. Always populated,
     /// always surfaced to a human (Observable & Actionable).

--- a/crates/ta-brain/src/route.rs
+++ b/crates/ta-brain/src/route.rs
@@ -214,6 +214,8 @@ pub fn route(input: &RoutingInput, workspace_root: &Path) -> RoutingDecision {
         &mut rationale,
     );
     let priority = resolve_priority(&ctx, &workload, &workflow_toml, &mut rationale);
+    let resolved_workflow_template =
+        resolve_workflow_template(&ctx, workspace_root, &mut rationale);
 
     RoutingDecision {
         team,
@@ -223,7 +225,48 @@ pub fn route(input: &RoutingInput, workspace_root: &Path) -> RoutingDecision {
         priority,
         workload_type: workload.workload_type,
         workload_confidence: workload.confidence,
+        resolved_workflow_template,
         rationale,
+    }
+}
+
+// ── Workflow-template signal (folds in ta-workflow::intent, v0.17.0.12.23) ─
+
+/// Consult `ta-workflow::intent::resolve_intent`'s template-matching as one
+/// signal `route()` reports, rather than a second, parallel intent system a
+/// caller would need to run separately. Only attempted when the caller
+/// didn't already name a workflow explicitly — an explicit
+/// `workflow_name_or_path` needs no matching.
+fn resolve_workflow_template(
+    ctx: &Context,
+    workspace_root: &Path,
+    rationale: &mut Vec<String>,
+) -> Option<String> {
+    if ctx.workflow_name_or_path.is_some() {
+        rationale.push("workflow_template: tier=explicit skipped=true".to_string());
+        return None;
+    }
+
+    let templates = ta_workflow::TemplateLibrary::new(workspace_root).list();
+    let plan_ctx = ta_workflow::PlanContext::load(workspace_root);
+
+    match ta_workflow::resolve_intent(&ctx.classification_text, &templates, &plan_ctx) {
+        ta_workflow::ResolutionResult::Resolved(candidate)
+            if candidate.score >= ta_workflow::CONFIDENCE_THRESHOLD =>
+        {
+            rationale.push(format!(
+                "workflow_template: tier=intent-match value={} score={:.2}",
+                candidate.template_name, candidate.score
+            ));
+            Some(candidate.template_name)
+        }
+        _ => {
+            rationale.push(
+                "workflow_template: tier=intent-match value=<none> (below confidence threshold)"
+                    .to_string(),
+            );
+            None
+        }
     }
 }
 
@@ -827,6 +870,44 @@ mod tests {
         let decision = route(&explicit("Update the README docs"), tmp.path());
         assert_eq!(decision.workload_type, "docs");
         assert_eq!(decision.priority, Priority::Low);
+    }
+
+    // ── workflow-template signal (v0.17.0.12.23) ────────────────────────
+
+    #[test]
+    fn workflow_template_matched_for_high_confidence_text() {
+        let tmp = tempfile::tempdir().unwrap();
+        // "implement remaining v0.15" scores 1.0 against the builtin
+        // "plan-build-phases" template (verb + multi-phase scope + version ref).
+        let decision = route(&explicit("implement remaining v0.15"), tmp.path());
+        assert_eq!(
+            decision.resolved_workflow_template,
+            Some("plan-build-phases".to_string())
+        );
+        assert!(decision
+            .rationale
+            .iter()
+            .any(|l| l.contains("workflow_template") && l.contains("plan-build-phases")));
+    }
+
+    #[test]
+    fn workflow_template_none_for_low_confidence_text() {
+        let tmp = tempfile::tempdir().unwrap();
+        let decision = route(&explicit("Add a new dashboard widget"), tmp.path());
+        assert_eq!(decision.resolved_workflow_template, None);
+    }
+
+    #[test]
+    fn workflow_template_skipped_when_workflow_explicit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut req = ExplicitGoalRequest::new("implement remaining v0.15");
+        req.workflow_name_or_path = Some("some-other-workflow".to_string());
+        let decision = route(&RoutingInput::ExplicitGoal(req), tmp.path());
+        assert_eq!(decision.resolved_workflow_template, None);
+        assert!(decision
+            .rationale
+            .iter()
+            .any(|l| l.contains("workflow_template: tier=explicit skipped=true")));
     }
 
     // ── explicit vs. triggered equivalence ──────────────────────────────

--- a/crates/ta-goal/Cargo.toml
+++ b/crates/ta-goal/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["development-tools"]
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-schemars = { workspace = true }
+schemars = { workspace = true, features = ["chrono04"] }
 chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/ta-session/src/intent_agent.rs
+++ b/crates/ta-session/src/intent_agent.rs
@@ -1,0 +1,302 @@
+// intent_agent.rs — Headless clarifying-question agent (v0.17.0.12.23).
+//
+// Advisor-driven goal creation needs to ask a human exactly one clarifying
+// question when `ta-brain::route()`'s workload-classification confidence is
+// low, without building a new conversational loop. This module reuses the
+// same subprocess-spawn + poll-file pattern `advisor_agent::spawn_advisor_agent`
+// already established for draft-review conversations: spawn a short-lived
+// `ta run --headless` subprocess whose context instructs it to call
+// `ta_ask_human` exactly once and write the answer to a well-known file,
+// then poll that file for the result.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use uuid::Uuid;
+
+/// Configuration for a single clarifying-question agent invocation.
+#[derive(Debug, Clone)]
+pub struct IntentAgentConfig {
+    /// Workspace root (project directory, where `.ta/` lives).
+    pub workspace_root: PathBuf,
+    /// The raw free-text prompt the human originally gave.
+    pub raw_prompt: String,
+    /// The clarifying question to ask, pre-built by the caller from the
+    /// low-confidence `RoutingDecision` (e.g. `ta-advisor::pipeline`).
+    pub question: String,
+    /// Item ID (used in context/answer file naming to avoid collisions).
+    pub item_id: Uuid,
+    /// Optional persona name (references `.ta/personas/<name>.toml`).
+    pub persona: Option<String>,
+    /// Timeout for the clarifying-question conversation (default: 10 min).
+    pub timeout: Duration,
+}
+
+impl IntentAgentConfig {
+    pub fn new(
+        workspace_root: impl Into<PathBuf>,
+        raw_prompt: impl Into<String>,
+        question: impl Into<String>,
+    ) -> Self {
+        Self {
+            workspace_root: workspace_root.into(),
+            raw_prompt: raw_prompt.into(),
+            question: question.into(),
+            item_id: Uuid::new_v4(),
+            persona: None,
+            timeout: Duration::from_secs(10 * 60),
+        }
+    }
+
+    pub fn with_item_id(mut self, item_id: Uuid) -> Self {
+        self.item_id = item_id;
+        self
+    }
+
+    pub fn with_persona(mut self, persona: impl Into<String>) -> Self {
+        self.persona = Some(persona.into());
+        self
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    fn item_dir(&self) -> PathBuf {
+        self.workspace_root
+            .join(".ta")
+            .join("advisor-intent")
+            .join(self.item_id.to_string())
+    }
+}
+
+/// Build the context markdown injected into the clarifying-question agent's
+/// CLAUDE.md. Deliberately narrow in scope compared to `build_advisor_context`
+/// (draft review): this agent's only job is to ask one question and report
+/// the answer, not to review a draft or apply/deny anything.
+pub fn build_intent_context(config: &IntentAgentConfig) -> String {
+    format!(
+        "# Advisor Context — Free-Text Goal Clarification\n\n\
+         A human asked for the following, but routing confidence was too low \
+         to act on directly:\n\n> {}\n\n\
+         Your only job is to ask ONE clarifying question and report the answer. \
+         Do not start any other work.\n\n\
+         ## Conversation Protocol\n\n\
+         1. Call `ta_ask_human(\"{}\")` with `response_hint: freeform`.\n\
+         2. Write the human's raw answer, verbatim, to `.ta/advisor-intent/{}/answer.json` \
+            (via `ta_fs_write`) as: `{{\"answer\": \"<their reply>\"}}`.\n\
+         3. Exit — do not ask a second question, and do not start a goal yourself.\n",
+        config.raw_prompt, config.question, config.item_id
+    )
+}
+
+/// Write the clarification context to `.ta/advisor-intent/<item_id>/context.md`.
+///
+/// Returns the path to the written context file.
+pub fn write_intent_context(config: &IntentAgentConfig) -> std::io::Result<PathBuf> {
+    let dir = config.item_dir();
+    std::fs::create_dir_all(&dir)?;
+    let context_path = dir.join("context.md");
+    std::fs::write(&context_path, build_intent_context(config))?;
+    Ok(context_path)
+}
+
+/// Spawn a clarifying-question agent for the given config.
+///
+/// Launches `ta run --headless` as a subprocess with
+/// `TA_ADVISOR_INTENT_CONTEXT_FILE=<path>` and `TA_ADVISOR_INTENT_ITEM_ID=<id>`
+/// environment variables, mirroring `advisor_agent::spawn_advisor_agent`.
+///
+/// Returns the clarification goal run ID extracted from stdout.
+pub fn spawn_intent_agent(config: &IntentAgentConfig, ta_bin: &Path) -> Result<Uuid, String> {
+    let context_path = write_intent_context(config)
+        .map_err(|e| format!("Failed to write clarification context: {}", e))?;
+
+    let persona = config.persona.as_deref().unwrap_or("advisor");
+    let goal_title = "Advisor: clarify free-text goal request".to_string();
+
+    let mut cmd = std::process::Command::new(ta_bin);
+    cmd.args([
+        "--project-root",
+        &config.workspace_root.to_string_lossy(),
+        "run",
+        &goal_title,
+        "--headless",
+        "--no-version-check",
+        "--persona",
+        persona,
+    ]);
+    cmd.env("TA_ADVISOR_INTENT_CONTEXT_FILE", &context_path);
+    cmd.env("TA_ADVISOR_INTENT_ITEM_ID", config.item_id.to_string());
+
+    tracing::info!(
+        item_id = %config.item_id,
+        raw_prompt = %config.raw_prompt,
+        "Spawning clarifying-question agent"
+    );
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to spawn ta run: {}", e))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if !output.status.success() {
+        return Err(format!(
+            "ta run --headless exited {} for clarification agent.\nstdout: {}\nstderr: {}",
+            output.status.code().unwrap_or(-1),
+            stdout.trim(),
+            stderr.trim()
+        ));
+    }
+
+    for line in stdout.lines().chain(stderr.lines()) {
+        if let Some(id_str) = line.strip_prefix("goal_id: ") {
+            let id_str = id_str.trim();
+            return Uuid::parse_str(id_str)
+                .map_err(|e| format!("Failed to parse clarification goal_id '{}': {}", id_str, e));
+        }
+    }
+
+    Err(format!(
+        "Clarification agent exited successfully but did not emit goal_id.\n\
+         stdout: {}\nstderr: {}",
+        stdout.trim(),
+        stderr.trim()
+    ))
+}
+
+/// Outcome of polling for the clarifying-question agent's answer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IntentAgentOutcome {
+    /// The human answered; here's their raw reply.
+    Answered(String),
+    /// No answer arrived before the timeout.
+    TimedOut,
+}
+
+/// Poll `.ta/advisor-intent/<item_id>/answer.json` until it appears or the
+/// timeout elapses. Sleep-based (the answer path is low-frequency enough
+/// that a file watcher isn't warranted, unlike `poll_draft_outcome`).
+pub fn poll_intent_answer(
+    workspace_root: &Path,
+    item_id: Uuid,
+    timeout: Duration,
+    poll_interval: Duration,
+) -> IntentAgentOutcome {
+    let answer_file = workspace_root
+        .join(".ta")
+        .join("advisor-intent")
+        .join(item_id.to_string())
+        .join("answer.json");
+    let deadline = Instant::now() + timeout;
+    let effective_interval = poll_interval.max(Duration::from_millis(200));
+
+    loop {
+        if let Some(outcome) = check_answer_file(&answer_file) {
+            return outcome;
+        }
+        if Instant::now() >= deadline {
+            tracing::warn!(
+                item_id = %item_id,
+                timeout_secs = timeout.as_secs(),
+                "Clarification agent timed out waiting for an answer"
+            );
+            return IntentAgentOutcome::TimedOut;
+        }
+        std::thread::sleep(effective_interval);
+    }
+}
+
+fn check_answer_file(path: &Path) -> Option<IntentAgentOutcome> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let answer = v.get("answer")?.as_str()?.to_string();
+    Some(IntentAgentOutcome::Answered(answer))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_config(tmp: &TempDir) -> IntentAgentConfig {
+        IntentAgentConfig::new(
+            tmp.path(),
+            "also clean up that auth thing",
+            "Which auth module — login, session refresh, or OAuth callback?",
+        )
+    }
+
+    #[test]
+    fn build_intent_context_includes_prompt_and_question() {
+        let tmp = TempDir::new().unwrap();
+        let config = make_config(&tmp);
+        let ctx = build_intent_context(&config);
+        assert!(ctx.contains("also clean up that auth thing"));
+        assert!(ctx.contains("Which auth module"));
+        assert!(ctx.contains("ta_ask_human"));
+        assert!(ctx.contains("answer.json"));
+    }
+
+    #[test]
+    fn write_intent_context_creates_file() {
+        let tmp = TempDir::new().unwrap();
+        let config = make_config(&tmp);
+        let path = write_intent_context(&config).unwrap();
+        assert!(path.exists());
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("Free-Text Goal Clarification"));
+    }
+
+    #[test]
+    fn poll_intent_answer_returns_timeout_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        let outcome = poll_intent_answer(
+            tmp.path(),
+            Uuid::new_v4(),
+            Duration::from_millis(50),
+            Duration::from_millis(10),
+        );
+        assert_eq!(outcome, IntentAgentOutcome::TimedOut);
+    }
+
+    #[test]
+    fn poll_intent_answer_reads_written_answer() {
+        let tmp = TempDir::new().unwrap();
+        let item_id = Uuid::new_v4();
+        let dir = tmp
+            .path()
+            .join(".ta/advisor-intent")
+            .join(item_id.to_string());
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("answer.json"),
+            r#"{"answer": "the OAuth callback handler"}"#,
+        )
+        .unwrap();
+
+        let outcome = poll_intent_answer(
+            tmp.path(),
+            item_id,
+            Duration::from_secs(5),
+            Duration::from_millis(10),
+        );
+        assert_eq!(
+            outcome,
+            IntentAgentOutcome::Answered("the OAuth callback handler".to_string())
+        );
+    }
+
+    #[test]
+    fn item_dir_is_scoped_by_item_id() {
+        let tmp = TempDir::new().unwrap();
+        let config = make_config(&tmp).with_item_id(Uuid::nil());
+        let path = write_intent_context(&config).unwrap();
+        assert!(path
+            .to_string_lossy()
+            .contains("00000000-0000-0000-0000-000000000000"));
+    }
+}

--- a/crates/ta-session/src/lib.rs
+++ b/crates/ta-session/src/lib.rs
@@ -7,6 +7,7 @@ pub mod advisor_session;
 pub mod agent_action;
 pub mod error;
 pub mod intent;
+pub mod intent_agent;
 pub mod manager;
 pub mod phase_summary;
 pub mod plan;
@@ -33,6 +34,10 @@ pub use agent_action::{
 };
 pub use error::SessionError;
 pub use intent::{classify_intent, Intent, IntentResult};
+pub use intent_agent::{
+    build_intent_context, poll_intent_answer, spawn_intent_agent, write_intent_context,
+    IntentAgentConfig, IntentAgentOutcome,
+};
 pub use manager::SessionManager;
 pub use phase_summary::{build_phase_summary, PhaseRecord, PhaseSummary};
 pub use plan::{PlanDocument, PlanItem};

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -33,16 +33,12 @@ Both paths install the same `ta` binary. Studio and CLI work side-by-side — yo
    - [Set up your project](#set-up-your-project)
    - [Start a development session](#start-a-development-session)
    - [Your first goal](#your-first-goal)
-3. [CLI Verb Reference](#cli-verb-reference)
-   - [The 10 verbs](#the-10-verbs)
-   - [Default vs. full help](#default-vs-full-help)
-   - [Old → new lookup table](#old--new-lookup-table)
-4. [Core Concepts](#core-concepts)
+3. [Core Concepts](#core-concepts)
    - [The Staging Model](#the-staging-model)
    - [Goals](#goals)
    - [Drafts](#drafts)
    - [Agents](#agents)
-5. [Common Workflows](#common-workflows)
+4. [Common Workflows](#common-workflows)
    - [Single Task](#single-task)
    - [Follow-Up Iterations](#follow-up-iterations)
    - [Macro Goals (multi-draft sessions)](#macro-goals-multi-draft-sessions)
@@ -52,7 +48,7 @@ Both paths install the same `ta` binary. Studio and CLI work side-by-side — yo
    - [Review Sessions](#review-sessions)
    - [Correcting a Draft](#correcting-a-draft)
    - [Draft Lifecycle Hygiene](#draft-lifecycle-hygiene)
-6. [Configuration](#configuration)
+5. [Configuration](#configuration)
    - [Workflow Config](#workflow-config-taworkflowtoml)
    - [Agent Configuration](#agent-configuration)
    - [Alignment Profiles](#alignment-profiles)
@@ -60,7 +56,7 @@ Both paths install the same `ta` binary. Studio and CLI work side-by-side — yo
    - [Configurable Summary Exemption](#configurable-summary-exemption)
    - [Plan Schema](#plan-schema-taplan-schemayaml)
    - [Channel Setup](#channel-setup)
-7. [Advanced Features](#advanced-features)
+6. [Advanced Features](#advanced-features)
    - [Selective Approval](#selective-approval)
    - [Behavioral Drift Detection](#behavioral-drift-detection)
    - [Conflict Detection](#conflict-detection)
@@ -98,9 +94,9 @@ Both paths install the same `ta` binary. Studio and CLI work side-by-side — yo
    - [Workflow Engine](#workflow-engine)
    - [Choosing Your Orchestration Stack](#choosing-your-orchestration-stack)
    - [Community Knowledge Hub](#community-knowledge-hub)
-8. [Roadmap](#roadmap)
-9. [Troubleshooting](#troubleshooting)
-10. [Getting Help](#getting-help)
+7. [Roadmap](#roadmap)
+8. [Troubleshooting](#troubleshooting)
+9. [Getting Help](#getting-help)
 
 ---
 
@@ -953,118 +949,6 @@ ta> [Pasted 2,847 chars / 47 lines — Tab to preview, Esc to cancel]
 **Auto-tail**: When streaming agent output, the shell follows new lines automatically (`tail -f` style). If you scroll up to read earlier output, auto-tail is paused. Scroll back to the bottom (mouse wheel, `PageDown`, or `Cmd+Down`) to resume — the viewport will immediately begin following new output again. `Ctrl+L` clears the output and also resumes auto-tail.
 
 **Stream reconnect**: If the connection to the daemon drops mid-stream (e.g. daemon restart, network interruption), the shell automatically reconnects — up to 5 retries with exponential backoff (1s, 2s, 4s, 8s, 16s). A non-blocking notice is shown in the output pane during reconnect. The daemon tracks a monotonic sequence number per goal stream (`id:` field in SSE), so reconnects resume from the last received event with no duplicate or lost lines. If all retries fail, an actionable message is shown and the tail session ends cleanly.
-
----
-
-## CLI Verb Reference
-
-TA's CLI has two surfaces that always execute identical code — the new form
-never re-implements a legacy command, it forwards to the exact same
-`Commands` variant (`apps/ta-cli/src/commands/verb.rs`):
-
-- **The 10-verb surface** (primary, recommended): `ta <verb> <noun> [id] [flags]`
-- **The legacy noun-first surface** (still works, unchanged): `ta <noun> <action> [id] [flags]`
-
-### The 10 verbs
-
-| Verb | Does | Replaces |
-|---|---|---|
-| `create` | Provision a new resource | `new`/`init`/`add`/`install` |
-| `list` | Show all resources of a kind | 15+ independent `list` implementations |
-| `show` | Single-item detail | `view`/`status`/`inspect` |
-| `update` | Modify a resource | `set`/`assign`/`reload` |
-| `remove` | Delete a resource | `delete`/`remove`/`revoke`/`uninstall` |
-| `approve` / `deny` | Decision-gate outcomes | same shape as `draft approve`/`deny`, generalized |
-| `apply` | Fire the Commit stage | TA's defining action — materializes an approved draft |
-| `check` | Correctness/validation | `validate`/`verify`/`audit` |
-| `sync` | Reconcile with remote/registry | `gc`/`prune`/`migrate` |
-
-`run` (launch an agent goal) and `status` (the no-argument dashboard) are
-already verb-shaped and unchanged.
-
-### Default vs. full help
-
-`ta --help` shows a curated ~15-command everyday surface: the 10 verbs above,
-plus `run`, `status`, `shell`, `onboard`, and `doctor`. Every legacy
-noun-first command (`ta goal ...`, `ta plugin ...`, `ta webhook ...`, etc.)
-and advanced/one-time command (`ta gc`, `ta upgrade`, `ta serve`, ...) keeps
-working exactly as before — it's just not listed in the default `--help`
-output, so a new user isn't confronted with the full ~60-command surface on
-day one.
-
-```bash
-ta --help              # curated: the 10 verbs + run/status/shell/onboard/doctor
-ta --help --all        # full surface: every legacy/advanced command, unhidden
-ta plugin --help       # drill into a legacy noun directly — always works,
-                        # hidden or not
-ta create --help       # drill into a verb to see its full noun list + examples
-```
-
-Automation (workflow definitions, the Advisor's tool-calling, `ta-brain`
-routing) always sees and can invoke the full command surface — `--help`
-curation only affects what a human reading `ta --help` sees first per
-`docs/design/ta-cli-verb-reference.md` §4.
-
-### Old → new lookup table
-
-Every noun-area below has a working legacy form (left) and, where mapped, an
-equivalent verb+noun form (right) that executes identical code. A noun with
-no verb+noun form yet in a given column means that legacy action isn't
-mapped — it keeps working via the legacy form only. Nouns marked with (*)
-were completed in v0.17.0.12.22; the rest shipped in v0.17.0.12.16.
-
-| Noun area | Legacy top-level | Verb+noun equivalents |
-|---|---|---|
-| Goal | `ta goal ...` | `list goal`, `show goal <id>`, `remove goal <id>`, `sync goal` |
-| Draft | `ta draft ...` | `list draft`, `show draft <id>`, `remove draft <id>`, `approve draft <id>`, `deny draft <id>`, `apply draft <id>`, `sync draft` |
-| Plan phase | `ta plan ...` | `list plan-phase`, `show plan-phase <id>`, `create plan-phase <id>`, `check plan-phase <id>`, `sync plan-phase` |
-| Team | `ta team ...` | `list team`, `update team <role> <agent>` |
-| Persona | `ta persona ...` | `list persona`, `create persona <name>`, `show persona <name>`, `update persona <name>` |
-| Workflow | `ta workflow ...` | `list workflow`, `show workflow <name>`, `create workflow <name>`, `update workflow <name>`, `remove workflow <name>`, `check workflow <name>`, `sync workflow` |
-| Plugin | `ta plugin ...` | `create plugin <name>`, `list plugin`, `show plugin <name>`, `remove plugin <name>`, `check plugin <name>`, `sync plugin` |
-| Template | `ta template ...` | `create template <name>`, `list template`, `remove template <name>` |
-| Session | `ta session ...` | `list session`, `show session <id>`, `remove session <id>` |
-| Credential | `ta credentials ...` | `create credential <name>`, `list credential`, `remove credential <name>` |
-| Event | `ta events ...` | `show event`, `sync event` |
-| Token | `ta token ...` | `create token`, `list token`, `sync token` |
-| Office | `ta office ...` | `create office`, `show office`, `remove office`, `sync office` |
-| Daemon | `ta daemon ...` | `create daemon`, `show daemon`, `remove daemon`, `check daemon`, `sync daemon` |
-| Connector | `ta connector ...` | `create connector <name>`, `list connector`, `show connector <name>`, `remove connector <name>`, `sync connector <name>` |
-| Community resource | `ta community ...` | `list community-resource`, `show community-resource <id>`, `sync community-resource` |
-| Context | `ta context ...` | `create context <key>`, `list context`, `show context <key>`, `remove context <key>`, `check context` |
-| Agent | `ta agent ...` | `create agent <name>`, `list agent`, `show agent <name>`, `check agent <name>`, `remove agent <name>`, `sync agent <name>` |
-| Runbook (*) | `ta runbook ...` | `list runbook`, `show runbook <name>`, `apply runbook <name>` |
-| Operations (*) | `ta operations ...` | `list operations` |
-| Audit (*) | `ta audit ...` | `list audit`, `show audit <goal-id>`, `check audit` |
-| Setup (*) | `ta setup ...` | `create setup`, `show setup`, `update setup <topic>`, `sync setup` |
-| Project (*) | `ta init ...` | `create project` |
-| Scaffold (*) | `ta new ...` | `create scaffold` |
-| Advisor (*) | `ta advisor ...` | `apply advisor "<message>"` |
-| Style (*) | `ta style ...` | `create style`, `show style`, `update style`, `remove style`, `check style`, `sync style <source>` |
-| Constitution (*) | `ta constitution ...` | `create constitution`, `show constitution`, `update constitution`, `check constitution` |
-| Memory (*) | `ta memory ...` | `create memory <key> <value>`, `list memory`, `show memory`, `check memory`, `sync memory` |
-| Adapter (*) | `ta adapter ...` | `create adapter <name>`, `list adapter`, `check adapter <type>`, `update adapter <plugin>` |
-| Release (*) | `ta release ...` | `apply release <version>`, `show release`, `create release`, `update release <key> <value>`, `check release <version>`, `sync release <tag>` |
-| Trigger / Intake (*) | `ta intake ...` | `list trigger`, `apply trigger <type>`, `show trigger` |
-| Stats (*) | `ta stats ...` | `list stats`, `show stats`, `sync stats` |
-| Meridian (*) | `ta meridian ...` | `create meridian`, `list meridian`, `check meridian` |
-| Tools (*) | `ta tools ...` | `list tools`, `create tools <name>` |
-| Manifest (*) | `ta manifest ...` | `create manifest`, `check manifest`, `show manifest [link]` |
-| Link (*) | `ta link ...` | `create link <target>`, `list link`, `check link`, `sync link [name]`, `remove link <name>` |
-| Policy (*) | `ta policy ...` | `check policy <draft-id>`, `show policy` |
-| Config (*) | `ta config ...` | `show config` |
-| Analysis (*) | `ta analysis ...` | `apply analysis` |
-| Compression (*) | `ta compression ...` | `show compression`, `create compression`, `remove compression` |
-| Webhook (*) | `ta webhook ...` | `check webhook <provider> <event>` |
-| PR | `ta pr ...` | none — `pr` is a deprecated, hidden alias of `draft`; use the `draft` noun above instead |
-
-That's all 42 noun-areas from `docs/design/ta-cli-verb-reference.md` §2
-accounted for: 18 fully mapped in v0.17.0.12.16, 23 more mapped in
-v0.17.0.12.22, and `pr` intentionally left unmapped (already superseded by
-`draft`). A handful of legacy actions per noun-area still have no verb+noun
-equivalent (e.g. `ta pr fix`, `ta constitution review`) — these keep working
-via their legacy form only; `ta <verb> <noun>` returns a clear error naming
-the supported verbs for that noun when you try an unmapped combination.
 
 ---
 
@@ -12926,7 +12810,7 @@ TA checks in order: `TA_MERIDIAN_BINARY` env var → `daemon.toml [meridian].bin
 ### Discovering available tools
 
 ```bash
-ta meridian tools
+ta meridian help
 ```
 
 Starts a short-lived `meridian serve` session, queries the MCP `tools/list` endpoint, and prints every tool name and description. Use this to see exactly which analytics are available as native tool calls inside a running goal — useful after upgrading Meridian to discover new capabilities.
@@ -15604,25 +15488,44 @@ The "team coordinator" — something that watches pending/queued work and recomm
 ta intake coordinate
 
 # Also act: dispatch (create a goal for, then dequeue) every recommendation
-# whose resolved security_tier is "auto"; leave everything else queued for
-# `ta intake fire` or manual review.
+# whose resolved security_tier is "auto"; recommendations with low workload-
+# classification confidence get one clarifying question first (see below);
+# everything else stays queued for `ta intake fire` or manual review.
 ta intake coordinate --dispatch
 ```
 
----
+Each recommendation carries one of three outcomes, not just an auto/review binary:
 
-## Data-Format Specs & Studio Boundary
+- **auto-eligible** — confidently classified and resolved to `security_tier = "auto"`; dispatched immediately with `--dispatch`.
+- **needs review** — confidently classified, but not at `auto` security; stays queued for a human.
+- **needs clarification** — workload-classification confidence is too low to trust either an autonomous dispatch or a silent "review later" — see below.
 
-TA publishes versioned JSON Schema for five core wire types — `Goal`, `Draft`/`Artifact`, `TriggerEvent`, `RoutingDecision`, and `Persona` — under `schema/*.schema.json`. This is what lets Studio (and community trigger-configs/plugins) build against TA without compiling Rust: the schema is the contract, generated directly from the real Rust types (`crates/ta-data-spec`), not a hand-maintained mirror.
+### Advisor-Driven Goal Creation: "just tell TA what you want"
 
-Full reference, including the versioning scheme and how to regenerate the schemas after changing one of the five types: [`docs/design/ta-data-format-spec.md`](design/ta-data-format-spec.md).
+Rather than filling in `--team`/`--persona`/`--agent`/`--security`/`--priority` yourself, hand the advisor a plain sentence and let `ta-brain::route()` resolve everything:
 
 ```bash
-# Regenerate schema/*.schema.json from the current Rust types.
-cargo run -p ta-data-spec --bin gen-schema
+ta advisor create "also clean up the flaky login test"
 ```
 
-**The Studio boundary rule**: Studio (the daemon's built-in web UI) only ever talks to TA over its HTTP/SSE API — it never special-cases an internal `ta-*` Rust type, only the versioned spec above. This is enforced by an automated check (`crates/ta-data-spec/tests/studio_boundary.rs`, part of `cargo test --workspace`) that flags any daemon API response exposing an internal type without going through the spec.
+This is the single natural-language front door for goal creation — it routes the raw prompt through the exact same `route()` function every other entry point uses (explicit `ta run` flags, triggered events), so a free-text request and a fully-flagged one are never resolved by two different systems:
+
+- **High confidence** (workload-classification confidence ≥ 65%): the goal is routed immediately — zero clarification. At `security_tier = "auto"` it's fired directly; at `suggest` you're shown the exact `ta run ...` command and asked to confirm; at `read_only` the command is printed (and copied to your clipboard on macOS) for you to run yourself.
+- **Low confidence**: the advisor asks exactly **one** clarifying question — reusing the same `ta_ask_human`-backed headless-agent mechanism already built for draft-review conversations, not a new conversational loop — folds your answer into the objective, and re-routes once. It never asks a second question; if the re-routed decision is still low-confidence, you'll see why in the `[routing]` rationale.
+
+```bash
+# Force a security tier regardless of what route() would otherwise resolve —
+# same "explicit beats everything" semantics as `ta run --security`.
+ta advisor create "fix the auth bypass" --security auto
+
+# Non-interactive: skip the clarifying question and any run confirmation,
+# and emit the full routing result (including any clarification) as JSON.
+ta advisor create "improve onboarding" --no-input --json
+```
+
+`ta advisor create` also folds in workflow-template matching: if your prompt closely matches a known workflow template (e.g. "implement remaining v0.15" matching the built-in `plan-build-phases` template), the `[routing]` output names the matched template — one signal `route()` consults, not a second, separate template-matching step you'd need to run yourself.
+
+The team coordinator (`ta intake coordinate --dispatch`, above) uses the identical clarifying-question mechanism for `needs_clarification` trigger-queue events — one clarification pattern for both the interactive and the automated entry points.
 
 ---
 

--- a/schema/routing_decision.schema.json
+++ b/schema/routing_decision.schema.json
@@ -59,6 +59,13 @@
       },
       "type": "array"
     },
+    "resolved_workflow_template": {
+      "description": "Workflow template `ta-workflow::intent::resolve_intent` matched\nagainst the request text at or above its own confidence threshold,\nwhen no `workflow_name_or_path` was given explicitly (v0.17.0.12.23).\nFolds workflow-template matching into `route()` as one signal among\nseveral, rather than a second, parallel intent system a caller would\nneed to consult separately.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "security_tier": {
       "$ref": "#/$defs/AdvisorSecurity",
       "description": "Resolved security tier — reuses the existing `AdvisorSecurity`\ntri-state (read_only/suggest/auto) rather than a new trust-level\nconcept, per `docs/design/ta-concepts-and-architecture.md` §3."


### PR DESCRIPTION
## Summary
- Manually completed the apply for draft `302e7b86` (goal `975c6aca`) — `ta draft apply` hit the recurring version-bump-to-own-phase-number conflict (12.23's staged Cargo.toml/CLAUDE.md targeted 12.23, but source had already advanced to 12.24 out of order). Content files copied directly from `.ta/staging/975c6aca-849c-4edb-8096-25ecd09b7cec/`.
- Adds `ta advisor create "<prompt>"` and a free-text intake entry point that spawns an intent-classification agent, folding workflow-template matching into `ta-brain::route()` as one signal (`resolve_workflow_template()`) instead of a second parallel intent system.
- `ta-advisor`'s coordinator now returns a `NeedsClarification` outcome instead of a binary `auto_dispatch_eligible` bool.

## Bugs found/fixed during manual completion
- Two files missed on the first copy pass (`intent_agent.rs`, `ta-session/src/lib.rs`) — caught via build failure, fixed by re-fetching the draft's full file list.
- Copying `decision.rs` from staging silently regressed 12.21's `schemars::JsonSchema` derive on `RoutingDecision` — restored while keeping 12.23's new field.
- `ta-brain/Cargo.toml` was missing a real `ta-workflow` dependency (caught via dependency-name-diff check).
- Unrelated latent bug: `ta-goal/Cargo.toml`'s `schemars` dep was missing the `chrono04` feature, which only surfaces when building `gen-schema` in isolation (masked in full-workspace builds by feature unification). Fixed, and regenerated `schema/routing_decision.schema.json` (adds `resolved_workflow_template`, 7-line diff).

## Test plan
- [x] `./dev cargo build --workspace`
- [x] `./dev cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./dev cargo fmt --all -- --check`
- [x] `./dev cargo test --workspace` (previously failing on `checked_in_schemas_match_generated_output`, now fixed by the schema regen)