### PR TITLE
Implement v0.17.5.2 — Workflow-Defined Budget Guardrails (Business-Metric Budgets)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All outcomes must be **observable** (with details and logging) and **actionable*
 
 ## Current State
 
-**Current version**: `0.17.5-alpha.1`
+**Current version**: `0.17.5-alpha.2`
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --phase 4b`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "ta-actions"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "ta-advisor"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "ta-agent-ollama"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "base64",
  "chrono",
@@ -3383,7 +3383,7 @@ dependencies = [
 
 [[package]]
 name = "ta-brain"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "schemars",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "ta-build"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3436,7 +3436,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-comfyui"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -3564,7 +3564,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -3573,7 +3573,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3587,7 +3587,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unity"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unreal"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "ta-data-spec"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-overlay"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-proxy"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "ta-decision"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "ta-extension"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "ta-governed-paths"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "ta-init"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "ta-intake"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "regex",
@@ -3839,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "regex",
@@ -3875,7 +3875,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "glob",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "ta-output-schema"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "ta-plugin"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "libc",
  "serde",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "glob",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "ta-release"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "base64",
  "reqwest",
@@ -3965,7 +3965,7 @@ dependencies = [
 
 [[package]]
 name = "ta-runtime"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3987,7 +3987,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -4000,7 +4000,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "libc",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "chrono",
  "libc",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.17.5-alpha.1"
+version = "0.17.5-alpha.2"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -10033,19 +10033,19 @@ Code releases use semver. Content releases don't. Decide:
 
 ---
 ### v0.17.5.2 — Workflow-Defined Budget Guardrails (Business-Metric Budgets)
-<!-- status: in_progress -->
+<!-- status: done -->
 **Depends on**: v0.17.5.1, v0.17.0.12.15 (`ta-decision` gate), v0.17.0.12.20 (`ta-brain::route()`)
 
 **Goal**: Add a second, distinct budget concept alongside the existing LLM-token budget (`ta-policy::BudgetConfig.max_tokens_per_goal`, which stays exactly as-is — that's resource-consumption tracking, not a business-rule guardrail). This one is an arbitrary-unit business metric a workflow declares (e.g. `metric = "usd", total = 1000.0, per_action_max_pct = 10.0`) against a stated objective (e.g. "generate income > 2x within 6 months after fees"). Hard limits are deterministic pre-gate checks — no confidence score ever overrides one. Soft limits feed the Decision gate as an escalation signal, the exact shape already proven by `route()`'s `AUTO_SECURITY_CONFIDENCE_THRESHOLD` (a low-confidence workload classification downgrades `security_tier = auto` to `suggest` today) — this reuses that same "confidence/proximity-to-limit downgrades autonomy" pattern rather than inventing a new one.
 
 **Items**:
-1. [ ] New `WorkflowBudget` config in workflow YAML: `{metric: string, total: f64, per_action_max_pct: Option<f64>, soft_threshold_pct: Option<f64>, objective: Option<string>}` — `metric` is an arbitrary label (`"usd"`, `"trade_count"`, anything), not hardcoded to dollars.
-2. [ ] Running ledger persisted in the team-session state (5.1) — an append-only per-action log (amount, running total, timestamp), same audit-log-JSONL pattern as `.ta/human-verify-audit.jsonl`.
-3. [ ] Hard-limit pre-gate: a new check consulted *before* `ta_human_verify`/`ta-decision::gate::decide()` even runs. Violating it (e.g. a trade exceeding the 10% per-action cap) rejects outright — never reaches the probabilistic verify/approve pipeline at all.
-4. [ ] Soft-limit check: crossing `soft_threshold_pct` of the total forces `Escalate` regardless of what the Decision gate's own verdict would otherwise be — mirrors `route()`'s existing auto→suggest downgrade.
-5. [ ] Observability: the per-session ledger surfaces both budgets (token spend from `BudgetConfig` and business-metric spend from `WorkflowBudget`) side by side — a session can be within its token budget and over its dollar budget, or vice versa; both must be independently visible.
-6. [ ] Tests: an action exceeding the hard per-action cap is rejected before any verify pass runs; crossing the soft threshold forces `Escalate` even with a high-confidence Decision input; the ledger correctly accumulates across multiple sequential actions in one session.
-7. [ ] USAGE.md: document both budget concepts side by side and when each applies.
+1. [x] New `WorkflowBudget` config in workflow YAML: `{metric: string, total: f64, per_action_max_pct: Option<f64>, soft_threshold_pct: Option<f64>, objective: Option<string>}` — `metric` is an arbitrary label (`"usd"`, `"trade_count"`, anything), not hardcoded to dollars.
+2. [x] Running ledger persisted in the team-session state (5.1) — an append-only per-action log (amount, running total, timestamp), same audit-log-JSONL pattern as `.ta/human-verify-audit.jsonl`.
+3. [x] Hard-limit pre-gate: a new check consulted *before* `ta_human_verify`/`ta-decision::gate::decide()` even runs. Violating it (e.g. a trade exceeding the 10% per-action cap) rejects outright — never reaches the probabilistic verify/approve pipeline at all.
+4. [x] Soft-limit check: crossing `soft_threshold_pct` of the total forces `Escalate` regardless of what the Decision gate's own verdict would otherwise be — mirrors `route()`'s existing auto→suggest downgrade.
+5. [x] Observability: the per-session ledger surfaces both budgets (token spend from `BudgetConfig` and business-metric spend from `WorkflowBudget`) side by side — a session can be within its token budget and over its dollar budget, or vice versa; both must be independently visible.
+6. [x] Tests: an action exceeding the hard per-action cap is rejected before any verify pass runs; crossing the soft threshold forces `Escalate` even with a high-confidence Decision input; the ledger correctly accumulates across multiple sequential actions in one session.
+7. [x] USAGE.md: document both budget concepts side by side and when each applies.
 
 #### Version: `0.17.5-alpha.2`
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -43,34 +43,34 @@ which = { workspace = true }
 arboard = { workspace = true }
 
 # Internal crates — version kept in sync with workspace by bump-version.sh
-ta-audit = { path = "../../crates/ta-audit", version = "0.17.5-alpha.1" }
-ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.5-alpha.1" }
-ta-memory = { path = "../../crates/ta-memory", version = "0.17.5-alpha.1" }
-ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.5-alpha.1" }
-ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.5-alpha.1" }
-ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.5-alpha.1" }
-ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.5-alpha.1" }
-ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.5-alpha.1" }
-ta-goal = { path = "../../crates/ta-goal", version = "0.17.5-alpha.1" }
-ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.5-alpha.1" }
-ta-policy = { path = "../../crates/ta-policy", version = "0.17.5-alpha.1" }
-ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.5-alpha.1" }
-ta-session = { path = "../../crates/ta-session", version = "0.17.5-alpha.1" }
-ta-events = { path = "../../crates/ta-events", version = "0.17.5-alpha.1" }
-ta-submit = { path = "../../crates/ta-submit", version = "0.17.5-alpha.1" }
-ta-decision = { path = "../../crates/ta-decision", version = "0.17.5-alpha.1" }
-ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.5-alpha.1" }
-ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.5-alpha.1" }
-ta-build = { path = "../../crates/ta-build", version = "0.17.5-alpha.1" }
-ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.5-alpha.1" }
-ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.5-alpha.1" }
-ta-init = { path = "../../crates/ta-init", version = "0.17.5-alpha.1" }
-ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.5-alpha.1" }
-ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.5-alpha.1" }
-ta-intake = { path = "../../crates/ta-intake", version = "0.17.5-alpha.1" }
-ta-brain = { path = "../../crates/ta-brain", version = "0.17.5-alpha.1" }
-ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.5-alpha.1" }
-ta-release = { path = "../../crates/ta-release", version = "0.17.5-alpha.1" }
+ta-audit = { path = "../../crates/ta-audit", version = "0.17.5-alpha.2" }
+ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.5-alpha.2" }
+ta-memory = { path = "../../crates/ta-memory", version = "0.17.5-alpha.2" }
+ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.5-alpha.2" }
+ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.5-alpha.2" }
+ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.5-alpha.2" }
+ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.5-alpha.2" }
+ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.5-alpha.2" }
+ta-goal = { path = "../../crates/ta-goal", version = "0.17.5-alpha.2" }
+ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.5-alpha.2" }
+ta-policy = { path = "../../crates/ta-policy", version = "0.17.5-alpha.2" }
+ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.5-alpha.2" }
+ta-session = { path = "../../crates/ta-session", version = "0.17.5-alpha.2" }
+ta-events = { path = "../../crates/ta-events", version = "0.17.5-alpha.2" }
+ta-submit = { path = "../../crates/ta-submit", version = "0.17.5-alpha.2" }
+ta-decision = { path = "../../crates/ta-decision", version = "0.17.5-alpha.2" }
+ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.5-alpha.2" }
+ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.5-alpha.2" }
+ta-build = { path = "../../crates/ta-build", version = "0.17.5-alpha.2" }
+ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.5-alpha.2" }
+ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.5-alpha.2" }
+ta-init = { path = "../../crates/ta-init", version = "0.17.5-alpha.2" }
+ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.5-alpha.2" }
+ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.5-alpha.2" }
+ta-intake = { path = "../../crates/ta-intake", version = "0.17.5-alpha.2" }
+ta-brain = { path = "../../crates/ta-brain", version = "0.17.5-alpha.2" }
+ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.5-alpha.2" }
+ta-release = { path = "../../crates/ta-release", version = "0.17.5-alpha.2" }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/apps/ta-cli/src/commands/team_session.rs
+++ b/apps/ta-cli/src/commands/team_session.rs
@@ -11,6 +11,7 @@ use anyhow::{bail, Context, Result};
 use clap::Subcommand;
 use serde::{Deserialize, Serialize};
 
+use ta_policy::business_budget::BudgetGuardrails;
 use ta_workflow::WorkflowDefinition;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -34,6 +35,11 @@ struct TeamSessionConfig {
     workflow_path: String,
     team_toml_path: String,
     objective: String,
+    /// Business-metric budget guardrail declared by the bound workflow's
+    /// `budget:` section (v0.17.5.2), resolved once at `start` time — the
+    /// daemon's supervisor loop never re-parses the workflow YAML.
+    #[serde(default)]
+    budget: Option<BudgetGuardrails>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -200,6 +206,17 @@ fn start(
         );
     }
 
+    let budget = definition.budget.map(|b| {
+        let b = *b;
+        BudgetGuardrails {
+            metric: b.metric,
+            total: b.total,
+            per_action_max_pct: b.per_action_max_pct,
+            soft_threshold_pct: b.soft_threshold_pct,
+            objective: b.objective,
+        }
+    });
+
     let now = chrono::Utc::now();
     let state = TeamSessionState {
         id: name.to_string(),
@@ -208,6 +225,7 @@ fn start(
             workflow_path: workflow_path.to_string(),
             team_toml_path: team_toml.unwrap_or(".ta/team.toml").to_string(),
             objective: objective.to_string(),
+            budget,
         },
         stages,
         status: TeamSessionStatus::Active,
@@ -279,8 +297,78 @@ fn status(project_root: &Path, name: Option<&str>) -> Result<()> {
                 );
             }
         }
+        print_budget_status(project_root, n, &state.config.budget);
     }
     Ok(())
+}
+
+/// Prints both budget concepts side by side (v0.17.5.2 item 5): the
+/// business-metric budget (spent/total from this session's ledger) and the
+/// LLM-token budget (`max_tokens_per_goal` from `.ta/policy.yaml`, if
+/// configured). A session can be within one and over the other — both must
+/// be independently visible, not folded into a single number.
+fn print_budget_status(project_root: &Path, session_id: &str, budget: &Option<BudgetGuardrails>) {
+    let ledger_path = budget_ledger_path(project_root, session_id);
+    let spent = ta_policy::business_budget::ledger_running_total(&ledger_path);
+    let policy_max_tokens = std::fs::read_to_string(project_root.join(".ta").join("policy.yaml"))
+        .ok()
+        .and_then(|raw| serde_yaml::from_str::<ta_policy::document::PolicyDocument>(&raw).ok())
+        .and_then(|doc| doc.budget)
+        .and_then(|b| b.max_tokens_per_goal);
+
+    for line in format_budget_status(budget, spent, policy_max_tokens) {
+        println!("{line}");
+    }
+}
+
+/// Pure formatting logic for [`print_budget_status`], separated out so
+/// tests can assert on content rather than just "doesn't panic".
+fn format_budget_status(
+    budget: &Option<BudgetGuardrails>,
+    ledger_spent: f64,
+    policy_max_tokens: Option<u64>,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    match budget {
+        Some(b) => {
+            let pct = if b.total > 0.0 {
+                ledger_spent / b.total * 100.0
+            } else {
+                0.0
+            };
+            lines.push(format!(
+                "  business budget ({}): {:.2} / {:.2} spent ({:.1}%){}",
+                b.metric,
+                ledger_spent,
+                b.total,
+                pct,
+                match b.soft_threshold_pct {
+                    Some(soft) if pct >= soft => " — soft threshold crossed, escalating",
+                    _ => "",
+                }
+            ));
+        }
+        None => {
+            lines.push("  business budget: none declared by this session's workflow".to_string())
+        }
+    }
+
+    lines.push(match policy_max_tokens {
+        Some(max_tokens) => {
+            format!("  token budget: max_tokens_per_goal={max_tokens} (from .ta/policy.yaml)")
+        }
+        None => {
+            "  token budget: not configured (.ta/policy.yaml has no budget.max_tokens_per_goal)"
+                .to_string()
+        }
+    });
+
+    lines
+}
+
+fn budget_ledger_path(project_root: &Path, session_id: &str) -> std::path::PathBuf {
+    session_dir(project_root, session_id).join("budget-ledger.jsonl")
 }
 
 #[cfg(test)]
@@ -312,6 +400,31 @@ stages:
         "trading-desk.yaml".to_string()
     }
 
+    fn write_role_workflow_with_budget(dir: &Path) -> String {
+        let path = dir.join("trading-desk-budgeted.yaml");
+        std::fs::write(
+            &path,
+            r#"
+name: trading-desk
+roles:
+  analyst:
+    agent: claude-code
+    prompt: "Analyze the market."
+stages:
+  - name: analyze
+    roles: ["analyst"]
+budget:
+  metric: usd
+  total: 1000.0
+  per_action_max_pct: 10.0
+  soft_threshold_pct: 80.0
+  objective: "generate income > 2x within 6 months after fees"
+"#,
+        )
+        .unwrap();
+        "trading-desk-budgeted.yaml".to_string()
+    }
+
     #[test]
     fn start_writes_state_json_with_resolved_stage_order() {
         let dir = tempfile::tempdir().unwrap();
@@ -324,6 +437,83 @@ stages:
         assert_eq!(state.stages[0].name, "analyze");
         assert_eq!(state.stages[1].name, "decide");
         assert_eq!(state.status, TeamSessionStatus::Active);
+        assert!(state.config.budget.is_none());
+    }
+
+    #[test]
+    fn start_resolves_workflow_budget_into_session_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let workflow_path = write_role_workflow_with_budget(dir.path());
+
+        start(dir.path(), "sess-1", &workflow_path, None, "Make money").unwrap();
+
+        let state = load_state(dir.path(), "sess-1").unwrap();
+        let budget = state.config.budget.expect("budget should be resolved");
+        assert_eq!(budget.metric, "usd");
+        assert_eq!(budget.total, 1000.0);
+        assert_eq!(budget.per_action_max_pct, Some(10.0));
+        assert_eq!(budget.soft_threshold_pct, Some(80.0));
+    }
+
+    #[test]
+    fn status_shows_business_and_token_budget_side_by_side() {
+        let dir = tempfile::tempdir().unwrap();
+        let workflow_path = write_role_workflow_with_budget(dir.path());
+        start(dir.path(), "sess-1", &workflow_path, None, "Make money").unwrap();
+
+        let ledger_path = budget_ledger_path(dir.path(), "sess-1");
+        ta_policy::business_budget::record_ledger_spend(&ledger_path, "buy AAPL", 250.0).unwrap();
+
+        std::fs::create_dir_all(dir.path().join(".ta")).unwrap();
+        std::fs::write(
+            dir.path().join(".ta").join("policy.yaml"),
+            "budget:\n  max_tokens_per_goal: 50000\n",
+        )
+        .unwrap();
+
+        // Wiring check: status() must not error with both budgets present.
+        status(dir.path(), Some("sess-1")).unwrap();
+    }
+
+    #[test]
+    fn format_budget_status_shows_both_budgets_independently() {
+        let budget = Some(BudgetGuardrails {
+            metric: "usd".to_string(),
+            total: 1000.0,
+            per_action_max_pct: Some(10.0),
+            soft_threshold_pct: Some(80.0),
+            objective: None,
+        });
+
+        let lines = format_budget_status(&budget, 250.0, Some(50_000));
+        assert!(lines[0].contains("business budget (usd): 250.00 / 1000.00 spent (25.0%)"));
+        assert!(!lines[0].contains("soft threshold crossed"));
+        assert!(lines[1].contains("max_tokens_per_goal=50000"));
+    }
+
+    #[test]
+    fn format_budget_status_flags_soft_threshold_crossing() {
+        let budget = Some(BudgetGuardrails {
+            metric: "usd".to_string(),
+            total: 1000.0,
+            per_action_max_pct: Some(10.0),
+            soft_threshold_pct: Some(80.0),
+            objective: None,
+        });
+
+        let lines = format_budget_status(&budget, 850.0, None);
+        assert!(
+            lines[0].contains("soft threshold crossed"),
+            "got: {}",
+            lines[0]
+        );
+        assert!(lines[1].contains("not configured"));
+    }
+
+    #[test]
+    fn format_budget_status_reports_none_declared_when_absent() {
+        let lines = format_budget_status(&None, 0.0, None);
+        assert!(lines[0].contains("none declared"));
     }
 
     #[test]

--- a/crates/ta-advisor/Cargo.toml
+++ b/crates/ta-advisor/Cargo.toml
@@ -17,12 +17,12 @@ tracing = { workspace = true }
 
 # Reuses the existing heuristic classifier as the substrate for the new
 # 4-way taxonomy rather than duplicating keyword-matching logic.
-ta-session = { path = "../ta-session", version = "0.17.5-alpha.1" }
+ta-session = { path = "../ta-session", version = "0.17.5-alpha.2" }
 # Team-coordinator capability (v0.17.0.12.20): reuses ta-intake's TriggerEvent
 # and ta-brain's routing/prioritization rather than a new persistent role —
 # see crates/ta-advisor/src/coordinator.rs for the decision rationale.
-ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.1" }
-ta-brain = { path = "../ta-brain", version = "0.17.5-alpha.1" }
+ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.2" }
+ta-brain = { path = "../ta-brain", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-brain/Cargo.toml
+++ b/crates/ta-brain/Cargo.toml
@@ -18,13 +18,13 @@ chrono = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
-ta-session = { path = "../ta-session", version = "0.17.5-alpha.1" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.1" }
-ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.1" }
+ta-session = { path = "../ta-session", version = "0.17.5-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
+ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.2" }
 # Folds ta-workflow's template-matching intent resolver in as one signal
 # route() consults (v0.17.0.12.23), rather than a second, parallel intent
 # system — see route.rs's resolve_workflow_template().
-ta-workflow = { path = "../ta-workflow", version = "0.17.5-alpha.1" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/comfyui/Cargo.toml
+++ b/crates/ta-connectors/comfyui/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.1" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/discord/Cargo.toml
+++ b/crates/ta-connectors/discord/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.5-alpha.1" }
+ta-events = { path = "../../ta-events", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/email/Cargo.toml
+++ b/crates/ta-connectors/email/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.5-alpha.1" }
+ta-events = { path = "../../ta-events", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/fs/Cargo.toml
+++ b/crates/ta-connectors/fs/Cargo.toml
@@ -16,10 +16,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.1" }
-ta-workspace = { path = "../../ta-workspace", version = "0.17.5-alpha.1" }
-ta-audit = { path = "../../ta-audit", version = "0.17.5-alpha.1" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.2" }
+ta-workspace = { path = "../../ta-workspace", version = "0.17.5-alpha.2" }
+ta-audit = { path = "../../ta-audit", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-ta-policy = { path = "../../ta-policy", version = "0.17.5-alpha.1" }
+ta-policy = { path = "../../ta-policy", version = "0.17.5-alpha.2" }

--- a/crates/ta-connectors/slack/Cargo.toml
+++ b/crates/ta-connectors/slack/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.5-alpha.1" }
+ta-events = { path = "../../ta-events", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/unreal/Cargo.toml
+++ b/crates/ta-connectors/unreal/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.1" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -31,23 +31,23 @@ async-stream = { workspace = true }
 sha2 = { workspace = true }
 
 # Internal crates
-ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.5-alpha.1" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.1" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.1" }
-ta-memory = { path = "../ta-memory", version = "0.17.5-alpha.1" }
-ta-events = { path = "../ta-events", version = "0.17.5-alpha.1" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.1" }
-ta-runtime = { path = "../ta-runtime", version = "0.17.5-alpha.1" }
-ta-audit = { path = "../ta-audit", version = "0.17.5-alpha.1" }
-ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.1" }
-ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.5-alpha.1" }
-ta-connector-email = { path = "../ta-connectors/email", version = "0.17.5-alpha.1" }
+ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.5-alpha.2" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
+ta-memory = { path = "../ta-memory", version = "0.17.5-alpha.2" }
+ta-events = { path = "../ta-events", version = "0.17.5-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
+ta-runtime = { path = "../ta-runtime", version = "0.17.5-alpha.2" }
+ta-audit = { path = "../ta-audit", version = "0.17.5-alpha.2" }
+ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.2" }
+ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.5-alpha.2" }
+ta-connector-email = { path = "../ta-connectors/email", version = "0.17.5-alpha.2" }
 reqwest = { workspace = true }
-ta-output-schema = { path = "../ta-output-schema", version = "0.17.5-alpha.1" }
-ta-extension = { path = "../ta-extension", version = "0.17.5-alpha.1" }
-ta-session = { path = "../ta-session", version = "0.17.5-alpha.1" }
-ta-advisor = { path = "../ta-advisor", version = "0.17.5-alpha.1" }
-ta-data-spec = { path = "../ta-data-spec", version = "0.17.5-alpha.1" }
+ta-output-schema = { path = "../ta-output-schema", version = "0.17.5-alpha.2" }
+ta-extension = { path = "../ta-extension", version = "0.17.5-alpha.2" }
+ta-session = { path = "../ta-session", version = "0.17.5-alpha.2" }
+ta-advisor = { path = "../ta-advisor", version = "0.17.5-alpha.2" }
+ta-data-spec = { path = "../ta-data-spec", version = "0.17.5-alpha.2" }
 which = "7"
 libc = { workspace = true }
 async-trait = "0.1"

--- a/crates/ta-daemon/src/team_session.rs
+++ b/crates/ta-daemon/src/team_session.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use ta_policy::business_budget::BudgetGuardrails;
 use ta_session::agent_action::TeamRole;
 use ta_session::team::TeamConfig;
 
@@ -55,6 +56,12 @@ pub struct TeamSessionConfig {
     pub workflow_path: String,
     pub team_toml_path: String,
     pub objective: String,
+    /// The bound workflow's business-metric budget guardrail, resolved by
+    /// the CLI from `WorkflowDefinition.budget` at `start` time (v0.17.5.2)
+    /// — `ta-daemon` never parses the workflow YAML itself, mirroring how
+    /// `stages` is already pre-resolved rather than re-derived here.
+    #[serde(default)]
+    pub budget: Option<BudgetGuardrails>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -92,6 +99,14 @@ impl TeamSessionState {
 
     pub fn state_path(project_root: &Path, id: &str) -> PathBuf {
         Self::state_dir(project_root, id).join("state.json")
+    }
+
+    /// Path to this session's business-metric budget ledger (v0.17.5.2) —
+    /// the same file `.ta_human_verify`'s `budget.ledger_path` param should
+    /// point at, so a role's budgeted actions accumulate into the session's
+    /// own running total.
+    pub fn budget_ledger_path(project_root: &Path, id: &str) -> PathBuf {
+        Self::state_dir(project_root, id).join("budget-ledger.jsonl")
     }
 
     /// Loads `state.json` for `id`, or `Ok(None)` if the session doesn't exist.
@@ -276,10 +291,43 @@ impl FailureTracker {
 /// context" shape as `ta_session::advisor_agent::build_advisor_context`,
 /// applied to a team session's own findings instead of a draft/phase
 /// summary.
-pub fn render_session_context(state: &TeamSessionState) -> String {
+pub fn render_session_context(project_root: &Path, state: &TeamSessionState) -> String {
     let mut out = String::new();
     out.push_str(&format!("# Team session: {}\n\n", state.config.name));
     out.push_str(&format!("**Objective:** {}\n\n", state.config.objective));
+
+    if let Some(budget) = &state.config.budget {
+        let ledger_path = TeamSessionState::budget_ledger_path(project_root, &state.id);
+        let spent = ta_policy::business_budget::ledger_running_total(&ledger_path);
+        let pct = if budget.total > 0.0 {
+            spent / budget.total * 100.0
+        } else {
+            0.0
+        };
+        out.push_str(&format!(
+            "**Budget ({metric}):** {spent:.2} / {total:.2} spent ({pct:.1}%)",
+            metric = budget.metric,
+            total = budget.total,
+        ));
+        if let Some(cap) = budget.per_action_max_pct {
+            out.push_str(&format!(", hard per-action cap {cap:.1}%"));
+        }
+        if let Some(soft) = budget.soft_threshold_pct {
+            out.push_str(&format!(", soft escalation threshold {soft:.1}%"));
+        }
+        out.push_str(".\n\n");
+        out.push_str(&format!(
+            "When performing a budgeted action, call `ta_human_verify` with a `budget` \
+             param: `{{\"metric\": \"{metric}\", \"total\": {total}, \
+             \"per_action_max_pct\": {cap:?}, \"soft_threshold_pct\": {soft:?}}}`, the \
+             action's amount, and `ledger_path: \".ta/team-sessions/{id}/budget-ledger.jsonl\"`.\n\n",
+            metric = budget.metric,
+            total = budget.total,
+            cap = budget.per_action_max_pct,
+            soft = budget.soft_threshold_pct,
+            id = state.id,
+        ));
+    }
 
     if state.findings.is_empty() {
         out.push_str("No prior role findings yet — this is the session's first goal-run.\n");
@@ -313,7 +361,7 @@ pub fn write_session_context(
     let dir = TeamSessionState::state_dir(project_root, &state.id);
     std::fs::create_dir_all(&dir)?;
     let path = session_context_path(project_root, &state.id, stage_name);
-    std::fs::write(&path, render_session_context(state))?;
+    std::fs::write(&path, render_session_context(project_root, state))?;
     Ok(path)
 }
 
@@ -642,6 +690,7 @@ mod tests {
             workflow_path: "templates/workflows/trading-desk.yaml".to_string(),
             team_toml_path: ".ta/team.toml".to_string(),
             objective: "Generate income > 2x within 6 months after fees".to_string(),
+            budget: None,
         }
     }
 
