### PR TITLE
fix: ta goal recover state guard blocks draft rebuild for Failed goals

### DIFF
--- a/apps/ta-cli/src/commands/goal.rs
+++ b/apps/ta-cli/src/commands/goal.rs
@@ -1261,6 +1261,16 @@ fn goal_recover(
             1 => {
                 println!();
                 println!("Rebuilding draft from staging...");
+                // `ta draft build` requires the goal to be Running or Finalizing (see
+                // draft.rs's state guard). A goal reaching this recovery path is
+                // typically Failed (e.g. the watchdog transitioned it after the agent
+                // process died) — force it back to Running first, bypassing the normal
+                // state machine, same as the has_valid_draft branch's direct state write.
+                if let Ok(Some(mut g)) = store.get(target.goal_run_id) {
+                    g.state = GoalRunState::Running;
+                    g.updated_at = chrono::Utc::now();
+                    store.save(&g)?;
+                }
                 super::draft::execute(
                     &super::draft::DraftCommands::Build {
                         goal_id: target.goal_run_id.to_string(),


### PR DESCRIPTION
## Summary
\`ta goal recover\`'s "Rebuild draft from staging" option (no-existing-draft branch) called \`ta draft build\` directly without transitioning the goal out of \`Failed\` state first. \`draft.rs\`'s build guard only accepts \`Running\`/\`Finalizing\`, so recovery always failed with "Goal is in failed state (must be running or finalizing to build draft)" — exactly the state a goal is normally in when it reaches this path (the documented "zombie not cleaned up" case: watchdog transitions a goal to \`Failed\` after its agent process dies).

## Fix
Force the goal state to \`Running\` before calling \`draft::execute\`, mirroring the existing \`has_valid_draft\` branch's direct state write (\`g.state = GoalRunState::PrReady\`) for the same kind of recovery-time state-machine bypass.

## How this was found
Found and fixed live while running the v0.17.3 autonomous phase-build. That goal's orchestrator had to be killed mid-run for an unrelated bug (#565), leaving the underlying agent to finish independently. It completed all 8 plan items (\`change_summary.json\` present, no draft), but \`ta goal recover\` errored instead of rebuilding the draft. This fix was validated directly against that real goal — recovery now correctly rebuilds the draft (18 files, matching the completed \`ta-release\` core implementation).

## Test plan
- \`cargo build --workspace\`, \`cargo test --workspace\` — 0 failures.
- \`cargo clippy --workspace --all-targets -- -D warnings\` — clean.
- \`cargo fmt --all -- --check\` — clean.
- Manually validated against real goal 81e89b3c: recovery now succeeds and produces a correct draft.
- No new automated test added — \`goal_recover\` reads interactively from stdin and drives the full draft-build pipeline (integration-test territory). The fix is a one-line state transition mirroring an existing pattern one branch over. Flagging as a coverage gap rather than skipping silently.