### PR TITLE
v0.17.0.12.28 — Documentation: Refreshed User Explainer + Maintainer Architecture Reference

### DIFF
--- a/.ta/plan_history.jsonl
+++ b/.ta/plan_history.jsonl
@@ -477,3 +477,4 @@
 {"new_status":"in_progress","old_status":"pending","phase_id":"v0.17.0.12.27","source":"daemon_claim","timestamp":"2026-07-16T21:42:39.226337+00:00"}
 {"new_status":"done","old_status":"in_progress","phase_id":"v0.17.0.12.27","timestamp":"2026-07-16T22:22:16.692955+00:00"}
 {"new_status":"in_progress","old_status":"pending","phase_id":"v0.17.0.12.28","source":"daemon_claim","timestamp":"2026-07-17T06:57:27.525576+00:00"}
+{"new_status":"done","old_status":"in_progress","phase_id":"v0.17.0.12.28","timestamp":"2026-07-17T07:04:57.465315+00:00"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All outcomes must be **observable** (with details and logging) and **actionable*
 
 ## Current State
 
-**Current version**: `0.17.0-alpha.12.27`
+**Current version**: `0.17.0-alpha.12.28`
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --phase 4b`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3537,7 +3537,7 @@ dependencies = [
 
 [[package]]
 name = "ta-actions"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "serde",
@@ -3551,7 +3551,7 @@ dependencies = [
 
 [[package]]
 name = "ta-advisor"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "serde",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "ta-agent-ollama"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "clap",
@@ -3581,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3597,7 +3597,7 @@ dependencies = [
 
 [[package]]
 name = "ta-brain"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "schemars",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "ta-build"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-comfyui"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "reqwest 0.12.28",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3737,7 +3737,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "serde",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "async-trait",
  "reqwest 0.12.28",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unity"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "serde",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unreal"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "serde",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "serde",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "ta-data-spec"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "schemars",
  "serde_json",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-overlay"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "serde",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-proxy"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "serde",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-proxy-sqlite"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "ta-decision"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "serde",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "ta-extension"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4005,7 +4005,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "ta-governed-paths"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "serde",
@@ -4036,7 +4036,7 @@ dependencies = [
 
 [[package]]
 name = "ta-init"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "ta-intake"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "schemars",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "regex",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "serde",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "glob",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "ta-output-schema"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "serde",
  "serde_json",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "ta-plugin"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "libc",
  "serde",
@@ -4160,7 +4160,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "glob",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "ta-runtime"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "serde",
  "serde_json",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "libc",
@@ -4230,7 +4230,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "chrono",
  "libc",
@@ -4250,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.17.0-alpha.12.27"
+version = "0.17.0-alpha.12.28"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -9644,15 +9644,15 @@ Recommendation: converge forward onto an explicit pinned version rather than pin
 
 ---
 ### v0.17.0.12.28 — Documentation: Refreshed User Explainer + Maintainer Architecture Reference
-<!-- status: in_progress -->
+<!-- status: done -->
 **Depends on**: v0.17.0.12.11 through v0.17.0.12.27 (all of it, including the post-12.21 additions above — this is the final, doc-only phase for the whole overhaul)
 
 **Goal**: Per the user's explicit request (2026-07-05, "once this is done"): once the full v0.17.0.12.11–12.27 overhaul has landed, produce two fresh documents reflecting the real, final state of the system — not working notes, stable references.
 
 **Items**:
-1. [ ] Refresh `docs/guides/what-is-ta.md` (the plain-language, no-jargon user explainer, previously confirmed accurate 2026-07-04) to describe the system as it now actually works: data-defined roles, agent/model switching (including `"auto"`), the trigger layer, the routing brain, the natural-language advisor entry point from 12.23, the `ta_human_verify` two-stage verification pipeline from 12.26/12.27, and the still-central staged-review/auto-approve/escalation model. Keep it just as jargon-free as the original.
-2. [ ] Write a new `docs/architecture/` doc for the user themselves (maintainer-level, not plain-language) — the "how it is set up" reference: the 3-tier model as actually built, the `ta-intake`/`ta-brain`/back-office library-crate boundaries, the data-format specs and how they gate Studio/community contributions, and why the codebase stays a single monorepo rather than split repos. This formalizes `docs/design/ta-concepts-and-architecture.md`'s working notes into a stable reference — the design doc can stay as historical record of how the decisions were reached; this new doc is the current-state reference.
-3. [ ] Cross-link both new/refreshed docs with `ta-action-reference.md`, the data-format spec from v0.17.0.12.21, and the CLI verb reference/user-personas docs completed by v0.17.0.12.22.
+1. [x] Refresh `docs/guides/what-is-ta.md` (the plain-language, no-jargon user explainer, previously confirmed accurate 2026-07-04) to describe the system as it now actually works: data-defined roles, agent/model switching (including `"auto"`), the trigger layer, the routing brain, the natural-language advisor entry point from 12.23, the `ta_human_verify` two-stage verification pipeline from 12.26/12.27, and the still-central staged-review/auto-approve/escalation model. Keep it just as jargon-free as the original.
+2. [x] Write a new `docs/architecture/` doc for the user themselves (maintainer-level, not plain-language) — the "how it is set up" reference: the 3-tier model as actually built, the `ta-intake`/`ta-brain`/back-office library-crate boundaries, the data-format specs and how they gate Studio/community contributions, and why the codebase stays a single monorepo rather than split repos. This formalizes `docs/design/ta-concepts-and-architecture.md`'s working notes into a stable reference — the design doc can stay as historical record of how the decisions were reached; this new doc is the current-state reference.
+3. [x] Cross-link both new/refreshed docs with `ta-action-reference.md`, the data-format spec from v0.17.0.12.21, and the CLI verb reference/user-personas docs completed by v0.17.0.12.22.
 
 #### Version: `0.17.0-alpha.12.28`
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -43,33 +43,33 @@ which = { workspace = true }
 arboard = { workspace = true }
 
 # Internal crates — version kept in sync with workspace by bump-version.sh
-ta-audit = { path = "../../crates/ta-audit", version = "0.17.0-alpha.12.27" }
-ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.0-alpha.12.27" }
-ta-memory = { path = "../../crates/ta-memory", version = "0.17.0-alpha.12.27" }
-ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.0-alpha.12.27" }
-ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.0-alpha.12.27" }
-ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.0-alpha.12.27" }
-ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.0-alpha.12.27" }
-ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.0-alpha.12.27" }
-ta-goal = { path = "../../crates/ta-goal", version = "0.17.0-alpha.12.27" }
-ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.0-alpha.12.27" }
-ta-policy = { path = "../../crates/ta-policy", version = "0.17.0-alpha.12.27" }
-ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.0-alpha.12.27" }
-ta-session = { path = "../../crates/ta-session", version = "0.17.0-alpha.12.27" }
-ta-events = { path = "../../crates/ta-events", version = "0.17.0-alpha.12.27" }
-ta-submit = { path = "../../crates/ta-submit", version = "0.17.0-alpha.12.27" }
-ta-decision = { path = "../../crates/ta-decision", version = "0.17.0-alpha.12.27" }
-ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.0-alpha.12.27" }
-ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.0-alpha.12.27" }
-ta-build = { path = "../../crates/ta-build", version = "0.17.0-alpha.12.27" }
-ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.0-alpha.12.27" }
-ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.0-alpha.12.27" }
-ta-init = { path = "../../crates/ta-init", version = "0.17.0-alpha.12.27" }
-ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.0-alpha.12.27" }
-ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.0-alpha.12.27" }
-ta-intake = { path = "../../crates/ta-intake", version = "0.17.0-alpha.12.27" }
-ta-brain = { path = "../../crates/ta-brain", version = "0.17.0-alpha.12.27" }
-ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.0-alpha.12.27" }
+ta-audit = { path = "../../crates/ta-audit", version = "0.17.0-alpha.12.28" }
+ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.0-alpha.12.28" }
+ta-memory = { path = "../../crates/ta-memory", version = "0.17.0-alpha.12.28" }
+ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.0-alpha.12.28" }
+ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.0-alpha.12.28" }
+ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.0-alpha.12.28" }
+ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.0-alpha.12.28" }
+ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.0-alpha.12.28" }
+ta-goal = { path = "../../crates/ta-goal", version = "0.17.0-alpha.12.28" }
+ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.0-alpha.12.28" }
+ta-policy = { path = "../../crates/ta-policy", version = "0.17.0-alpha.12.28" }
+ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.0-alpha.12.28" }
+ta-session = { path = "../../crates/ta-session", version = "0.17.0-alpha.12.28" }
+ta-events = { path = "../../crates/ta-events", version = "0.17.0-alpha.12.28" }
+ta-submit = { path = "../../crates/ta-submit", version = "0.17.0-alpha.12.28" }
+ta-decision = { path = "../../crates/ta-decision", version = "0.17.0-alpha.12.28" }
+ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.0-alpha.12.28" }
+ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.0-alpha.12.28" }
+ta-build = { path = "../../crates/ta-build", version = "0.17.0-alpha.12.28" }
+ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.0-alpha.12.28" }
+ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.0-alpha.12.28" }
+ta-init = { path = "../../crates/ta-init", version = "0.17.0-alpha.12.28" }
+ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.0-alpha.12.28" }
+ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.0-alpha.12.28" }
+ta-intake = { path = "../../crates/ta-intake", version = "0.17.0-alpha.12.28" }
+ta-brain = { path = "../../crates/ta-brain", version = "0.17.0-alpha.12.28" }
+ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.0-alpha.12.28" }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/crates/ta-advisor/Cargo.toml
+++ b/crates/ta-advisor/Cargo.toml
@@ -17,12 +17,12 @@ tracing = { workspace = true }
 
 # Reuses the existing heuristic classifier as the substrate for the new
 # 4-way taxonomy rather than duplicating keyword-matching logic.
-ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.27" }
+ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.28" }
 # Team-coordinator capability (v0.17.0.12.20): reuses ta-intake's TriggerEvent
 # and ta-brain's routing/prioritization rather than a new persistent role —
 # see crates/ta-advisor/src/coordinator.rs for the decision rationale.
-ta-intake = { path = "../ta-intake", version = "0.17.0-alpha.12.27" }
-ta-brain = { path = "../ta-brain", version = "0.17.0-alpha.12.27" }
+ta-intake = { path = "../ta-intake", version = "0.17.0-alpha.12.28" }
+ta-brain = { path = "../ta-brain", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-brain/Cargo.toml
+++ b/crates/ta-brain/Cargo.toml
@@ -18,13 +18,13 @@ chrono = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
-ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.27" }
-ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.27" }
-ta-intake = { path = "../ta-intake", version = "0.17.0-alpha.12.27" }
+ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.28" }
+ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.28" }
+ta-intake = { path = "../ta-intake", version = "0.17.0-alpha.12.28" }
 # Folds ta-workflow's template-matching intent resolver in as one signal
 # route() consults (v0.17.0.12.23), rather than a second, parallel intent
 # system — see route.rs's resolve_workflow_template().
-ta-workflow = { path = "../ta-workflow", version = "0.17.0-alpha.12.27" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/comfyui/Cargo.toml
+++ b/crates/ta-connectors/comfyui/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.0-alpha.12.27" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/discord/Cargo.toml
+++ b/crates/ta-connectors/discord/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.0-alpha.12.27" }
+ta-events = { path = "../../ta-events", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/email/Cargo.toml
+++ b/crates/ta-connectors/email/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.0-alpha.12.27" }
+ta-events = { path = "../../ta-events", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/fs/Cargo.toml
+++ b/crates/ta-connectors/fs/Cargo.toml
@@ -16,10 +16,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.0-alpha.12.27" }
-ta-workspace = { path = "../../ta-workspace", version = "0.17.0-alpha.12.27" }
-ta-audit = { path = "../../ta-audit", version = "0.17.0-alpha.12.27" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.0-alpha.12.28" }
+ta-workspace = { path = "../../ta-workspace", version = "0.17.0-alpha.12.28" }
+ta-audit = { path = "../../ta-audit", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-ta-policy = { path = "../../ta-policy", version = "0.17.0-alpha.12.27" }
+ta-policy = { path = "../../ta-policy", version = "0.17.0-alpha.12.28" }

--- a/crates/ta-connectors/slack/Cargo.toml
+++ b/crates/ta-connectors/slack/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.0-alpha.12.27" }
+ta-events = { path = "../../ta-events", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/unreal/Cargo.toml
+++ b/crates/ta-connectors/unreal/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.0-alpha.12.27" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -31,23 +31,23 @@ async-stream = { workspace = true }
 sha2 = { workspace = true }
 
 # Internal crates
-ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.0-alpha.12.27" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.27" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.27" }
-ta-memory = { path = "../ta-memory", version = "0.17.0-alpha.12.27" }
-ta-events = { path = "../ta-events", version = "0.17.0-alpha.12.27" }
-ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.27" }
-ta-runtime = { path = "../ta-runtime", version = "0.17.0-alpha.12.27" }
-ta-audit = { path = "../ta-audit", version = "0.17.0-alpha.12.27" }
-ta-policy = { path = "../ta-policy", version = "0.17.0-alpha.12.27" }
-ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.0-alpha.12.27" }
-ta-connector-email = { path = "../ta-connectors/email", version = "0.17.0-alpha.12.27" }
+ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.0-alpha.12.28" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.28" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.28" }
+ta-memory = { path = "../ta-memory", version = "0.17.0-alpha.12.28" }
+ta-events = { path = "../ta-events", version = "0.17.0-alpha.12.28" }
+ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.28" }
+ta-runtime = { path = "../ta-runtime", version = "0.17.0-alpha.12.28" }
+ta-audit = { path = "../ta-audit", version = "0.17.0-alpha.12.28" }
+ta-policy = { path = "../ta-policy", version = "0.17.0-alpha.12.28" }
+ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.0-alpha.12.28" }
+ta-connector-email = { path = "../ta-connectors/email", version = "0.17.0-alpha.12.28" }
 reqwest = { workspace = true }
-ta-output-schema = { path = "../ta-output-schema", version = "0.17.0-alpha.12.27" }
-ta-extension = { path = "../ta-extension", version = "0.17.0-alpha.12.27" }
-ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.27" }
-ta-advisor = { path = "../ta-advisor", version = "0.17.0-alpha.12.27" }
-ta-data-spec = { path = "../ta-data-spec", version = "0.17.0-alpha.12.27" }
+ta-output-schema = { path = "../ta-output-schema", version = "0.17.0-alpha.12.28" }
+ta-extension = { path = "../ta-extension", version = "0.17.0-alpha.12.28" }
+ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.28" }
+ta-advisor = { path = "../ta-advisor", version = "0.17.0-alpha.12.28" }
+ta-data-spec = { path = "../ta-data-spec", version = "0.17.0-alpha.12.28" }
 which = "7"
 libc = { workspace = true }
 async-trait = "0.1"

--- a/crates/ta-data-spec/Cargo.toml
+++ b/crates/ta-data-spec/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 [dependencies]
 schemars = { workspace = true }
 serde_json = { workspace = true }
-ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.27" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.27" }
-ta-brain = { path = "../ta-brain", version = "0.17.0-alpha.12.27" }
-ta-intake = { path = "../ta-intake", version = "0.17.0-alpha.12.27" }
+ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.28" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.28" }
+ta-brain = { path = "../ta-brain", version = "0.17.0-alpha.12.28" }
+ta-intake = { path = "../ta-intake", version = "0.17.0-alpha.12.28" }

--- a/crates/ta-db-proxy-sqlite/Cargo.toml
+++ b/crates/ta-db-proxy-sqlite/Cargo.toml
@@ -18,8 +18,8 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 rusqlite = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.0-alpha.12.27" }
-ta-db-proxy = { path = "../ta-db-proxy", version = "0.17.0-alpha.12.27" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.0-alpha.12.28" }
+ta-db-proxy = { path = "../ta-db-proxy", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-db-proxy/Cargo.toml
+++ b/crates/ta-db-proxy/Cargo.toml
@@ -17,9 +17,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.0-alpha.12.27" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.0-alpha.12.27" }
-ta-decision = { path = "../ta-decision", version = "0.17.0-alpha.12.27" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.0-alpha.12.28" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.0-alpha.12.28" }
+ta-decision = { path = "../ta-decision", version = "0.17.0-alpha.12.28" }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ta-intake/Cargo.toml
+++ b/crates/ta-intake/Cargo.toml
@@ -18,7 +18,7 @@ uuid = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
-ta-submit = { path = "../ta-submit", version = "0.17.0-alpha.12.27" }
+ta-submit = { path = "../ta-submit", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -25,22 +25,22 @@ which = { workspace = true }
 toml = { workspace = true }
 
 # Internal crates
-ta-audit = { path = "../ta-audit", version = "0.17.0-alpha.12.27" }
-ta-events = { path = "../ta-events", version = "0.17.0-alpha.12.27" }
-ta-memory = { path = "../ta-memory", version = "0.17.0-alpha.12.27" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.27" }
-ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.0-alpha.12.27" }
-ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.0-alpha.12.27" }
-ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.0-alpha.12.27" }
-ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.0-alpha.12.27" }
-ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.27" }
-ta-policy = { path = "../ta-policy", version = "0.17.0-alpha.12.27" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.27" }
-ta-workflow = { path = "../ta-workflow", version = "0.17.0-alpha.12.27" }
-ta-actions = { path = "../ta-actions", version = "0.17.0-alpha.12.27" }
-ta-submit = { path = "../ta-submit", version = "0.17.0-alpha.12.27" }
-ta-decision = { path = "../ta-decision", version = "0.17.0-alpha.12.27" }
-ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.27" }
+ta-audit = { path = "../ta-audit", version = "0.17.0-alpha.12.28" }
+ta-events = { path = "../ta-events", version = "0.17.0-alpha.12.28" }
+ta-memory = { path = "../ta-memory", version = "0.17.0-alpha.12.28" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.28" }
+ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.0-alpha.12.28" }
+ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.0-alpha.12.28" }
+ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.0-alpha.12.28" }
+ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.0-alpha.12.28" }
+ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.28" }
+ta-policy = { path = "../ta-policy", version = "0.17.0-alpha.12.28" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.28" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.0-alpha.12.28" }
+ta-actions = { path = "../ta-actions", version = "0.17.0-alpha.12.28" }
+ta-submit = { path = "../ta-submit", version = "0.17.0-alpha.12.28" }
+ta-decision = { path = "../ta-decision", version = "0.17.0-alpha.12.28" }
+ta-session = { path = "../ta-session", version = "0.17.0-alpha.12.28" }
 
 
 [dev-dependencies]

--- a/crates/ta-mediation/Cargo.toml
+++ b/crates/ta-mediation/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates for FsMediator
-ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.27" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.27" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.28" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-runtime/Cargo.toml
+++ b/crates/ta-runtime/Cargo.toml
@@ -23,8 +23,8 @@ which = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
 
-ta-credentials = { path = "../ta-credentials", version = "0.17.0-alpha.12.27" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.0-alpha.12.27" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.0-alpha.12.28" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.0-alpha.12.28" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }
-ta-policy = { path = "../ta-policy", version = "0.17.0-alpha.12.27" }
+ta-policy = { path = "../ta-policy", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-session/Cargo.toml
+++ b/crates/ta-session/Cargo.toml
@@ -25,9 +25,9 @@ notify = { workspace = true }
 toml = { workspace = true }
 
 # Workspace crates
-ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.27" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.27" }
-ta-decision = { path = "../ta-decision", version = "0.17.0-alpha.12.27" }
+ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.28" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.28" }
+ta-decision = { path = "../ta-decision", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -16,11 +16,11 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.27" }
-ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.27" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.27" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.0-alpha.12.27" }
-ta-decision = { path = "../ta-decision", version = "0.17.0-alpha.12.27" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.28" }
+ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.28" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.0-alpha.12.28" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.0-alpha.12.28" }
+ta-decision = { path = "../ta-decision", version = "0.17.0-alpha.12.28" }
 toml = "0.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/ta-workflow/Cargo.toml
+++ b/crates/ta-workflow/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.27" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.28" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -21,8 +21,8 @@ reqwest = { workspace = true }
 anyhow = { workspace = true }
 sha2 = "0.10"
 base64 = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.27" }
-ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.27" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.0-alpha.12.28" }
+ta-goal = { path = "../ta-goal", version = "0.17.0-alpha.12.28" }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -15590,4 +15590,4 @@ The team coordinator (`ta intake coordinate --dispatch`, above) uses the identic
 - **Source and documentation**: [github.com/trustedautonomy/ta](https://github.com/trustedautonomy/ta)
 - **Report bugs**: [GitHub Issues](https://github.com/trustedautonomy/ta/issues)
 - **Development roadmap**: [PLAN.md](../PLAN.md)
-- **Architecture overview**: [docs/ARCHITECTURE.md](ARCHITECTURE.md)
+- **Architecture overview**: [docs/architecture/ta-architecture-reference.md](architecture/ta-architecture-reference.md)

--- a/docs/architecture/ta-architecture-reference.md
+++ b/docs/architecture/ta-architecture-reference.md
@@ -1,0 +1,142 @@
+# TA Architecture Reference (Current State)
+
+**Status**: stable maintainer reference, first published 2026-07-16 as the v0.17.0.12.11–12.27 overhaul lands.
+**Audience**: maintainers and contributors who need "how is this actually set up," not the plain-language product description.
+**Purpose**: the current-state architecture — what's built, where the boundaries are, why the repo is organized the way it is. This is a snapshot of *what exists now*, kept accurate going forward; it formalizes the working notes in [`docs/design/ta-concepts-and-architecture.md`](../design/ta-concepts-and-architecture.md) into a stable reference. That design doc remains valuable as the historical record of *how* these decisions were reached (the gap analysis, the alternatives considered, the sequencing rationale) — read it if you want the "why," read this doc if you want the "what, today."
+**Plain-language companion**: [`docs/guides/what-is-ta.md`](../guides/what-is-ta.md) — read that first if you want the no-jargon version this document assumes.
+**Companion references**: [`ta-action-reference.md`](../design/ta-action-reference.md) (the Write/Review/Decision/Commit/Reject action vocabulary this doc's Tier 3 implements), [`ta-data-format-spec.md`](../design/ta-data-format-spec.md) (the schemas backing §3 below), [`ta-cli-verb-reference.md`](../design/ta-cli-verb-reference.md) and [`ta-user-personas.md`](../design/ta-user-personas.md) (the CLI surface built on top of everything here).
+
+---
+
+## 1. The Three-Tier Request Model, As Built
+
+Every unit of work TA does — however it originates — flows through the same three tiers:
+
+```
+Tier 1: Triggers (ta-intake)   — how work gets fed in
+        │
+        ▼
+Tier 2: Routing Brain (ta-brain) — who does it, how autonomously, how urgently
+        │
+        ▼
+Tier 3: Back Office (staged review) — Write → Review → Decision → Commit/Reject/Escalate
+```
+
+A fourth, orthogonal concern — **Tier 0, substrate maintenance** (`ta doctor`, `ta gc`) — keeps the tiers above healthy but isn't part of any one goal's flow. See §1.4.
+
+### 1.1 Tier 1 — Triggers (`ta-intake`)
+
+`ta-intake` is a **library crate with no CLI or daemon glue** — its only job is "normalize an external event into one `TriggerEvent` shape." Everything downstream (dispatch to a goal, append to a queue, route through `ta-brain`) is a thin, swappable consumer.
+
+Trigger types are **data, not code** — the same pattern used for personas and plugins. Each type is one TOML file at `.ta/triggers/<type>.toml`:
+
+```toml
+type = "schedule"
+enabled = true
+dispatch = "direct"       # or "queue"
+[settings]
+interval_secs = 3600
+goal_title = "Nightly health check"
+```
+
+Two shipped, real (not stub) `TriggerSource` implementations: `schedule` (fires on an elapsed interval) and `inbound-email` (polls a messaging plugin for new messages since a watermark). A community-authored trigger type needs only a config file plus, for a genuinely new kind of source, a small `TriggerSource` implementation — no `ta-intake` code change.
+
+`dispatch` is per-type, not hardcoded: `"direct"` creates a goal immediately (`ta run --headless`); `"queue"` appends to `.ta/intake-queue.jsonl` for batch/coordinator processing. Each trigger type tracks its own watermark independently, so repeated fires only act on genuinely new events.
+
+### 1.2 Tier 2 — Routing Brain (`ta-brain`)
+
+Every goal request — an explicit `ta run` invocation, a fired trigger event, or a free-text `ta advisor create` prompt — resolves through **one shared pure function**, `ta_brain::route()`. This is the load-bearing design discipline of this tier: one decision function, called identically regardless of how the request arrived, so an explicit CLI call and an automated trigger can never be resolved by two different systems that quietly disagree.
+
+`route()` answers five questions:
+
+| Question | Values |
+|---|---|
+| **team** | which team role (`.ta/team.toml`) owns the work |
+| **persona** | which persona (`.ta/personas/<name>.toml`), if any |
+| **agent** | which agent/model/framework runs it |
+| **security_tier** | `read_only` / `suggest` / `auto` — how autonomously it may proceed |
+| **priority** | `low` / `normal` / `high` / `urgent` |
+
+Each is resolved through the same tiered lookup (most-specific wins):
+1. Explicit flag (`--team`/`--persona`/`--agent`/`--security`/`--priority` on `ta run`)
+2. Per-workload-type binding (`.ta/workflow.toml`'s `[workload_types.<type>]`)
+3. Workflow-level default (`.ta/team.toml` per-role binding, or `.ta/workflow.toml`'s top-level `[team]`/`[security]`/`[priority]`)
+4. Built-in heuristic fallback
+
+Before resolving those tiers, `route()` classifies the request's **workload type** (`bugfix`, `docs`, `feature`, `refactor`, `test`, `release`, `security`, `chore`, `other`) from the title/payload — a simple, auditable keyword heuristic, not a model, always carrying a confidence score. Low-confidence classification is handled conservatively: `security_tier = "auto"` automatically downgrades to `"suggest"` below 65% confidence, so an uncertain guess never grants full autonomy on its own. Every routing decision (including the downgrade and its reason) is logged to `.ta/routing-decisions.jsonl`.
+
+**Two entry points sit in front of `route()`, not beside it:**
+- **`ta intake coordinate [--dispatch]`** — the "team coordinator" is a capability of the existing Advisor (its `AdvisorSecurity` trust tri-state extended, not a new persistent role), triaging `.ta/intake-queue.jsonl` into `auto-eligible` / `needs review` / `needs clarification`.
+- **`ta advisor create "<free text>"`** — parses a raw sentence into title/objective/hints via the same advisor-agent headless-conversation mechanism used for draft-review dialogue, then feeds the result into `route()` exactly as a structured request. High confidence routes immediately; low confidence asks exactly one clarifying question (via the same `ta_ask_human`-backed mechanism, see §1.3) and re-routes once. This folds `ta-workflow::intent::resolve_intent`'s workflow-template matching in as one signal `route()` consults, not a second parallel intent system.
+
+### 1.3 Tier 3 — Back Office (Staged Review)
+
+The most mature tier, and the one that doesn't change shape as part of this overhaul: an agent works inside a staged overlay (`.ta/staging/<goal-id>/`); the result becomes a reviewable `DraftPackage` (diff + AI summary + supervisor verdict); a human or a trusted policy approves; `apply` materializes it. See [`ta-action-reference.md`](../design/ta-action-reference.md) for the full Write/Review/Decision/Commit/Reject/Escalate vocabulary this tier implements, and [`ta-data-format-spec.md`](../design/ta-data-format-spec.md) for the wire shapes (`Goal`, `Draft`/`Artifact`).
+
+**What's new in this tier as of 12.26/12.27 — confidence-gated verification, closing the loop it opens:**
+
+`ta_human_verify` replaces `ta_ask_human`'s unconditional block-and-wait (kept registered as a deprecated alias) with a two-stage synthetic pre-check before ever escalating to a real human:
+1. **Opinion pass** — a headless-agent call answers the question the way a careful human reviewer would, with explicit reasoning and self-reported confidence.
+2. **Validator pass** — an independent second headless-agent call, sharing no prompt/context with the opinion pass, critiquing the opinion's reasoning rather than trusting its confidence, producing a `DecisionInput` (verdict/risk/confidence).
+
+The pair is scored through the same generic `ta_decision::gate::decide()` used elsewhere in the graph. `Commit` auto-confirms (writing the full opinion + validator reasoning to `.ta/human-verify-audit.jsonl`, gitignored); `Reject`/`Rework`/`Escalate` fall through to a real blocking human question, with the synthetic reasoning attached as context. A `security_tier != "auto"` workload always escalates straight through, skipping the synthetic stage entirely — per-`workload_type` thresholds live in `.ta/workflow.toml`'s `[human_verify.<type>]`.
+
+**Red-team autoreward (12.27) closes the remaining gap**: the validator only checks whether the opinion's reasoning is internally *sound* — it can't catch a mistake both LLM passes are blind to in the same way. `ta audit human-verify sample` runs a distinctly-framed adversarial pass ("assume this is wrong; find the failure the opinion+validator pair missed," never a second soundness check) over a sample of already-auto-confirmed entries. Confirmed misses are appended to `.ta/verify-failures.jsonl` — **committed, not gitignored**, a durable calibration dataset — and feed back into the system two ways: (a) folded into future opinion/validator prompts for that `workload_type` as few-shot context, and (b) if misses cluster above a configurable rate, a threshold-tightening *proposal* is appended to `.ta/verify-threshold-proposals.jsonl` for a human to approve — never applied automatically, since thresholds are a trust boundary. `ta audit human-verify metrics` surfaces auto-confirm rate, catch rate, and false-confirm rate per `workload_type` over time, so drift is visible instead of discovered after an incident.
+
+### 1.4 Tier 0 — Substrate Maintenance (`ta doctor`, `ta gc`)
+
+Not a Trigger, not the Brain, not part of the Write/Review/Decision/Commit/Reject graph. `ta doctor`'s checks (daemon health, disk pressure, stale goals/staging dirs/drafts, version/plan drift, log size) are the health of the substrate the three tiers above run on — orthogonal to any specific goal or routing decision, the same way office facility maintenance has nothing to do with any one contractor's job. `ta gc` is the same Tier-0 backend, exposed as the non-interactive alias (`doctor --fix --yes`) for cron/unattended use.
+
+---
+
+## 2. Library-Crate Boundaries
+
+The three tiers are organized as **library crates, decoupled from any one binary**, so the Brain is genuinely reusable rather than reimplemented per entry point:
+
+| Crate | Owns | Consumed by |
+|---|---|---|
+| `ta-intake` | `TriggerEvent` normalization, per-type `TriggerSource` trait, watermarking | `ta intake fire`/`list`/`queue`/`coordinate` (thin CLI glue), `ta-brain` |
+| `ta-brain` | `route()` — the pure decision function; workload classification | `ta run`, `ta advisor create`, `ta intake coordinate --dispatch`, any future trigger-fired entry point |
+| Back office (`ta-changeset`, `ta-policy`, `ta-goal`, `ta-submit`) | Staging, `DraftPackage`, `ApprovalRule`/`AccessConstitution`, per-application `commit()`, supervisor review | `ta draft`/`ta run`/`ta apply` command paths |
+| `ta-mcp-gateway` | `ta_human_verify` (+ deprecated `ta_ask_human` alias), other MCP tool surfaces | Agents calling back into TA mid-goal; the human-verify audit/red-team loop (§1.3) |
+| `ta-data-spec` | The five versioned JSON Schema wire types (§3) | `ta-daemon`'s API layer, Studio, community trigger-configs/plugins |
+
+**The discipline that makes this work**: `ta-brain::route()` is a single function called identically whether the request is an explicit `ta run` or a normalized `TriggerEvent` — there is no second, parallel routing path for automated work. The same applies to the Advisor's clarifying-question mechanism (§1.2, §1.3): `ta advisor create`'s low-confidence path and `ta intake coordinate --dispatch`'s `needs_clarification` outcome both reuse the identical `ta_ask_human`-backed headless-agent mechanism, not two separate conversational loops.
+
+---
+
+## 3. Data-Format Specs — The Real Interface Boundary
+
+TA stays a **single Cargo workspace**, not a split of per-tier repos — a split would add cross-repo schema drift and version-pinning friction without a real payoff for a project with a single release train. Instead, the boundary between TA's core and everything that needs to interoperate with it (Studio, community trigger-configs, community plugins) is enforced at the **data** level.
+
+`ta-data-spec` (published v0.17.0.12.21) generates versioned JSON Schema directly from the real, already-`serde`-annotated Rust types via [`schemars`](https://docs.rs/schemars) — not a hand-maintained mirror that can drift from what's actually serialized on the wire:
+
+| Spec | Rust type | Crate |
+|---|---|---|
+| `Goal` | `GoalRun` | `ta-goal` |
+| `Draft` / `Artifact` | `DraftPackage` / `Artifact` | `ta-changeset` |
+| `TriggerEvent` | `TriggerEvent` | `ta-intake` |
+| `RoutingDecision` | `RoutingDecision` | `ta-brain` |
+| `Persona` | `PersonaConfig` | `ta-goal` |
+
+Each schema carries a stable `$id` and an explicit `x-ta-schema-version`, independent of the workspace semver. A schema-sync test fails CI if a checked-in schema drifts from what the current Rust types would generate; a round-trip test fails CI if a type change breaks deserialization of a frozen example — the concrete guarantee behind "a schema change that breaks an existing serialized example fails CI."
+
+**The Studio boundary rule, and how it's enforced**: Studio is a separately-deployable add-on against the daemon's HTTP/SSE API — it may never special-case internal Rust types, only the versioned spec above. Since Studio is JS, the rule is enforced one layer down, at `ta-daemon`'s own API response types: prefer a purpose-built response DTO over serializing an internal type directly; a response may embed a spec type directly only alongside an explicit `schema_version` field. `ta-data-spec`'s `studio_boundary.rs` test statically scans `ta-daemon`'s API response definitions for a spec type embedded without that sibling field and fails CI if it finds one.
+
+Full detail: [`ta-data-format-spec.md`](../design/ta-data-format-spec.md).
+
+---
+
+## 4. Why This Stays One Monorepo
+
+Multi-repo only pays off when pieces need independent release cadence or separate team ownership — neither applies here (single release train). A split would *add* the exact friction it would be trying to solve: cross-repo schema drift, version-pinning overhead, more install/setup steps. TA is already workspace-organized (~30 crates); the fix for coupling concerns is tighter internal boundaries — the library-crate split in §2 and the data-format contract in §3 — not repo boundaries. Studio remains what it already is: a separately-deployable add-on against the daemon's API, governed by the boundary rule in §3, living in the same workspace for now because nothing about it requires an independent release cycle.
+
+---
+
+## 5. Where to Go Next
+
+- **The action/graph vocabulary** (Write/Review/Decision/Commit/Reject, Consensus, HumanGate, Invoke/Switch/Parallel, Audit/Meter): [`ta-action-reference.md`](../design/ta-action-reference.md).
+- **The wire-format schemas**: [`ta-data-format-spec.md`](../design/ta-data-format-spec.md).
+- **The CLI surface built on top of all of this** (10-verb human-facing layer vs. full automation-facing surface): [`ta-cli-verb-reference.md`](../design/ta-cli-verb-reference.md) and, for how each persona actually uses it, [`ta-user-personas.md`](../design/ta-user-personas.md).
+- **The design history** — gap analysis, alternatives considered, and the sequencing rationale behind everything in this doc: [`ta-concepts-and-architecture.md`](../design/ta-concepts-and-architecture.md). Its §4 (knowledge hierarchy), §8 (community contribution security review), and §13 (this three-tier model's original proposal) sections cover work still ahead, not yet reflected here because it isn't built.
+- **User-facing behavior docs**: [`docs/USAGE.md`](../USAGE.md)'s "Trigger Layer", "Routing Brain", and "Confidence-Gated Verification" sections document the same systems from an operator's how-do-I-configure-this angle.

--- a/docs/design/ta-action-reference.md
+++ b/docs/design/ta-action-reference.md
@@ -3,6 +3,7 @@
 **Status**: canonical reference, distilled from [`ta-concepts-and-architecture.md`](ta-concepts-and-architecture.md) §1–12, 2026-07-04.
 **Purpose**: the complete instruction set TA operates in — every action, grouped, and how real flows compose them. Deliberately mirrors [kwg/sage-lore](https://github.com/kwg/sage-lore)'s own README shape (Execution Model → grouped Primitives → composed Flows) since that presentation is exactly what was asked for — without adopting sage-lore itself (see [`sage-lore-review.md`](sage-lore-review.md): complement, don't depend on it).
 **Read first if you want the plain version**: [`docs/guides/what-is-ta.md`](../guides/what-is-ta.md).
+**Current-state architecture reference**: [`ta-architecture-reference.md`](../architecture/ta-architecture-reference.md) — the maintainer-level "how it is set up" doc; this reference is scoped to actions, that one is scoped to the tier/crate/data-boundary architecture those actions run inside.
 **Data shapes for these actions**: [`ta-data-format-spec.md`](ta-data-format-spec.md) — the versioned JSON Schema for `Goal`, `Draft`/`Artifact`, `TriggerEvent`, `RoutingDecision`, and `Persona`, the data these actions actually operate on.
 
 ---

--- a/docs/design/ta-cli-verb-reference.md
+++ b/docs/design/ta-cli-verb-reference.md
@@ -59,3 +59,5 @@ This is the actual design principle, not just a cleanup: **the full 70+ command 
 - **Agent/workflow-authoring surface (full ~70+ commands)**: this is what a workflow definition, the Advisor's own tool-calling, or a future visual workflow builder (v0.18+) compose against. An LLM predicting "what should happen next in this workflow" needs the *full* verb+noun+flag vocabulary, not the trimmed human one — restricting automation to the same small surface a person sees would make workflows less capable, not safer.
 
 So the reduction target is specifically the **`--help` output and documentation a new user reads first**, not the actual command count. See `docs/design/ta-user-personas.md` for what this looks like from each persona's side — what they'd want to do, what they'd actually type, and what happens invisibly.
+
+See also [`ta-architecture-reference.md`](../architecture/ta-architecture-reference.md) for how the systems these commands drive (triggers, the routing brain, staged review) actually fit together.

--- a/docs/design/ta-concepts-and-architecture.md
+++ b/docs/design/ta-concepts-and-architecture.md
@@ -1,6 +1,6 @@
 # TA Concepts & Architecture: Current State, Right Abstractions, and Refactor Path
 
-**Status**: Living design document review, first written 2026-07-04
+**Status**: Historical design-review record, first written 2026-07-04. As of v0.17.0.12.28, the parts of this document that shipped (§§1-3, 13, 13.1) have been formalized into [`ta-architecture-reference.md`](../architecture/ta-architecture-reference.md) as the current-state maintainer reference — read that doc for "what's built today." This document remains the record of *how* those decisions were reached (the gap analysis, alternatives considered, sequencing rationale) and of what's still deliberately deferred (§4 knowledge hierarchy, §8 community security review workflow, true concurrent sub-goal execution).
 **Purpose**: A single, honest inventory of every core concept TA has, what abstraction each one *should* use, whether it currently does, and a sequenced plan to close the gaps. Written in response to a direct architecture review request after the 0.17.0.12.x cleanup arc and the sage-lore/sage/graphify research (see [`sage-lore-review.md`](sage-lore-review.md)).
 
 **How to use this doc**: it's the reference for (a) what to refactor and when, (b) why Studio's UI is overly complex, (c) why the CLI command surface is overly complex, and (d) what "smallest clean verb set" TA should converge on. Update it as concepts change — don't let it go stale like the old `docs/design/sage-lore-review.md` reference did before this session existed.

--- a/docs/design/ta-data-format-spec.md
+++ b/docs/design/ta-data-format-spec.md
@@ -61,4 +61,5 @@ In practice, since Studio itself is JS (it can't import a Rust type even by acci
 ## See also
 
 - [`ta-action-reference.md`](ta-action-reference.md) — the action/verb model these data types flow through.
+- [`ta-architecture-reference.md`](../architecture/ta-architecture-reference.md) §3 — the current-state maintainer reference covering this same boundary alongside the rest of the system's tier/crate structure.
 - [`ta-concepts-and-architecture.md` §13.1](ta-concepts-and-architecture.md) — the design reasoning behind staying monorepo and using data-format specs as the real boundary.

--- a/docs/design/ta-user-personas.md
+++ b/docs/design/ta-user-personas.md
@@ -73,3 +73,5 @@ ta show draft <id>       # to see the rendered output, not a code diff
 ## The pattern across all four
 
 Every persona's *explicit* surface is a handful of commands (`run`, `status`, `show`, `approve`/`deny`, and increasingly just natural language to the Advisor). Everything else — agent selection, policy checks, plugin dispatch, team/persona resolution — is implicit, chained by a workflow definition or decided by the Advisor. The full ~70-command surface exists for that implicit layer to compose against, not for a person to memorize. See §4 of `ta-cli-verb-reference.md` for why that's a deliberate split, not a shortfall.
+
+The "just natural language to the Advisor" path referenced above is `ta advisor create` — see [`ta-architecture-reference.md`](../architecture/ta-architecture-reference.md) §1.2 for how it resolves a free-text request through the same routing brain every other entry point uses.

--- a/docs/guides/what-is-ta.md
+++ b/docs/guides/what-is-ta.md
@@ -1,6 +1,6 @@
 # What Is TA, In Plain Terms
 
-> A no-jargon description of what Trusted Autonomy actually is and does, meant to be read as a sanity check before committing to technical plan work. If this doesn't match the product you're trying to build, that's worth catching *before* the plan, not after. The deep technical version of everything below lives in [`docs/design/ta-concepts-and-architecture.md`](../design/ta-concepts-and-architecture.md); this document is the plain-language companion, the same relationship [why-constitution.md](why-constitution.md) has to [`TA-CONSTITUTION.md`](../TA-CONSTITUTION.md).
+> A no-jargon description of what Trusted Autonomy actually is and does, meant to be read as a sanity check before committing to technical plan work. If this doesn't match the product you're trying to build, that's worth catching *before* the plan, not after. The deep technical version of everything below lives in [`docs/architecture/ta-architecture-reference.md`](../architecture/ta-architecture-reference.md) (the current-state maintainer reference); the fuller design history behind those decisions is in [`docs/design/ta-concepts-and-architecture.md`](../design/ta-concepts-and-architecture.md). This document is the plain-language companion, the same relationship [why-constitution.md](why-constitution.md) has to [`TA-CONSTITUTION.md`](../TA-CONSTITUTION.md).
 
 ## The one-sentence version
 
@@ -19,27 +19,33 @@ Think of TA's AI agents like a new contractor on your team: talented, fast, work
 - **A built-in reviewer ("supervisor")** — an AI that automatically double-checks the writeup before a human even sees it, like a QA pass that never gets tired.
 - **The rulebook ("constitution")** — the standing rules for what's always fine, what always needs a person's sign-off, and what's off-limits entirely. Written once; applies to everything after.
 - **The "make it real" moment ("commit" / "apply")** — the one narrow gate where a change actually becomes permanent: code gets saved, a database updates, a post goes live, a release ships. This is the *only* place anything becomes real, and it is always the last step — never something the worker does directly.
-- **An assistant you talk to ("advisor")** — a plain-language chat partner that explains what's going on, answers questions, and can queue up new work.
-- **Different specialists (teams, roles, "personas")** — you can configure different AI workers for different kinds of jobs: a careful reviewer, a fast implementer, someone specifically trusted with releases — each with its own level of trust.
+- **An assistant you talk to ("advisor")** — a plain-language chat partner that explains what's going on, answers questions, and can queue up new work. You can also just tell it what you want in a sentence ("also clean up the flaky login test") instead of filling in who should do it or how careful to be — it figures the rest out, and if it isn't sure, it asks you one clarifying question rather than guessing.
+- **Different specialists (teams, roles, "personas")** — you can configure different AI workers for different kinds of jobs: a careful reviewer, a fast implementer, someone specifically trusted with releases — each with its own level of trust. Roles and their trust level aren't fixed in stone; adding a new kind of specialist, or changing which underlying AI model/engine actually powers one, is a configuration change, not a rebuild.
+- **Work that starts itself ("triggers")** — not everything has to begin with you typing a request. A trigger is a standing rule for "when X happens, turn it into work": a clock ("every night, do a health check"), an inbound email, or (eventually) an incoming webhook. You define the trigger once; after that, the work shows up in the same place everything else does.
+- **A dispatcher ("the routing brain")** — whether work arrives because you asked directly or because a trigger fired, the same dispatcher decides who should do it, how autonomously they're allowed to proceed, and how urgent it is — so a triggered job and a hand-typed request get sorted by the same rules, not two different systems that can quietly disagree.
+- **A second opinion before bothering you ("verification")** — when the worker genuinely can't resolve something on its own and would normally have to stop and ask you, TA first tries a quick, disciplined double-check of its own: one AI pass answers the question the way a careful reviewer would, a second, independent pass critiques that answer's reasoning. If the two agree confidently, TA moves on and simply shows you the reasoning later — no need to interrupt you for something routine. If they don't agree, or the stakes are high, it still stops and asks you, exactly as before. Every one of these auto-answered questions is logged, and a separate adversarial check periodically re-examines a sample of them looking specifically for cases where the double-check itself was fooled — so a wrong auto-answer gets caught and folded back into how future questions are judged, instead of quietly repeating.
 - **Plug-ins for the outside world ("adapters," "connectors")** — how TA reaches real systems: your code repository, a database, social media, email, chat tools. Some come built in; others can be added later, including ones the community builds and shares.
 
 ## How a piece of work actually flows
 
-1. Something needs doing — you say so, or (eventually) the system pulls the next item from an agreed backlog on its own.
-2. TA gives an AI worker a private practice copy to work in. Nothing outside that copy can be touched.
-3. The worker does the job.
-4. Before anything becomes real, TA's own reviewer checks the work and writes a plain-language summary: what changed, why, anything that looks risky.
-5. That summary goes to you for a final look — unless the work is routine and low-risk enough that you've already said "things like this can go through automatically," in which case it's approved on the spot, with the reasoning recorded so you can always see why later.
-6. Only now does the change become real, through the one careful gate.
-7. If it's rejected, the worker tries again with your feedback, or the idea is dropped. Either way nothing was ever at risk, because nothing outside the practice copy was ever touched.
-8. Every step is logged. You can always answer "what happened, and why" for anything TA has ever done.
+1. Something needs doing — you say so (in plain language, or with the specific details filled in), or a trigger you set up fires on its own (a schedule, an inbound email, and eventually other sources).
+2. The routing brain sorts it: who should do this, how much autonomy they get, how urgent it is. If you asked directly and were specific, your answer wins outright. If you just described the work in a sentence, or a trigger fired, the brain fills in the rest — and asks you one clarifying question first if it isn't confident.
+3. TA gives an AI worker a private practice copy to work in. Nothing outside that copy can be touched.
+4. The worker does the job. If it hits a question it can't resolve alone, TA tries its own quick double-check first (see "verification" above) before ever interrupting you — and still comes straight to you when the double-check itself isn't confident.
+5. Before anything becomes real, TA's own reviewer checks the work and writes a plain-language summary: what changed, why, anything that looks risky.
+6. That summary goes to you for a final look — unless the work is routine and low-risk enough that you've already said "things like this can go through automatically," in which case it's approved on the spot, with the reasoning recorded so you can always see why later.
+7. Only now does the change become real, through the one careful gate.
+8. If it's rejected, the worker tries again with your feedback, or the idea is dropped. Either way nothing was ever at risk, because nothing outside the practice copy was ever touched.
+9. Every step is logged. You can always answer "what happened, and why" for anything TA has ever done.
 
 ## How you'd actually use it, day to day
 
 - Talk to it as a command-line tool if you're technical, or through a web dashboard ("Studio") if you want something more visual. Both are getting simpler as part of the current cleanup — today both have more buttons and screens than they should, which is exactly the kind of thing the plan work fixes.
-- Set up your rules and your team once: who does what, what needs your OK, what doesn't.
-- After that, your day-to-day involvement should mostly be: hand it work (or let it pull from an agreed backlog), answer the occasional question it can't resolve alone, glance at a dashboard, and weigh in on the handful of things that genuinely need your judgment. Most of the repetitive, grinding work should happen without anyone babysitting every step — that's the actual point of calling this a "team" instead of a tool you have to keep operating by hand.
+- Set up your rules and your team once: who does what, what needs your OK, what doesn't, and any standing triggers you want firing work on their own.
+- Hand it work either by describing it precisely (which team, which specialist, how careful to be) or just by saying what you want in plain language and letting the routing brain work out the rest.
+- After that, your day-to-day involvement should mostly be: hand it work (or let it pull from an agreed backlog, or a trigger feed it automatically), answer the occasional question it genuinely can't resolve on its own — even after its own double-check — glance at a dashboard, and weigh in on the handful of things that genuinely need your judgment. Most of the repetitive, grinding work should happen without anyone babysitting every step — that's the actual point of calling this a "team" instead of a tool you have to keep operating by hand.
 - The same trust model applies no matter what the "real thing" is — a codebase, a database, a social account, a game or content release. Same shape, different destination.
+- There's also quiet, unglamorous upkeep running in the background — checking that the system itself is healthy (disk space, stale files, things left half-finished) — that has nothing to do with any specific piece of work. Think of it as building maintenance for the office the workers operate out of: it's not part of any job, it's what keeps the building usable for the next one.
 
 ## Why this matters before the plan work starts
 


### PR DESCRIPTION
## Summary
- Refreshes `docs/guides/what-is-ta.md` to describe the system as it actually works post 12.11-12.27 (data-defined roles, agent/model switching, trigger layer, routing brain, NL advisor entry point, `ta_human_verify` two-stage verification + red-team loop).
- Adds `docs/architecture/ta-architecture-reference.md` — new maintainer-level current-state reference, formalizing `ta-concepts-and-architecture.md`'s working notes (now repositioned as historical record).
- Cross-links new/refreshed docs with the existing action-reference, data-format-spec, CLI-verb-reference, and user-personas docs.
- Fixes a pre-existing dead "Architecture overview" link in USAGE.md.

Supervisor review: PASS (5/5 findings), doc-only, no scope drift, no manual version tampering.

## Test plan
- [x] `./dev cargo build --workspace`
- [x] `./dev cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./dev cargo fmt --all -- --check`
- [x] `./dev cargo test --workspace`