@@ -851,10 +900,34 @@ mod tests {
 
     #[test]
     fn render_context_with_no_findings_says_so() {
+        let dir = tempfile::tempdir().unwrap();
         let state = TeamSessionState::new("sess-1".to_string(), sample_config(), sample_stages());
-        let rendered = render_session_context(&state);
+        let rendered = render_session_context(dir.path(), &state);
         assert!(rendered.contains("No prior role findings yet"));
         assert!(rendered.contains("trading-desk"));
+    }
+
+    #[test]
+    fn render_context_includes_budget_and_running_ledger_total() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = sample_config();
+        config.budget = Some(BudgetGuardrails {
+            metric: "usd".to_string(),
+            total: 1000.0,
+            per_action_max_pct: Some(10.0),
+            soft_threshold_pct: Some(80.0),
+            objective: Some("generate income > 2x within 6 months after fees".to_string()),
+        });
+        let state = TeamSessionState::new("sess-1".to_string(), config, sample_stages());
+
+        let ledger_path = TeamSessionState::budget_ledger_path(dir.path(), "sess-1");
+        ta_policy::business_budget::record_ledger_spend(&ledger_path, "buy AAPL", 250.0).unwrap();
+
+        let rendered = render_session_context(dir.path(), &state);
+        assert!(rendered.contains("Budget (usd)"), "got: {rendered}");
+        assert!(rendered.contains("250.00 / 1000.00"), "got: {rendered}");
+        assert!(rendered.contains("25.0%"), "got: {rendered}");
+        assert!(rendered.contains("budget-ledger.jsonl"), "got: {rendered}");
     }
 
     #[test]
