### PR TITLE
fix: two more .ta/drafts wrong-path bugs (same class as #560)

### DIFF
--- a/apps/ta-cli/src/commands/plan.rs
+++ b/apps/ta-cli/src/commands/plan.rs
@@ -7528,7 +7528,7 @@ fn plan_build_autonomous(
 /// Try to find the PR number for a phase from the applied draft's VCS tracking metadata.
 fn find_pr_for_phase(workspace: &std::path::Path, phase_id: &str) -> Option<u64> {
     use ta_changeset::draft_package::{DraftPackage, DraftStatus};
-    let drafts_dir = workspace.join(".ta").join("drafts");
+    let drafts_dir = workspace.join(".ta").join("pr_packages");
     if !drafts_dir.is_dir() {
         return None;
     }

--- a/crates/ta-session/src/advisor_agent.rs
+++ b/crates/ta-session/src/advisor_agent.rs
@@ -455,7 +455,7 @@ fn check_draft_terminal(draft_file: &Path, draft_id: Uuid) -> Option<AdvisorOutc
 
 /// Poll the draft status until it reaches a terminal state (Applied or Denied).
 ///
-/// Preferred path: watches `.ta/drafts/<id>.json` with `notify` for modify/create
+/// Preferred path: watches `.ta/pr_packages/<id>.json` with `notify` for modify/create
 /// events — no spin-sleep. Falls back to `poll_interval` (min 500 ms) sleep-polling
 /// when a file watcher cannot be established.
 pub fn poll_draft_outcome(
@@ -464,7 +464,7 @@ pub fn poll_draft_outcome(
     timeout: Duration,
     poll_interval: Duration,
 ) -> AdvisorOutcome {
-    let drafts_dir = workspace_root.join(".ta").join("drafts");
+    let drafts_dir = workspace_root.join(".ta").join("pr_packages");
     let draft_file = drafts_dir.join(format!("{}.json", draft_id));
     let deadline = Instant::now() + timeout;
 
@@ -908,7 +908,7 @@ mod tests {
     fn poll_draft_outcome_applied_status() {
         let tmp = TempDir::new().unwrap();
         let draft_id = Uuid::new_v4();
-        let drafts_dir = tmp.path().join(".ta/drafts");
+        let drafts_dir = tmp.path().join(".ta/pr_packages");
         std::fs::create_dir_all(&drafts_dir).unwrap();
         let draft_file = drafts_dir.join(format!("{}.json", draft_id));
         // Write a draft JSON with "applied" status.
@@ -930,7 +930,7 @@ mod tests {
     fn poll_draft_outcome_denied_status() {
         let tmp = TempDir::new().unwrap();
         let draft_id = Uuid::new_v4();
-        let drafts_dir = tmp.path().join(".ta/drafts");
+        let drafts_dir = tmp.path().join(".ta/pr_packages");
         std::fs::create_dir_all(&drafts_dir).unwrap();
         let draft_file = drafts_dir.join(format!("{}.json", draft_id));
         std::fs::write(


### PR DESCRIPTION
## Summary
- Fixes `plan.rs::find_pr_for_phase` and `ta-session::advisor_agent::poll_draft_outcome`, both of which hardcoded the nonexistent `.ta/drafts` path instead of the real `.ta/pr_packages` — the same bug class fixed in #560's `poll_for_phase_draft`, in two separate, independently-implemented draft-lookup functions.

## Why this is urgent
Discovered live while running the v0.17.3+ autonomous phase-build loop, before it hit the broken step:
- `find_pr_for_phase` is called by `ta plan build --autonomous` right after a draft applies, to find the PR number so it can wait for CI and merge. Since it always returned `None`, the loop would silently skip CI-wait/merge-wait and mark the phase **complete without ever confirming the PR merged** — which would then let the next dependent phase start against a stale `main` missing the "completed" phase's actual changes.
- `poll_draft_outcome` is the advisor-review polling loop used earlier in the same flow; it would have hung the full timeout on every review before even reaching `find_pr_for_phase`.

## Also swept, left as-is
- `acquire_reviewer_lock` (advisor_agent.rs) and `dialog_path` (ta-daemon/draft_dialog.rs) both reference `.ta/drafts` too, but self-consistently — they create and read their own files there, not the shared `DraftPackage` JSON written elsewhere.
- `governed_workflow.rs::build_reviewer_prompt` has a similar dead primary path but degrades gracefully via an existing fallback to `pr_packages`; different shape (expects a per-draft directory with sub-files nothing writes), not blocking, not fixed here.

## Test plan
- `cargo test -p ta-session advisor_agent` — 21 passed.
- `cargo build --workspace`, `cargo test --workspace` — 0 failures.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.