### PR TITLE
fix: advisor-review subprocess collides with parent goal's phase claim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ result-*
 .ta/workflow-runs/
 .ta/review/
 .ta/advisor-notes/
+.ta/advisor/
 
 # Ephemeral staging-root artifacts — written by agent during goal run, scoped to that run
 # These must NOT be applied back to source (v0.15.14.7 enforces this in the overlay)

--- a/.ta/personas/advisor.toml
+++ b/.ta/personas/advisor.toml
@@ -1,0 +1,27 @@
+[persona]
+name = "advisor"
+description = "Draft-review advisor — represents the human's interests when reviewing an agent's completed work"
+system_prompt = """
+You are the advisor reviewing a draft produced by another agent inside the
+Trusted Autonomy pipeline. You are explicitly on the human's side, not the
+implementing agent's — your job is to look out for their interests before
+anything gets applied.
+
+Focus on:
+- Present what changed clearly, in plain English, before recommending anything
+- Proactively flag risks, missing tests, or incomplete work
+- Advocate against applying a draft that looks wrong, even if it appears to satisfy the letter of the objective
+- Ask clarifying questions when something is ambiguous rather than guessing
+
+Rules:
+- When you're satisfied the draft is correct and complete, call `ta draft approve` then `ta draft apply`
+- When it isn't, call `ta draft deny` with a clear, actionable reason
+- You may NOT write to `.ta/personas/` — persona files are governed read-only for agents and can only be changed by a human via the normal `ta draft` workflow
+"""
+
+[capabilities]
+forbidden_tools = ["Edit", "Write"]
+
+[style]
+output_format = "markdown"
+max_response_length = ""

--- a/crates/ta-session/src/advisor_agent.rs
+++ b/crates/ta-session/src/advisor_agent.rs
@@ -360,6 +360,17 @@ pub fn spawn_advisor_agent(config: &AdvisorConfig, ta_bin: &Path) -> Result<Uuid
         "--no-version-check",
         "--persona",
         persona,
+        // Without this, the advisor's own `ta run` has no explicit --phase, so
+        // auto_detect_phase() falls through to "exactly one phase in_progress"
+        // and tries to claim the SAME phase the draft's implementer goal already
+        // claimed -- a guaranteed "could not be claimed: already in progress"
+        // fatal error on every autonomous-loop review. --follow-up-draft resolves
+        // the phase from the draft (which already correctly identifies it) and
+        // is the one thing in run.rs that suppresses the re-claim attempt
+        // (`if follow_up.is_none() { ...claim... }`), without changing the goal
+        // title we already set above or reusing the implementer's staging.
+        "--follow-up-draft",
+        &config.draft_id.to_string(),
     ]);
     cmd.env("TA_ADVISOR_DRAFT_ID", config.draft_id.to_string());
     // Also set the env var for any future consumer that reads it directly --


### PR DESCRIPTION
## Summary
`spawn_advisor_agent`'s `ta run --headless` invocation had no `--phase` flag, so `auto_detect_phase()` fell through to its "exactly one phase currently in_progress" fallback and tried to claim the same phase the draft's implementer goal had already claimed — a guaranteed `Phase vX.Y.Z could not be claimed: already in progress` fatal error on every autonomous-loop review step.

## Impact
This blocked the v0.17.3+ autonomous rollout at the very first real advisor-review call. v0.17.3 itself never exercised this path (its orchestrator was killed earlier for an unrelated bug and the phase was recovered manually via `ta goal recover`), so this went unnoticed until v0.17.4 hit it directly — confirmed live: `[escalate] Phase v0.17.4 agent review ended with unexpected outcome: spawn_failed: ta run --headless exited 1 for advisor goal.`

## Fix
Add `--follow-up-draft <draft_id>` to the advisor's spawn args. This resolves the phase from the draft (already correctly linked to the implementer's phase) and is the one existing mechanism in `run.rs` that suppresses the re-claim attempt (`if follow_up.is_none() { ...claim... }`) — exactly the "phase already in_progress from the parent goal" case the surrounding code's own doc comment anticipates. Verified this doesn't change the goal title (already set explicitly) or cause staging reuse (follow-up context injection is additive, not `--goal-id` reuse).

## Test plan
- `cargo build --workspace`, `cargo test -p ta-session` — 0 failures.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- Will validate against the actual stuck v0.17.4 draft (`93d53440...`) locally before merge.