@@ -873,7 +946,8 @@ mod tests {
             completed_at: Utc::now(),
             summary: "Open a long position.".to_string(),
         });
-        let rendered = render_session_context(&state);
+        let dir = tempfile::tempdir().unwrap();
+        let rendered = render_session_context(dir.path(), &state);
         let analyst_pos = rendered.find("analyst").unwrap();
         let strategist_pos = rendered.find("strategist").unwrap();
         assert!(

--- a/crates/ta-data-spec/Cargo.toml
+++ b/crates/ta-data-spec/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 [dependencies]
 schemars = { workspace = true }
 serde_json = { workspace = true }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.1" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.1" }
-ta-brain = { path = "../ta-brain", version = "0.17.5-alpha.1" }
-ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
+ta-brain = { path = "../ta-brain", version = "0.17.5-alpha.2" }
+ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.2" }

--- a/crates/ta-db-proxy/Cargo.toml
+++ b/crates/ta-db-proxy/Cargo.toml
@@ -17,10 +17,10 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.5-alpha.1" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.1" }
-ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.1" }
-ta-actions = { path = "../ta-actions", version = "0.17.5-alpha.1" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.5-alpha.2" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.2" }
+ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.2" }
+ta-actions = { path = "../ta-actions", version = "0.17.5-alpha.2" }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ta-intake/Cargo.toml
+++ b/crates/ta-intake/Cargo.toml
@@ -19,8 +19,8 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 regex = { workspace = true }
-ta-submit = { path = "../ta-submit", version = "0.17.5-alpha.1" }
-ta-events = { path = "../ta-events", version = "0.17.5-alpha.1" }
+ta-submit = { path = "../ta-submit", version = "0.17.5-alpha.2" }
+ta-events = { path = "../ta-events", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -25,22 +25,22 @@ which = { workspace = true }
 toml = { workspace = true }
 
 # Internal crates
-ta-audit = { path = "../ta-audit", version = "0.17.5-alpha.1" }
-ta-events = { path = "../ta-events", version = "0.17.5-alpha.1" }
-ta-memory = { path = "../ta-memory", version = "0.17.5-alpha.1" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.1" }
-ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.5-alpha.1" }
-ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.5-alpha.1" }
-ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.5-alpha.1" }
-ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.5-alpha.1" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.1" }
-ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.1" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.1" }
-ta-workflow = { path = "../ta-workflow", version = "0.17.5-alpha.1" }
-ta-actions = { path = "../ta-actions", version = "0.17.5-alpha.1" }
-ta-submit = { path = "../ta-submit", version = "0.17.5-alpha.1" }
-ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.1" }
-ta-session = { path = "../ta-session", version = "0.17.5-alpha.1" }
+ta-audit = { path = "../ta-audit", version = "0.17.5-alpha.2" }
+ta-events = { path = "../ta-events", version = "0.17.5-alpha.2" }
+ta-memory = { path = "../ta-memory", version = "0.17.5-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
+ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.5-alpha.2" }
+ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.5-alpha.2" }
+ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.5-alpha.2" }
+ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.5-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
+ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.2" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.2" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.5-alpha.2" }
+ta-actions = { path = "../ta-actions", version = "0.17.5-alpha.2" }
+ta-submit = { path = "../ta-submit", version = "0.17.5-alpha.2" }
+ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.2" }
+ta-session = { path = "../ta-session", version = "0.17.5-alpha.2" }
 
 
 [dev-dependencies]

--- a/crates/ta-mcp-gateway/src/tools/human_verify.rs
+++ b/crates/ta-mcp-gateway/src/tools/human_verify.rs
@@ -43,6 +43,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use ta_decision::{decide, Decision, DecisionInput, DecisionThresholds, Verdict};
+use ta_policy::business_budget::{self, BudgetCheckResult, BudgetGuardrails};
 use ta_session::workflow_session::AdvisorSecurity;
 
 use crate::server::GatewayState;
@@ -54,6 +55,65 @@ fn default_response_hint() -> String {
 
 fn default_timeout() -> Option<u64> {
     Some(600)
+}
+
+fn default_budget_action_label() -> String {
+    "unlabeled action".to_string()
+}
+
+/// A workflow's declared business-metric budget guardrail, as passed by an
+/// MCP tool caller (v0.17.5.2). Field-identical to
+/// `ta_policy::business_budget::BudgetGuardrails`, kept as a local mirror
+/// type so `ta-policy` doesn't need a `schemars`/`rmcp` dependency just to
+/// appear in a tool's JSON schema.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct BudgetGuardrailParams {
+    /// Arbitrary label for the unit being budgeted (e.g. "usd", "trade_count").
+    pub metric: String,
+    /// Total budget available for the session's lifetime, in `metric` units.
+    pub total: f64,
+    /// Hard limit: no single action may exceed this percentage of `total`.
+    #[serde(default)]
+    pub per_action_max_pct: Option<f64>,
+    /// Soft limit: cumulative spend crossing this percentage of `total`
+    /// forces `Escalate` regardless of the Decision gate's own verdict.
+    #[serde(default)]
+    pub soft_threshold_pct: Option<f64>,
+    /// Human-readable objective this budget serves.
+    #[serde(default)]
+    pub objective: Option<String>,
+}
+
+impl From<BudgetGuardrailParams> for BudgetGuardrails {
+    fn from(p: BudgetGuardrailParams) -> Self {
+        Self {
+            metric: p.metric,
+            total: p.total,
+            per_action_max_pct: p.per_action_max_pct,
+            soft_threshold_pct: p.soft_threshold_pct,
+            objective: p.objective,
+        }
+    }
+}
+
+/// A proposed budgeted action to check against a [`BudgetGuardrailParams`]
+/// before `ta_human_verify` runs its opinion/validator/decide pipeline
+/// (v0.17.5.2 items 3-4). The hard-limit check happens deterministically,
+/// before any of that probabilistic pipeline even starts; a soft-limit
+/// crossing forces the eventual Decision gate verdict to `Escalate`.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct BudgetActionParams {
+    /// The workflow's budget guardrails for this session.
+    pub guardrails: BudgetGuardrailParams,
+    /// Amount this action would consume, in `guardrails.metric` units.
+    pub action_amount: f64,
+    /// Path, relative to the workspace root, to the session's ledger JSONL
+    /// file (e.g. `.ta/team-sessions/<id>/budget-ledger.jsonl`).
+    pub ledger_path: String,
+    /// Free-text description of the action, recorded in the ledger if the
+    /// action is ultimately auto-approved.
+    #[serde(default = "default_budget_action_label")]
+    pub action_label: String,
 }
 
 /// Parameters for `ta_human_verify`. Field-identical to the legacy
@@ -76,6 +136,12 @@ pub struct HumanVerifyParams {
     /// real human. Default: 600 (10 min).
     #[serde(default = "default_timeout")]
     pub timeout_secs: Option<u64>,
+    /// A business-metric budget guardrail check to run against this action,
+    /// before the opinion/validator/decide pipeline (v0.17.5.2). Absent for
+    /// non-budgeted questions — the legacy `ta_ask_human` alias never sets
+    /// this.
+    #[serde(default)]
+    pub budget: Option<BudgetActionParams>,
 }
 
 impl From<AskHumanParams> for HumanVerifyParams {
@@ -86,6 +152,7 @@ impl From<AskHumanParams> for HumanVerifyParams {
             response_hint: p.response_hint,
             choices: p.choices,
             timeout_secs: p.timeout_secs,
+            budget: None,
         }
     }
 }
@@ -593,6 +660,44 @@ fn handle_human_verify_with_pipeline(
         locked.config.workspace_root.clone()
     };
 
+    // Business-metric budget hard-limit pre-gate (v0.17.5.2 item 3) — runs
+    // before workload/security resolution and before any of the
+    // opinion/validator/decide pipeline. A violation is a deterministic
+    // rejection: no confidence score ever overrides a hard limit, and it
+    // never reaches the probabilistic pipeline (or a human) at all.
+    let mut budget_soft_limit_reason: Option<String> = None;
+    if let Some(budget_params) = params.budget.clone() {
+        validate_ledger_path(&budget_params.ledger_path)?;
+        let guardrails: BudgetGuardrails = budget_params.guardrails.clone().into();
+        let ledger_path = workspace_root.join(&budget_params.ledger_path);
+        let ledger_total_before = business_budget::ledger_running_total(&ledger_path);
+        match business_budget::check_budget(
+            &guardrails,
+            ledger_total_before,
+            budget_params.action_amount,
+        ) {
+            BudgetCheckResult::HardLimitExceeded(reason) => {
+                tracing::warn!(
+                    metric = %guardrails.metric,
+                    amount = budget_params.action_amount,
+                    reason = %reason,
+                    "ta_human_verify: business-metric budget hard limit exceeded, rejecting before any verify pass"
+                );
+                return reject_for_budget_hard_limit(&params, &reason);
+            }
+            BudgetCheckResult::SoftLimitCrossed(reason) => {
+                tracing::info!(
+                    metric = %guardrails.metric,
+                    amount = budget_params.action_amount,
+                    reason = %reason,
+                    "ta_human_verify: business-metric budget soft threshold crossed"
+                );
+                budget_soft_limit_reason = Some(reason);
+            }
+            BudgetCheckResult::Ok => {}
+        }
+    }
+
     let (workload_type, security_tier) = resolve_workload_context(&workspace_root);
 
     if security_tier != AdvisorSecurity::Auto {
@@ -640,7 +745,22 @@ fn handle_human_verify_with_pipeline(
         risk_score: validator.risk_score,
         confidence: validator.confidence,
     };
-    let decision = decide(&input, &thresholds);
+    let mut decision = decide(&input, &thresholds);
+
+    // Soft-limit crossing forces `Escalate` regardless of what the Decision
+    // gate's own verdict would otherwise be (v0.17.5.2 item 4) — mirrors
+    // `ta-brain::route()`'s confidence-downgrade pattern: a proximity-to-limit
+    // signal downgrades autonomy, it never upgrades it.
+    if let Some(reason) = &budget_soft_limit_reason {
+        if decision != Decision::Escalate {
+            tracing::info!(
+                reason = %reason,
+                original_decision = ?decision,
+                "ta_human_verify: forcing Escalate — business-metric budget soft threshold crossed"
+            );
+        }
+        decision = Decision::Escalate;
+    }
 
     tracing::info!(
         workload_type = %workload_type,
@@ -658,6 +778,21 @@ fn handle_human_verify_with_pipeline(
     crate::verify_audit::record_invocation(&workspace_root, &workload_type, decision);
 
     if decision.is_auto_approvable() {
+        if let Some(budget_params) = &params.budget {
+            let ledger_path = workspace_root.join(&budget_params.ledger_path);
+            if let Err(e) = business_budget::record_ledger_spend(
+                &ledger_path,
+                &budget_params.action_label,
+                budget_params.action_amount,
+            ) {
+                tracing::warn!(
+                    path = %ledger_path.display(),
+                    error = %e,
+                    "ta_human_verify: failed to record business-metric budget ledger entry"
+                );
+            }
+        }
+
         let entry = HumanVerifyAuditEntry {
             id: Uuid::new_v4(),
             timestamp: Utc::now().to_rfc3339(),
@@ -697,6 +832,60 @@ fn handle_human_verify_with_pipeline(
         validator.reasoning,
     );
     escalate_to_human(state, params, Some(extra_context))
+}
+
+/// Rejects an agent-supplied `budget.ledger_path` that could escape
+/// `workspace_root` (v0.17.5.2). `ledger_path` is joined directly onto
+/// `workspace_root` before every ledger read/write — `Path::join` discards
+/// the base entirely when the right-hand side is absolute, and `..`
+/// segments walk out of the workspace, so an unvalidated value would let a
+/// tool caller read or write an arbitrary file on disk. Same traversal
+/// pattern already guarded against in `ta-policy::engine`'s target-URI
+/// check and `unity.rs`'s path-component validator — reused here rather
+/// than reinvented, adapted to allow the legitimate multi-segment relative
+/// paths this parameter needs (e.g. `.ta/team-sessions/<id>/budget-ledger.jsonl`).
+fn validate_ledger_path(path: &str) -> Result<(), McpError> {
+    if path.is_empty()
+        || path.contains("..")
+        || path.contains("%2e%2e")
+        || path.contains("%2E%2E")
+        || Path::new(path).is_absolute()
+    {
+        return Err(McpError::invalid_params(
+            format!(
+                "invalid_parameter: 'budget.ledger_path' must be a relative path within the \
+                 workspace, with no '..' traversal segments. Got: {:?}. Use a path like \
+                 '.ta/team-sessions/<id>/budget-ledger.jsonl'.",
+                path
+            ),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+/// Deterministic rejection for a business-metric budget hard-limit
+/// violation (v0.17.5.2 item 3). Distinct from the probabilistic pipeline's
+/// `Decision::Reject` (which still escalates to a human) — a hard limit is
+/// a workflow-declared rule with no confidence override, so this returns
+/// directly without running the opinion/validator/decide pipeline or
+/// escalating to a human.
+fn reject_for_budget_hard_limit(
+    params: &HumanVerifyParams,
+    reason: &str,
+) -> Result<CallToolResult, McpError> {
+    let response = serde_json::json!({
+        "answer": serde_json::Value::Null,
+        "auto_confirmed": false,
+        "decision": "reject",
+        "budget_hard_limit_exceeded": true,
+        "reason": reason,
+        "question": params.question,
+    });
+    Ok(CallToolResult::success(vec![Content::json(response)
+        .map_err(|e| {
+            McpError::internal_error(e.to_string(), None)
+        })?]))
 }
 
 /// Fall through to the existing, unchanged blocking human-ask flow
@@ -846,6 +1035,20 @@ mod tests {
             response_hint: "yes_no".to_string(),
             choices: vec![],
             timeout_secs: Some(5),
+            budget: None,
+        }
+    }
+
+    fn budget_guardrails(
+        per_action_max_pct: Option<f64>,
+        soft_threshold_pct: Option<f64>,
+    ) -> BudgetGuardrailParams {
+        BudgetGuardrailParams {
+            metric: "usd".to_string(),
+            total: 1000.0,
+            per_action_max_pct,
+            soft_threshold_pct,
+            objective: Some("generate income > 2x within 6 months after fees".to_string()),
         }
     }
 
@@ -878,6 +1081,197 @@ mod tests {
         let audit = std::fs::read_to_string(&audit_path).expect("audit log should exist");
         assert!(audit.contains("\"decision\":\"commit\""), "got: {}", audit);
         assert!(audit.contains("docs"), "got: {}", audit);
+    }
+
+    #[test]
+    fn budget_ledger_path_with_traversal_is_rejected() {
+        let dir = tempdir().unwrap();
+        write_routing_decision(dir.path(), "trading", "auto");
+        let state = make_state(dir.path());
+
+        let mut params = base_params();
+        params.budget = Some(BudgetActionParams {
+            guardrails: budget_guardrails(Some(10.0), Some(80.0)),
+            action_amount: 50.0,
+            ledger_path: "../../../../tmp/evil-ledger.jsonl".to_string(),
+            action_label: "buy AAPL".to_string(),
+        });
+
+        let err = handle_human_verify_with_pipeline(&state, params, &MustNotBeCalledPipeline)
+            .expect_err("traversal path must be rejected before any pipeline or ledger access");
+        assert!(err.message.contains("ledger_path"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn budget_ledger_path_absolute_is_rejected() {
+        let dir = tempdir().unwrap();
+        write_routing_decision(dir.path(), "trading", "auto");
+        let state = make_state(dir.path());
+
+        let mut params = base_params();
+        params.budget = Some(BudgetActionParams {
+            guardrails: budget_guardrails(Some(10.0), Some(80.0)),
+            action_amount: 50.0,
+            ledger_path: "/etc/evil-ledger.jsonl".to_string(),
+            action_label: "buy AAPL".to_string(),
+        });
+
+        let err = handle_human_verify_with_pipeline(&state, params, &MustNotBeCalledPipeline)
+            .expect_err("absolute path must be rejected before any pipeline or ledger access");
+        assert!(err.message.contains("ledger_path"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn budget_action_exceeding_hard_per_action_cap_is_rejected_before_any_verify_pass_runs() {
+        let dir = tempdir().unwrap();
+        write_routing_decision(dir.path(), "trading", "auto");
+        let state = make_state(dir.path());
+
+        let mut params = base_params();
+        params.budget = Some(BudgetActionParams {
+            // 10% of 1000 = 100 cap; 500 exceeds it.
+            guardrails: budget_guardrails(Some(10.0), Some(80.0)),
+            action_amount: 500.0,
+            ledger_path: ".ta/team-sessions/sess-1/budget-ledger.jsonl".to_string(),
+            action_label: "buy AAPL".to_string(),
+        });
+
+        // MustNotBeCalledPipeline panics if the opinion/validator pass ever
+        // runs — proves the hard-limit pre-gate short-circuits before any
+        // of that probabilistic pipeline starts.
+        let result = handle_human_verify_with_pipeline(&state, params, &MustNotBeCalledPipeline)
+            .expect("should succeed with a rejection response, not an error");
+        let text = content_text(&result);
+        assert!(text.contains("\"decision\":\"reject\""), "got: {}", text);
+        assert!(
+            text.contains("\"budget_hard_limit_exceeded\":true"),
+            "got: {}",
+            text
+        );
+        assert!(text.contains("\"auto_confirmed\":false"), "got: {}", text);
+
+        // No ledger entry recorded for a rejected action.
+        let ledger_path = dir
+            .path()
+            .join(".ta")
+            .join("team-sessions")
+            .join("sess-1")
+            .join("budget-ledger.jsonl");
+        assert!(
+            !ledger_path.exists(),
+            "rejected action must not touch the ledger"
+        );
+    }
+
+    #[test]
+    fn budget_soft_threshold_crossing_forces_escalate_despite_high_confidence() {
+        let dir = tempdir().unwrap();
+        write_routing_decision(dir.path(), "trading", "auto");
+        let state = make_state(dir.path());
+
+        // Pre-seed the ledger at 750/1000 spent; an 80 action crosses the
+        // 80% (800) soft threshold but stays within the 100 per-action cap
+        // and the 1000 total.
+        let ledger_path = dir
+            .path()
+            .join(".ta")
+            .join("team-sessions")
+            .join("sess-1")
+            .join("budget-ledger.jsonl");
+        ta_policy::business_budget::record_ledger_spend(&ledger_path, "prior trade", 750.0)
+            .unwrap();
+
+        let mut params = base_params();
+        params.budget = Some(BudgetActionParams {
+            guardrails: budget_guardrails(Some(10.0), Some(80.0)),
+            action_amount: 80.0,
+            ledger_path: ".ta/team-sessions/sess-1/budget-ledger.jsonl".to_string(),
+            action_label: "buy TSLA".to_string(),
+        });
+
+        // Deliberately high confidence / low risk / Pass verdict: decide()
+        // alone would return Commit. The soft-limit override must still
+        // force Escalate.
+        let pipeline = FakePipeline {
+            opinion: OpinionResult {
+                answer: "Yes, buy it.".to_string(),
+                reasoning: "Strong signal.".to_string(),
+                confidence: 0.99,
+            },
+            validator: ValidatorResult {
+                verdict: Verdict::Pass,
+                risk_score: 1,
+                confidence: 0.99,
+                reasoning: "Very confident.".to_string(),
+            },
+        };
+
+        spawn_answer_thread(dir.path(), "human confirmed");
+        let result = handle_human_verify_with_pipeline(&state, params, &pipeline)
+            .expect("should succeed via escalation to human");
+        let text = content_text(&result);
+        assert!(text.contains("human confirmed"), "got: {}", text);
+
+        // Escalated, not auto-approved -> no ledger entry beyond the
+        // pre-seeded one.
+        let entries = ta_policy::business_budget::read_ledger_entries(&ledger_path);
+        assert_eq!(
+            entries.len(),
+            1,
+            "escalated action must not be recorded as spend"
+        );
+
+        // Not auto-approved -> no commit audit entry written.
+        let audit_path = dir.path().join(".ta").join("human-verify-audit.jsonl");
+        assert!(
+            !audit_path.exists(),
+            "escalated action must not write a commit audit entry"
+        );
+    }
+
+    #[test]
+    fn budget_action_within_limits_auto_confirms_and_appends_ledger_entry() {
+        let dir = tempdir().unwrap();
+        write_routing_decision(dir.path(), "trading", "auto");
+        let state = make_state(dir.path());
+
+        let mut params = base_params();
+        params.budget = Some(BudgetActionParams {
+            guardrails: budget_guardrails(Some(10.0), Some(80.0)),
+            action_amount: 50.0,
+            ledger_path: ".ta/team-sessions/sess-1/budget-ledger.jsonl".to_string(),
+            action_label: "buy AAPL".to_string(),
+        });
+        let pipeline = FakePipeline {
+            opinion: OpinionResult {
+                answer: "Yes, buy it.".to_string(),
+                reasoning: "Solid.".to_string(),
+                confidence: 0.95,
+            },
+            validator: ValidatorResult {
+                verdict: Verdict::Pass,
+                risk_score: 5,
+                confidence: 0.95,
+                reasoning: "Low risk.".to_string(),
+            },
+        };
+
+        let result =
+            handle_human_verify_with_pipeline(&state, params, &pipeline).expect("should succeed");
+        let text = content_text(&result);
+        assert!(text.contains("\"auto_confirmed\":true"), "got: {}", text);
+
+        let ledger_path = dir
+            .path()
+            .join(".ta")
+            .join("team-sessions")
+            .join("sess-1")
+            .join("budget-ledger.jsonl");
+        let entries = ta_policy::business_budget::read_ledger_entries(&ledger_path);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].amount, 50.0);
+        assert_eq!(entries[0].running_total, 50.0);
+        assert_eq!(entries[0].action, "buy AAPL");
     }
 
     #[test]

--- a/crates/ta-mcp-gateway/src/tools/human_verify.rs
+++ b/crates/ta-mcp-gateway/src/tools/human_verify.rs
@@ -845,17 +845,26 @@ fn handle_human_verify_with_pipeline(
 /// than reinvented, adapted to allow the legitimate multi-segment relative
 /// paths this parameter needs (e.g. `.ta/team-sessions/<id>/budget-ledger.jsonl`).
 fn validate_ledger_path(path: &str) -> Result<(), McpError> {
+    // `Path::is_absolute()` alone isn't platform-parity-safe here: a
+    // Unix-style absolute path like "/etc/evil.jsonl" has no drive letter,
+    // so on Windows `is_absolute()` returns false for it (it reads as
+    // "root of the current drive", not absolute) — confirmed failing in CI
+    // (Windows Build) on exactly this input. A leading '/' or '\\' is
+    // rejected explicitly, on every platform, regardless of what
+    // `is_absolute()` reports for it locally.
+    let starts_with_root_separator = path.starts_with('/') || path.starts_with('\\');
     if path.is_empty()
         || path.contains("..")
         || path.contains("%2e%2e")
         || path.contains("%2E%2E")
+        || starts_with_root_separator
         || Path::new(path).is_absolute()
     {
         return Err(McpError::invalid_params(
             format!(
                 "invalid_parameter: 'budget.ledger_path' must be a relative path within the \
-                 workspace, with no '..' traversal segments. Got: {:?}. Use a path like \
-                 '.ta/team-sessions/<id>/budget-ledger.jsonl'.",
+                 workspace, with no '..' traversal segments and no leading path separator. \
+                 Got: {:?}. Use a path like '.ta/team-sessions/<id>/budget-ledger.jsonl'.",
                 path
             ),
             None,

--- a/crates/ta-mediation/Cargo.toml
+++ b/crates/ta-mediation/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates for FsMediator
-ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.1" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.1" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-policy/src/business_budget.rs
+++ b/crates/ta-policy/src/business_budget.rs
@@ -1,0 +1,289 @@
+//! Workflow-defined business-metric budget guardrails (v0.17.5.2).
+//!
+//! A second, distinct budget concept alongside [`crate::document::BudgetConfig`]
+//! (the existing LLM-token budget, unchanged by this module). Where
+//! `BudgetConfig` tracks resource consumption (tokens spent), this module
+//! tracks an arbitrary-unit business metric a workflow declares — dollars,
+//! trade count, anything domain-specific — against a stated objective.
+//!
+//! Hard limits ([`BudgetCheckResult::HardLimitExceeded`]) are deterministic
+//! pre-gate checks: no confidence score ever overrides one, and a violation
+//! must reject the action before any probabilistic verify/approve pass runs.
+//! Soft limits ([`BudgetCheckResult::SoftLimitCrossed`]) feed the Decision
+//! gate as an escalation signal — the same "confidence/proximity-to-limit
+//! downgrades autonomy" pattern already proven by
+//! `ta-brain::route()`'s `AUTO_SECURITY_CONFIDENCE_THRESHOLD` downgrade.
+//!
+//! The running ledger is an append-only JSONL log, the same pattern used by
+//! `.ta/human-verify-audit.jsonl` (`ta-mcp-gateway::tools::human_verify`):
+//! a private borrow-based writer entry type, a public owned reader record
+//! type, `OpenOptions::new().create(true).append(true)`, and a
+//! missing-file-tolerant reader.
+
+use std::io;
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A workflow's business-metric budget guardrail, resolved from
+/// `ta-workflow::WorkflowBudget` (or hand-constructed by callers that don't
+/// depend on `ta-workflow`, e.g. `ta-daemon`'s team-session runtime).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BudgetGuardrails {
+    /// Arbitrary label for the unit being budgeted (e.g. "usd", "trade_count").
+    pub metric: String,
+    /// Total budget available for the session's lifetime, in `metric` units.
+    pub total: f64,
+    /// Hard limit: no single action may exceed this percentage of `total`.
+    #[serde(default)]
+    pub per_action_max_pct: Option<f64>,
+    /// Soft limit: cumulative spend crossing this percentage of `total`
+    /// forces every subsequent action to `Escalate`.
+    #[serde(default)]
+    pub soft_threshold_pct: Option<f64>,
+    /// Human-readable objective this budget serves.
+    #[serde(default)]
+    pub objective: Option<String>,
+}
+
+/// One append-only entry in a session's business-budget ledger.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BudgetLedgerEntry {
+    /// Free-text description of the action that consumed budget.
+    pub action: String,
+    /// Amount consumed by this action, in the guardrail's `metric` units.
+    pub amount: f64,
+    /// Cumulative total after this entry (previous running total + `amount`).
+    pub running_total: f64,
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Result of checking a proposed action against a [`BudgetGuardrails`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum BudgetCheckResult {
+    /// Within both hard and soft limits.
+    Ok,
+    /// Deterministic hard-limit violation — reject before any verify pass.
+    HardLimitExceeded(String),
+    /// Within hard limits but crosses the soft threshold — force `Escalate`.
+    SoftLimitCrossed(String),
+}
+
+impl BudgetCheckResult {
+    pub fn is_hard_limit_exceeded(&self) -> bool {
+        matches!(self, BudgetCheckResult::HardLimitExceeded(_))
+    }
+
+    pub fn is_soft_limit_crossed(&self) -> bool {
+        matches!(self, BudgetCheckResult::SoftLimitCrossed(_))
+    }
+}
+
+/// Checks a proposed action of `amount` (in `guardrails.metric` units)
+/// against the hard per-action cap, the total budget, and the soft
+/// escalation threshold, given `ledger_total_before` (the running total
+/// accumulated so far, from [`ledger_running_total`]).
+///
+/// Hard-limit checks (per-action cap, total budget) take priority over the
+/// soft-limit check — an action that is rejected outright is never also
+/// reported as merely crossing the soft threshold.
+pub fn check_budget(
+    guardrails: &BudgetGuardrails,
+    ledger_total_before: f64,
+    amount: f64,
+) -> BudgetCheckResult {
+    if let Some(per_action_max_pct) = guardrails.per_action_max_pct {
+        let cap = guardrails.total * per_action_max_pct / 100.0;
+        if amount > cap {
+            return BudgetCheckResult::HardLimitExceeded(format!(
+                "action amount {amount:.2} {metric} exceeds the per-action cap of {cap:.2} \
+                 {metric} ({per_action_max_pct:.1}% of the {total:.2} {metric} total budget)",
+                metric = guardrails.metric,
+                total = guardrails.total,
+            ));
+        }
+    }
+
+    let running_total_after = ledger_total_before + amount;
+    if running_total_after > guardrails.total {
+        return BudgetCheckResult::HardLimitExceeded(format!(
+            "action would bring the running total to {running_total_after:.2} {metric}, \
+             exceeding the {total:.2} {metric} total budget ({ledger_total_before:.2} \
+             {metric} already spent)",
+            metric = guardrails.metric,
+            total = guardrails.total,
+        ));
+    }
+
+    if let Some(soft_threshold_pct) = guardrails.soft_threshold_pct {
+        let threshold = guardrails.total * soft_threshold_pct / 100.0;
+        if running_total_after >= threshold {
+            return BudgetCheckResult::SoftLimitCrossed(format!(
+                "running total of {running_total_after:.2} {metric} crosses the soft \
+                 threshold of {threshold:.2} {metric} ({soft_threshold_pct:.1}% of the \
+                 {total:.2} {metric} total budget) — forcing escalation",
+                metric = guardrails.metric,
+                total = guardrails.total,
+            ));
+        }
+    }
+
+    BudgetCheckResult::Ok
+}
+
+/// Appends one entry to a business-budget ledger JSONL file, creating the
+/// parent directory and file if needed. Mirrors
+/// `human_verify::write_audit_entry`'s append pattern exactly.
+pub fn append_ledger_entry(log_path: &Path, entry: &BudgetLedgerEntry) -> io::Result<()> {
+    if let Some(parent) = log_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let line =
+        serde_json::to_string(entry).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    use std::io::Write as _;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)?;
+    writeln!(f, "{line}")
+}
+
+/// Reads all entries from a business-budget ledger JSONL file, in append
+/// order. Tolerant of a missing file (returns empty) and of individual
+/// malformed lines (skipped), same as `verify_audit::read_audit_entries`.
+pub fn read_ledger_entries(log_path: &Path) -> Vec<BudgetLedgerEntry> {
+    let Ok(content) = std::fs::read_to_string(log_path) else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect()
+}
+
+/// The cumulative running total from a ledger file, or `0.0` if the ledger
+/// is empty or missing (a session with no spend yet).
+pub fn ledger_running_total(log_path: &Path) -> f64 {
+    read_ledger_entries(log_path)
+        .last()
+        .map(|e| e.running_total)
+        .unwrap_or(0.0)
+}
+
+/// Appends a new entry for `amount` spent on `action`, computing the new
+/// running total from the ledger's current tail. Returns the appended entry.
+pub fn record_ledger_spend(
+    log_path: &Path,
+    action: &str,
+    amount: f64,
+) -> io::Result<BudgetLedgerEntry> {
+    let running_total = ledger_running_total(log_path) + amount;
+    let entry = BudgetLedgerEntry {
+        action: action.to_string(),
+        amount,
+        running_total,
+        timestamp: Utc::now(),
+    };
+    append_ledger_entry(log_path, &entry)?;
+    Ok(entry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn guardrails() -> BudgetGuardrails {
+        BudgetGuardrails {
+            metric: "usd".to_string(),
+            total: 1000.0,
+            per_action_max_pct: Some(10.0),
+            soft_threshold_pct: Some(80.0),
+            objective: Some("generate income > 2x within 6 months after fees".to_string()),
+        }
+    }
+
+    #[test]
+    fn action_within_all_limits_is_ok() {
+        let result = check_budget(&guardrails(), 0.0, 50.0);
+        assert_eq!(result, BudgetCheckResult::Ok);
+    }
+
+    #[test]
+    fn action_exceeding_per_action_cap_is_hard_rejected() {
+        // 10% of 1000 = 100 cap; 150 exceeds it.
+        let result = check_budget(&guardrails(), 0.0, 150.0);
+        assert!(result.is_hard_limit_exceeded());
+    }
+
+    #[test]
+    fn action_exceeding_total_budget_is_hard_rejected_even_under_per_action_cap() {
+        // 90 is under the 100 per-action cap, but 950 already spent + 90 > 1000 total.
+        let result = check_budget(&guardrails(), 950.0, 90.0);
+        assert!(result.is_hard_limit_exceeded());
+    }
+
+    #[test]
+    fn crossing_soft_threshold_is_reported_and_not_a_hard_rejection() {
+        // 80% of 1000 = 800 threshold; 750 spent + 60 = 810 crosses it, but is
+        // still within the 100 per-action cap and the 1000 total.
+        let result = check_budget(&guardrails(), 750.0, 60.0);
+        assert!(result.is_soft_limit_crossed());
+        assert!(!result.is_hard_limit_exceeded());
+    }
+
+    #[test]
+    fn hard_limit_takes_priority_over_soft_limit_reporting() {
+        // Exceeds the per-action cap AND would cross the soft threshold —
+        // must report as a hard rejection, not a soft crossing.
+        let result = check_budget(&guardrails(), 750.0, 150.0);
+        assert!(result.is_hard_limit_exceeded());
+    }
+
+    #[test]
+    fn budget_without_thresholds_only_checks_total() {
+        let g = BudgetGuardrails {
+            metric: "usd".to_string(),
+            total: 1000.0,
+            per_action_max_pct: None,
+            soft_threshold_pct: None,
+            objective: None,
+        };
+        assert_eq!(check_budget(&g, 0.0, 999.0), BudgetCheckResult::Ok);
+        assert!(check_budget(&g, 0.0, 1001.0).is_hard_limit_exceeded());
+    }
+
+    #[test]
+    fn ledger_accumulates_across_multiple_sequential_actions() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("budget-ledger.jsonl");
+
+        assert_eq!(ledger_running_total(&log_path), 0.0);
+
+        let e1 = record_ledger_spend(&log_path, "buy AAPL", 100.0).unwrap();
+        assert_eq!(e1.running_total, 100.0);
+
+        let e2 = record_ledger_spend(&log_path, "buy TSLA", 250.0).unwrap();
+        assert_eq!(e2.running_total, 350.0);
+
+        let e3 = record_ledger_spend(&log_path, "sell AAPL", 50.0).unwrap();
+        assert_eq!(e3.running_total, 400.0);
+
+        assert_eq!(ledger_running_total(&log_path), 400.0);
+
+        let entries = read_ledger_entries(&log_path);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].action, "buy AAPL");
+        assert_eq!(entries[1].action, "buy TSLA");
+        assert_eq!(entries[2].action, "sell AAPL");
+    }
+
+    #[test]
+    fn reading_a_missing_ledger_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("does-not-exist.jsonl");
+        assert!(read_ledger_entries(&log_path).is_empty());
+        assert_eq!(ledger_running_total(&log_path), 0.0);
+    }
+}

--- a/crates/ta-policy/src/lib.rs
+++ b/crates/ta-policy/src/lib.rs
@@ -24,6 +24,7 @@
 //! - **Path traversal blocked**: URIs containing ".." are always denied.
 
 pub mod alignment;
+pub mod business_budget;
 pub mod capability;
 pub mod cascade;
 pub mod compiler;
@@ -37,6 +38,10 @@ pub mod exemption;
 pub use alignment::{
     AgentSetupProposal, AlignmentProfile, AutonomyEnvelope, CoordinationConfig, Milestone,
     ProposedAgent,
+};
+pub use business_budget::{
+    append_ledger_entry, check_budget, ledger_running_total, read_ledger_entries,
+    record_ledger_spend, BudgetCheckResult, BudgetGuardrails, BudgetLedgerEntry,
 };
 pub use capability::{CapabilityGrant, CapabilityManifest};
 pub use cascade::{CliOverrides, PolicyCascade};

--- a/crates/ta-release/Cargo.toml
+++ b/crates/ta-release/Cargo.toml
@@ -18,7 +18,7 @@ toml = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true, features = ["multipart"] }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.1" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-runtime/Cargo.toml
+++ b/crates/ta-runtime/Cargo.toml
@@ -23,8 +23,8 @@ which = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
 
-ta-credentials = { path = "../ta-credentials", version = "0.17.5-alpha.1" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.1" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.5-alpha.2" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.2" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }
-ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.1" }
+ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-session/Cargo.toml
+++ b/crates/ta-session/Cargo.toml
@@ -25,9 +25,9 @@ notify = { workspace = true }
 toml = { workspace = true }
 
 # Workspace crates
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.1" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.1" }
-ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
+ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -16,11 +16,11 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.1" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.1" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.1" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.1" }
-ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.2" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.2" }
+ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.2" }
 toml = "0.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/ta-workflow/Cargo.toml
+++ b/crates/ta-workflow/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-workflow/src/definition.rs
+++ b/crates/ta-workflow/src/definition.rs
@@ -95,6 +95,52 @@ pub struct WorkflowDefinition {
     /// All stage/role string fields support `{{params.name}}` substitution.
     #[serde(default)]
     pub params: HashMap<String, ParamDecl>,
+    /// Business-metric budget guardrail for this workflow (v0.17.5.2).
+    ///
+    /// Distinct from the LLM-token budget (`ta-policy::BudgetConfig`, unchanged),
+    /// this declares an arbitrary-unit business metric (e.g. dollars, trade
+    /// count) against a stated objective, enforced by hard/soft limit checks
+    /// wherever the workflow's roles call `ta_human_verify`.
+    ///
+    /// Example in workflow YAML:
+    ///   budget:
+    ///     metric: usd
+    ///     total: 1000.0
+    ///     per_action_max_pct: 10.0
+    ///     soft_threshold_pct: 80.0
+    ///     objective: "generate income > 2x within 6 months after fees"
+    ///
+    /// Boxed (rather than inline `Option<WorkflowBudget>`) to keep
+    /// `WorkflowDefinition` from tipping `EngineRequest::Start` over
+    /// clippy's `large_enum_variant` threshold — this field is optional and
+    /// rarely present, so the indirection cost is paid only when it's used.
+    #[serde(default)]
+    pub budget: Option<Box<WorkflowBudget>>,
+}
+
+/// A workflow-declared business-metric budget guardrail (v0.17.5.2).
+///
+/// `metric` is an arbitrary label, not hardcoded to dollars — a workflow can
+/// declare `"usd"`, `"trade_count"`, or any other domain-specific unit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowBudget {
+    /// Arbitrary label for the unit being budgeted (e.g. "usd", "trade_count").
+    pub metric: String,
+    /// Total budget available for the session's lifetime, in `metric` units.
+    pub total: f64,
+    /// Hard limit: no single action may exceed this percentage of `total`.
+    /// Violating this rejects the action before any verify/approve pass runs.
+    #[serde(default)]
+    pub per_action_max_pct: Option<f64>,
+    /// Soft limit: once cumulative spend crosses this percentage of `total`,
+    /// every subsequent action is forced to `Escalate` regardless of the
+    /// Decision gate's own verdict.
+    #[serde(default)]
+    pub soft_threshold_pct: Option<f64>,
+    /// Human-readable objective this budget serves (e.g. "generate income
+    /// > 2x within 6 months after fees") — carried into role context.
+    #[serde(default)]
+    pub objective: Option<String>,
 }
 
 /// A single stage in the workflow.
@@ -307,6 +353,61 @@ roles:
         assert_eq!(def.name, "simple-review");
         assert_eq!(def.stages.len(), 2);
         assert_eq!(def.roles.len(), 2);
+        assert!(def.budget.is_none());
+    }
+
+    #[test]
+    fn parse_workflow_yaml_with_business_budget() {
+        let yaml = r#"
+name: trading-desk
+stages:
+  - name: trade
+    roles: [trader]
+roles:
+  trader:
+    agent: claude-code
+    prompt: "Execute trades"
+budget:
+  metric: usd
+  total: 1000.0
+  per_action_max_pct: 10.0
+  soft_threshold_pct: 80.0
+  objective: "generate income > 2x within 6 months after fees"
+"#;
+        let def = WorkflowDefinition::from_yaml(yaml).unwrap();
+        let budget = def.budget.expect("budget should be parsed");
+        assert_eq!(budget.metric, "usd");
+        assert_eq!(budget.total, 1000.0);
+        assert_eq!(budget.per_action_max_pct, Some(10.0));
+        assert_eq!(budget.soft_threshold_pct, Some(80.0));
+        assert_eq!(
+            budget.objective.as_deref(),
+            Some("generate income > 2x within 6 months after fees")
+        );
+    }
+
+    #[test]
+    fn parse_workflow_yaml_with_minimal_budget() {
+        let yaml = r#"
+name: trading-desk
+stages:
+  - name: trade
+    roles: [trader]
+roles:
+  trader:
+    agent: claude-code
+    prompt: "Execute trades"
+budget:
+  metric: usd
+  total: 500.0
+"#;
+        let def = WorkflowDefinition::from_yaml(yaml).unwrap();
+        let budget = def.budget.expect("budget should be parsed");
+        assert_eq!(budget.metric, "usd");
+        assert_eq!(budget.total, 500.0);
+        assert_eq!(budget.per_action_max_pct, None);
+        assert_eq!(budget.soft_threshold_pct, None);
+        assert_eq!(budget.objective, None);
     }
 
     #[test]
@@ -341,6 +442,7 @@ roles:
             verdict: None,
             agent_framework: None,
             params: Default::default(),
+            budget: None,
         };
         let order = def.stage_order().unwrap();
         assert_eq!(order, vec!["build", "review"]);
@@ -378,6 +480,7 @@ roles:
             verdict: None,
             agent_framework: None,
             params: Default::default(),
+            budget: None,
         };
         let result = def.stage_order();
         assert!(matches!(

--- a/crates/ta-workflow/src/lib.rs
+++ b/crates/ta-workflow/src/lib.rs
@@ -46,7 +46,7 @@ pub use consensus::{
     run_consensus, ConsensusAlgorithm, ConsensusInput, ConsensusResult, ReviewerVote,
 };
 pub use definition::{
-    FailureRouting, RoleDefinition, StageDefinition, StageReview, WorkflowCatalog,
+    FailureRouting, RoleDefinition, StageDefinition, StageReview, WorkflowBudget, WorkflowCatalog,
     WorkflowDefinition,
 };
 pub use dependency_wave::{api_impact_overlaps, plan_waves, WaveError, WaveNode};

--- a/crates/ta-workflow/src/process_engine.rs
+++ b/crates/ta-workflow/src/process_engine.rs
@@ -371,6 +371,7 @@ mod tests {
                 verdict: None,
                 agent_framework: None,
                 params: Default::default(),
+                budget: None,
             },
         };
         let json = serde_json::to_string(&req).unwrap();
@@ -403,6 +404,7 @@ mod tests {
             verdict: None,
             agent_framework: None,
             params: Default::default(),
+            budget: None,
         };
         let result = engine.start(&def);
         assert!(matches!(result, Err(WorkflowError::ProcessError { .. })));

--- a/crates/ta-workflow/src/validate.rs
+++ b/crates/ta-workflow/src/validate.rs
@@ -516,6 +516,7 @@ mod tests {
             verdict: None,
             agent_framework: None,
             params: Default::default(),
+            budget: None,
         }
     }
 
@@ -598,6 +599,7 @@ mod tests {
             verdict: None,
             agent_framework: None,
             params: Default::default(),
+            budget: None,
         };
         let result = validate_workflow(&wf, None);
         assert!(result.has_errors());

--- a/crates/ta-workflow/src/yaml_engine.rs
+++ b/crates/ta-workflow/src/yaml_engine.rs
@@ -374,6 +374,7 @@ mod tests {
             verdict: None,
             agent_framework: None,
             params: Default::default(),
+            budget: None,
         }
     }
 

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -21,8 +21,8 @@ reqwest = { workspace = true }
 anyhow = { workspace = true }
 sha2 = "0.10"
 base64 = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.1" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: 0.17.5-alpha.1
+**Version**: 0.17.5-alpha.2
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 
@@ -15564,6 +15564,90 @@ session's findings list and rendered as markdown context
 (`.ta/team-sessions/<name>/context-<stage>.md`) passed to the next role's `ta run
 --objective-file`, so a "strategist" role can see what the "analyst" role before it
 found, and so on across the whole session's lifetime — not just within one goal-run.
+
+### Budget Guardrails: Two Distinct Budgets
+
+TA tracks two independent budget concepts. A team session can be within one and over
+the other at the same time — they are never folded into a single number.
+
+| | **Token budget** | **Business-metric budget** |
+|---|---|---|
+| Tracks | LLM token consumption per goal | An arbitrary business metric (dollars, trade count, anything domain-specific) |
+| Configured in | `.ta/policy.yaml` → `budget.max_tokens_per_goal` | The workflow YAML's `budget:` section |
+| Enforcement | Warns at `warn_at_percent`, denies over the cap | Hard per-action cap rejects outright; soft threshold forces escalation |
+| Applies to | Every goal-run | Only workflows that declare a `budget:` section (e.g. a persistent team session) |
+
+**Declaring a business-metric budget** — add a `budget:` section to a workflow YAML:
+
+```yaml
+name: trading-desk
+budget:
+  metric: usd                # arbitrary label — "usd", "trade_count", anything
+  total: 1000.0               # total budget for the session's lifetime
+  per_action_max_pct: 10.0    # hard limit: no single action may exceed 10% of total
+  soft_threshold_pct: 80.0    # soft limit: crossing 80% forces every subsequent
+                               # action to escalate, regardless of confidence
+  objective: "generate income > 2x within 6 months after fees"
+roles:
+  trader:
+    agent: claude-code
+    prompt: "Execute trades within budget."
+stages:
+  - name: trade
+    roles: ["trader"]
+```
+
+`ta team-session start` resolves this once at start time and persists it into the
+session's `state.json` — the daemon never re-parses the workflow YAML for it, the same
+pattern already used for the resolved stage order.
+
+**Hard vs soft limits**:
+- **Hard limit** (`per_action_max_pct`, and the total itself): a deterministic
+  pre-gate check. A violating action is rejected *before* any opinion/validator pass
+  or human escalation runs — no confidence score ever overrides it.
+- **Soft limit** (`soft_threshold_pct`): once cumulative spend crosses this
+  percentage of the total, every subsequent action is forced to escalate to a real
+  human, even if the Decision gate's own verdict would otherwise auto-approve it —
+  the same "proximity-to-limit downgrades autonomy" pattern used elsewhere for
+  low-confidence workload routing.
+
+**Spending against the budget** — a role performs a budgeted action by calling
+`ta_human_verify` with a `budget` parameter:
+
+```json
+{
+  "question": "Buy 10 shares of AAPL at $180?",
+  "budget": {
+    "guardrails": {
+      "metric": "usd",
+      "total": 1000.0,
+      "per_action_max_pct": 10.0,
+      "soft_threshold_pct": 80.0
+    },
+    "action_amount": 80.0,
+    "ledger_path": ".ta/team-sessions/trading-desk/budget-ledger.jsonl",
+    "action_label": "buy 10 AAPL @ 180"
+  }
+}
+```
+
+The session's rendered context (`context-<stage>.md`) already includes the
+guardrails and the exact `ledger_path` to use, so a role doesn't need to look them up
+separately.
+
+**The ledger** — every auto-approved budgeted action is appended to
+`.ta/team-sessions/<name>/budget-ledger.jsonl`, an append-only JSONL log (amount,
+running total, timestamp) in the same format as `.ta/human-verify-audit.jsonl`.
+Rejected (hard-limit) and escalated (soft-limit) actions are never recorded as spend.
+
+**Checking both budgets side by side**:
+
+```bash
+ta team-session status trading-desk
+# trading-desk: active (stage=Some("trade") role=Some("trader") restarts=0 ...)
+#   business budget (usd): 650.00 / 1000.00 spent (65.0%)
+#   token budget: max_tokens_per_goal=50000 (from .ta/policy.yaml)
+```
 
 ---
 


### PR DESCRIPTION
## Summary
Adds a second, distinct budget concept alongside the existing LLM-token budget (`ta-policy::BudgetConfig`, unchanged): an arbitrary-unit business metric a workflow declares (e.g. `metric="usd", total=1000.0, per_action_max_pct=10.0`) against a stated objective.

- New `ta-policy::business_budget` module: `BudgetGuardrails`, `BudgetLedgerEntry`, `check_budget()` (hard per-action cap + total budget + soft threshold), and JSONL ledger helpers mirroring the existing human-verify-audit append/read pattern.
- `WorkflowBudget` YAML schema on `ta-workflow::WorkflowDefinition`.
- Wired into `ta_human_verify` (`ta-mcp-gateway`): a hard-limit violation rejects deterministically before the opinion/validator/decide pipeline ever runs (no confidence score overrides it); a soft-limit crossing forces `Decision::Escalate` regardless of the gate's own verdict. Ledger entry recorded only on actual auto-approval.
- Persistent team sessions (v0.17.5.1) carry the budget forward in rendered context; `ta team-session status` shows both budgets independently.

## Security fix found during review
`budget.ledger_path` is an agent-supplied MCP tool parameter joined directly onto `workspace_root` with no traversal validation — `Path::join` discards its base when the right side is absolute, and `..` segments walk out of the workspace, so an unvalidated value would let a tool caller write an arbitrary JSONL line to any writable path on disk (constitution §6.3 Path Traversal Guard). Fixed with `validate_ledger_path()`, reusing the same pattern already established in `ta-policy::engine`'s target-URI check and `unity.rs`'s path-component validator. Added 2 regression tests.

## Test plan
- 35 new tests total, all passing
- `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all clean