### PR TITLE
Implement v0.17.5.3 — Pluggable Domain-Action Adapters (User-Authored Plugins, Not Just Built-In)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All outcomes must be **observable** (with details and logging) and **actionable*
 
 ## Current State
 
-**Current version**: `0.17.5-alpha.2`
+**Current version**: `0.17.5-alpha.3`
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --phase 4b`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3323,11 +3323,12 @@ dependencies = [
 
 [[package]]
 name = "ta-actions"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "ta-plugin",
  "tempfile",
  "thiserror 2.0.20",
  "toml 0.8.23",
@@ -3337,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "ta-advisor"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -3352,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "ta-agent-ollama"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3367,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "base64",
  "chrono",
@@ -3383,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "ta-brain"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "schemars",
@@ -3403,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "ta-build"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "reqwest",
  "serde",
@@ -3415,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3436,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3495,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-comfyui"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -3510,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3524,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3538,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -3555,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -3564,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -3573,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3587,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unity"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -3600,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unreal"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -3614,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -3623,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -3637,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3687,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "ta-data-spec"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "schemars",
  "serde_json",
@@ -3699,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-overlay"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -3713,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-proxy"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -3731,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "ta-decision"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -3742,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3760,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "ta-extension"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3777,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3794,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "ta-governed-paths"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -3808,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "ta-init"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3821,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "ta-intake"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "regex",
@@ -3839,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "regex",
@@ -3875,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -3890,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "glob",
@@ -3908,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "ta-output-schema"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -3920,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "ta-plugin"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "libc",
  "serde",
@@ -3934,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "glob",
@@ -3949,7 +3950,7 @@ dependencies = [
 
 [[package]]
 name = "ta-release"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "base64",
  "reqwest",
@@ -3965,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "ta-runtime"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3987,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -4000,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "libc",
@@ -4020,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "chrono",
  "libc",
@@ -4040,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4059,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.17.5-alpha.2"
+version = "0.17.5-alpha.3"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -10051,20 +10051,20 @@ Code releases use semver. Content releases don't. Decide:
 
 ---
 ### v0.17.5.3 — Pluggable Domain-Action Adapters (User-Authored Plugins, Not Just Built-In)
-<!-- status: in_progress -->
+<!-- status: done -->
 **Depends on**: v0.17.5.2, `StepAction::external_adapter()` (existing hook, currently zero production callers), v0.17.4 item 3 (release adapter plugin protocol — reuse its transport, don't invent a second one)
 
 **Goal**: Today, adding a new domain action (e.g. "execute a stock trade via a brokerage API") requires a TA core code change — every existing connector (Slack/Discord/email/social) is built into `ta-daemon`'s own crates, and the one generic hook meant for this (`StepAction::external_adapter()`) has never been dispatched to in production. Make it genuinely user-authorable, reusing the exact same external-subprocess-plugin transport already proven twice in this codebase (`[[connectors.managed]]` in `connector_supervisor.rs`, and v0.17.4 item 3's release-adapter "JSON-over-stdio, same pattern as VCS plugins") rather than inventing a third plugin protocol.
 
 **Items**:
-1. [ ] Plugin manifest format (`.ta/adapters/<name>/manifest.toml`): declares the action verb(s) it handles (e.g. `"trade.execute"`), a risk-scoring subprocess hook that must return a real computed `risk_score` (not the hardcoded `0` the social adapter uses today), and its commit/publish subprocess entrypoint.
-2. [ ] Wire `StepAction::external_adapter()` to actually dispatch to a registered plugin's subprocess — its first real production caller.
-3. [ ] Approval-gate integration: a dispatched action's risk_score/verdict flows through the same `ta-decision::gate::decide()` used by code drafts and `ta_human_verify` — one uniform `Commit`/`Reject`/`Rework`/`Escalate` contract regardless of domain (per the existing "one uniform contract, policy decides caution" design principle), and consults `security_tier` directly to close the gap found this session where `check_advisor_auto_approve()` is unwired and the real draft-apply path never checks `security_tier` at all.
-4. [ ] Budget guardrail (5.2) consulted as part of the same dispatch path for any adapter action carrying a cost/quantity field.
-5. [ ] Reference implementation: a mock/paper-trading adapter (not a real brokerage integration — no live external API dependency in TA's own test suite) proving the full loop end-to-end: analyst/strategist/trader roles from a persistent session (5.1), a `"trade.execute"` action, hard/soft budget enforcement (5.2), and real non-zero risk scoring.
-6. [ ] Docs: `docs/community-adapter-plugin.md` — how to author a new domain adapter, modeled on the existing `docs/community-ide-plugin.md` pattern.
-7. [ ] Tests: a registered mock adapter's action round-trips through the full gate (approve and reject cases); an unregistered action verb is rejected with a clear "no adapter registered for this verb" error, not a silent no-op.
-8. [ ] USAGE.md: adapter authoring guide, linked from the new community-adapter-plugin.md doc.
+1. [x] Plugin manifest format (`.ta/adapters/<name>/manifest.toml`): declares the action verb(s) it handles (e.g. `"trade.execute"`), a risk-scoring subprocess hook that must return a real computed `risk_score` (not the hardcoded `0` the social adapter uses today), and its commit/publish subprocess entrypoint.
+2. [x] Wire `StepAction::external_adapter()` to actually dispatch to a registered plugin's subprocess — its first real production caller.
+3. [x] Approval-gate integration: a dispatched action's risk_score/verdict flows through the same `ta-decision::gate::decide()` used by code drafts and `ta_human_verify` — one uniform `Commit`/`Reject`/`Rework`/`Escalate` contract regardless of domain (per the existing "one uniform contract, policy decides caution" design principle), and consults `security_tier` directly to close the gap found this session where `check_advisor_auto_approve()` is unwired and the real draft-apply path never checks `security_tier` at all.
+4. [x] Budget guardrail (5.2) consulted as part of the same dispatch path for any adapter action carrying a cost/quantity field.
+5. [x] Reference implementation: a mock/paper-trading adapter (not a real brokerage integration — no live external API dependency in TA's own test suite) proving the full loop end-to-end: analyst/strategist/trader roles from a persistent session (5.1), a `"trade.execute"` action, hard/soft budget enforcement (5.2), and real non-zero risk scoring.
+6. [x] Docs: `docs/community-adapter-plugin.md` — how to author a new domain adapter, modeled on the existing `docs/community-ide-plugin.md` pattern.
+7. [x] Tests: a registered mock adapter's action round-trips through the full gate (approve and reject cases); an unregistered action verb is rejected with a clear "no adapter registered for this verb" error, not a silent no-op.
+8. [x] USAGE.md: adapter authoring guide, linked from the new community-adapter-plugin.md doc.
 
 #### Version: `0.17.5-alpha.3`
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -43,34 +43,34 @@ which = { workspace = true }
 arboard = { workspace = true }
 
 # Internal crates — version kept in sync with workspace by bump-version.sh
-ta-audit = { path = "../../crates/ta-audit", version = "0.17.5-alpha.2" }
-ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.5-alpha.2" }
-ta-memory = { path = "../../crates/ta-memory", version = "0.17.5-alpha.2" }
-ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.5-alpha.2" }
-ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.5-alpha.2" }
-ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.5-alpha.2" }
-ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.5-alpha.2" }
-ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.5-alpha.2" }
-ta-goal = { path = "../../crates/ta-goal", version = "0.17.5-alpha.2" }
-ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.5-alpha.2" }
-ta-policy = { path = "../../crates/ta-policy", version = "0.17.5-alpha.2" }
-ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.5-alpha.2" }
-ta-session = { path = "../../crates/ta-session", version = "0.17.5-alpha.2" }
-ta-events = { path = "../../crates/ta-events", version = "0.17.5-alpha.2" }
-ta-submit = { path = "../../crates/ta-submit", version = "0.17.5-alpha.2" }
-ta-decision = { path = "../../crates/ta-decision", version = "0.17.5-alpha.2" }
-ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.5-alpha.2" }
-ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.5-alpha.2" }
-ta-build = { path = "../../crates/ta-build", version = "0.17.5-alpha.2" }
-ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.5-alpha.2" }
-ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.5-alpha.2" }
-ta-init = { path = "../../crates/ta-init", version = "0.17.5-alpha.2" }
-ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.5-alpha.2" }
-ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.5-alpha.2" }
-ta-intake = { path = "../../crates/ta-intake", version = "0.17.5-alpha.2" }
-ta-brain = { path = "../../crates/ta-brain", version = "0.17.5-alpha.2" }
-ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.5-alpha.2" }
-ta-release = { path = "../../crates/ta-release", version = "0.17.5-alpha.2" }
+ta-audit = { path = "../../crates/ta-audit", version = "0.17.5-alpha.3" }
+ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.5-alpha.3" }
+ta-memory = { path = "../../crates/ta-memory", version = "0.17.5-alpha.3" }
+ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.5-alpha.3" }
+ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.5-alpha.3" }
+ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.5-alpha.3" }
+ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.5-alpha.3" }
+ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.5-alpha.3" }
+ta-goal = { path = "../../crates/ta-goal", version = "0.17.5-alpha.3" }
+ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.5-alpha.3" }
+ta-policy = { path = "../../crates/ta-policy", version = "0.17.5-alpha.3" }
+ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.5-alpha.3" }
+ta-session = { path = "../../crates/ta-session", version = "0.17.5-alpha.3" }
+ta-events = { path = "../../crates/ta-events", version = "0.17.5-alpha.3" }
+ta-submit = { path = "../../crates/ta-submit", version = "0.17.5-alpha.3" }
+ta-decision = { path = "../../crates/ta-decision", version = "0.17.5-alpha.3" }
+ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.5-alpha.3" }
+ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.5-alpha.3" }
+ta-build = { path = "../../crates/ta-build", version = "0.17.5-alpha.3" }
+ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.5-alpha.3" }
+ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.5-alpha.3" }
+ta-init = { path = "../../crates/ta-init", version = "0.17.5-alpha.3" }
+ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.5-alpha.3" }
+ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.5-alpha.3" }
+ta-intake = { path = "../../crates/ta-intake", version = "0.17.5-alpha.3" }
+ta-brain = { path = "../../crates/ta-brain", version = "0.17.5-alpha.3" }
+ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.5-alpha.3" }
+ta-release = { path = "../../crates/ta-release", version = "0.17.5-alpha.3" }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/apps/ta-cli/src/commands/team_session.rs
+++ b/apps/ta-cli/src/commands/team_session.rs
@@ -584,4 +584,56 @@ budget:
         // must not error, must fall back to persisted state.json.
         status(dir.path(), Some("sess-1")).unwrap();
     }
+
+    /// v0.17.5.3's reference implementation — proves
+    /// `templates/workflows/trading-desk.yaml` (the file this module's own
+    /// `Start` doc comment tells users to pass to `--workflow`) is real,
+    /// loadable, and resolves to the analyst -> strategist -> trader stage
+    /// chain with the declared business-metric budget, not just prose.
+    #[test]
+    fn real_trading_desk_template_parses_and_resolves_analyst_strategist_trader_chain() {
+        let yaml = include_str!("../../../../templates/workflows/trading-desk.yaml");
+        let definition = WorkflowDefinition::from_yaml(yaml)
+            .expect("templates/workflows/trading-desk.yaml must be valid workflow YAML");
+
+        assert_eq!(definition.name, "trading-desk");
+        let stage_order = definition.stage_order().unwrap();
+        assert_eq!(stage_order, vec!["analyze", "decide", "execute"]);
+
+        for role in ["analyst", "strategist", "trader"] {
+            assert!(
+                definition.roles.contains_key(role),
+                "expected a '{role}' role definition"
+            );
+        }
+
+        let budget = definition
+            .budget
+            .as_ref()
+            .expect("trading-desk.yaml must declare a budget guardrail");
+        assert_eq!(budget.metric, "usd");
+        assert_eq!(budget.total, 1000.0);
+    }
+
+    #[test]
+    fn real_trading_desk_template_starts_a_team_session_end_to_end() {
+        let dir = tempfile::tempdir().unwrap();
+        let workflow_path = dir.path().join("trading-desk.yaml");
+        std::fs::write(
+            &workflow_path,
+            include_str!("../../../../templates/workflows/trading-desk.yaml"),
+        )
+        .unwrap();
+
+        start(
+            dir.path(),
+            "trading-desk",
+            "trading-desk.yaml",
+            None,
+            "Generate income > 2x within 6 months after fees",
+        )
+        .unwrap();
+
+        status(dir.path(), Some("trading-desk")).unwrap();
+    }
 }

--- a/crates/ta-actions/Cargo.toml
+++ b/crates/ta-actions/Cargo.toml
@@ -17,6 +17,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 toml = { workspace = true }
+ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-actions/src/action.rs
+++ b/crates/ta-actions/src/action.rs
@@ -31,6 +31,32 @@ pub enum ActionError {
     MissingField(String),
 }
 
+// ── Risk assessment ──────────────────────────────────────────────────────────
+
+/// The result of scoring a payload before dispatch (v0.17.5.3).
+///
+/// `risk_score` is 0-100 (higher is riskier), `confidence` is 0.0-1.0 — the
+/// same shape `ta_decision::gate::DecisionInput` expects, so a caller can
+/// build one directly from this without any unit conversion.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct RiskAssessment {
+    pub risk_score: u32,
+    pub confidence: f64,
+}
+
+impl Default for RiskAssessment {
+    /// The zero-risk, fully-confident default used by every built-in stub.
+    /// A registered plugin overrides `risk_score()` to compute a real value
+    /// instead of relying on this default (see the module doc: built-in
+    /// stubs are schema-only, not risk-aware).
+    fn default() -> Self {
+        Self {
+            risk_score: 0,
+            confidence: 1.0,
+        }
+    }
+}
+
 // ── Trait ────────────────────────────────────────────────────────────────────
 
 /// The contract every external action plugin must implement.
@@ -49,6 +75,16 @@ pub trait ExternalAction: Send + Sync {
     /// Validate a payload against this action's schema.
     /// Returns `Ok(())` if the payload is structurally valid.
     fn validate(&self, payload: &Value) -> Result<(), ActionError>;
+
+    /// Score a payload's risk before it is dispatched (v0.17.5.3).
+    ///
+    /// Defaults to [`RiskAssessment::default`] (zero risk, full confidence)
+    /// so the four built-in stubs keep their existing auto-approvable
+    /// behavior unchanged. A domain-action plugin overrides this with a
+    /// real, subprocess-computed score — never a hardcoded value.
+    fn risk_score(&self, _payload: &Value) -> Result<RiskAssessment, ActionError> {
+        Ok(RiskAssessment::default())
+    }
 
     /// Execute the action with the given payload.
     /// Built-in stubs return `Err(ActionError::StubOnly(...))`.
@@ -401,5 +437,14 @@ mod tests {
         let registry = ActionRegistry::new();
         assert!(registry.get("email").is_some());
         assert!(registry.get("unknown_type").is_none());
+    }
+
+    #[test]
+    fn built_in_actions_default_to_zero_risk_full_confidence() {
+        let payload = json!({"to": "a@b.com", "subject": "s", "body": "b"});
+        let assessment = EmailAction.risk_score(&payload).unwrap();
+        assert_eq!(assessment, RiskAssessment::default());
+        assert_eq!(assessment.risk_score, 0);
+        assert_eq!(assessment.confidence, 1.0);
     }
 }

--- a/crates/ta-actions/src/lib.rs
+++ b/crates/ta-actions/src/lib.rs
@@ -37,15 +37,17 @@ pub mod action;
 pub mod capture;
 pub mod constitution_rules;
 pub mod dispatch;
+pub mod plugin_action;
 pub mod policy;
 pub mod rate_limit;
 pub mod ratelimit;
 
 // Re-export the most commonly used types.
-pub use action::{ActionError, ActionRegistry, ActionTypeInfo, ExternalAction};
+pub use action::{ActionError, ActionRegistry, ActionTypeInfo, ExternalAction, RiskAssessment};
 pub use capture::{ActionCapture, ActionOutcome, CaptureError, CapturedAction};
 pub use constitution_rules::{ConstitutionViolation, PolicyConstitution};
 pub use dispatch::{DispatchResult, EmailDispatchGuard};
+pub use plugin_action::{discover_adapter_actions, AdapterPluginAction};
 pub use policy::{ActionPolicies, ActionPolicy, ActionPolicyConfig};
 pub use rate_limit::{RateLimitResult, RateLimiter};
 pub use ratelimit::{SessionRateLimitResult, SessionRateLimiter};

--- a/crates/ta-actions/src/plugin_action.rs
+++ b/crates/ta-actions/src/plugin_action.rs
@@ -218,12 +218,31 @@ mod tests {
         fs::write(&script_path, script).unwrap();
 
         let capabilities: Vec<String> = verbs.iter().map(|v| format!("verb:{v}")).collect();
-        let manifest = format!(
-            "name = \"{name}\"\ntype = \"adapter\"\ncommand = \"python3\"\nargs = [\"{}\"]\ncapabilities = {:?}\n",
-            script_path.display(),
+        // Serialize via serde/toml rather than hand-formatting the TOML
+        // string: `script_path.display()` on Windows renders backslashes
+        // (`C:\Users\...`), and TOML string literals treat `\` as an
+        // escape-sequence introducer — `format!`-ing it in raw produced
+        // "invalid unicode 8-digit hex code" parse errors in Windows CI.
+        // `toml::to_string` escapes the path correctly for every platform.
+        let manifest = PluginManifest {
+            name: name.to_string(),
+            version: "0.1.0".to_string(),
+            kind: "adapter".to_string(),
+            command: "python3".to_string(),
+            args: vec![script_path.to_string_lossy().to_string()],
             capabilities,
-        );
-        fs::write(plugin_dir.join("plugin.toml"), manifest).unwrap();
+            description: None,
+            timeout_secs: None,
+            protocol_version: None,
+            min_daemon_version: None,
+            source_url: None,
+            staging_env: Default::default(),
+        };
+        fs::write(
+            plugin_dir.join("plugin.toml"),
+            toml::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
         plugin_dir
     }
 

--- a/crates/ta-actions/src/plugin_action.rs
+++ b/crates/ta-actions/src/plugin_action.rs
@@ -1,0 +1,364 @@
+// plugin_action.rs — user-authored domain-action adapter plugins (v0.17.5.3).
+//
+// Today, adding a new domain action (e.g. "execute a stock trade via a
+// brokerage API") required a TA core code change: every built-in action type
+// (`email`/`social_post`/`api_call`/`db_query`) is a hardcoded stub in
+// `action.rs`, and `ActionRegistry::register` had no real-world caller.
+//
+// This module makes domain actions genuinely user-authorable by reusing the
+// exact same external-subprocess-plugin transport already proven twice in
+// this codebase — VCS plugins (`ta-submit::ExternalVcsAdapter`) and release
+// plugins (`ta-release::PluginReleaseAdapter`) — rather than inventing a
+// third protocol. A plugin is discovered the same way any other Plugin-
+// category integration is: `.ta/plugins/adapter/<name>/plugin.toml`
+// (project-local) or `~/.config/ta/plugins/adapter/<name>/plugin.toml`
+// (user-global), found via `ta_plugin::discovery::discover_plugins("adapter", ..)`.
+//
+// A plugin declares the verb(s) it handles as `capabilities` entries
+// prefixed `verb:` (e.g. `capabilities = ["verb:trade.execute"]`) — the same
+// prefix-convention idiom `PluginReleaseAdapter` already uses for
+// `"channel:<name>"` custom channel declarations, so no new manifest field
+// is needed.
+//
+// Wire protocol (fresh process per call, same `PluginRequest`/`PluginResponse`
+// envelope every other Plugin-category integration uses):
+//
+//   | Method       | Params                          | Result                              |
+//   |--------------|----------------------------------|--------------------------------------|
+//   | `risk_score` | `{"verb": ..., "payload": ...}` | `{"risk_score": u32, "confidence": f64}` |
+//   | `execute`    | `{"verb": ..., "payload": ...}` | arbitrary JSON (the commit/publish outcome) |
+//
+// A plugin's `risk_score` response is what makes the score real and
+// computed, not the hardcoded `0` `ta-submit::social_adapter.rs`'s `publish()`
+// uses today — see `action.rs::ExternalAction::risk_score`'s default, which
+// this type overrides.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use ta_plugin::discovery::discover_plugins;
+use ta_plugin::envelope::{PluginRequest, PluginResponse};
+use ta_plugin::manifest::PluginManifest;
+
+use crate::action::{ActionError, ExternalAction, RiskAssessment};
+
+const ADAPTER_PLUGIN_KIND: &str = "adapter";
+const VERB_PREFIX: &str = "verb:";
+
+/// Verb(s) an adapter plugin's manifest declares it handles — every
+/// `capabilities` entry prefixed `verb:`, in declaration order.
+fn declared_verbs(manifest: &PluginManifest) -> Vec<String> {
+    manifest
+        .capabilities
+        .iter()
+        .filter_map(|c| c.strip_prefix(VERB_PREFIX))
+        .filter(|v| !v.is_empty())
+        .map(|v| v.to_string())
+        .collect()
+}
+
+#[derive(Debug, Serialize)]
+struct VerbParams<'a> {
+    verb: &'a str,
+    payload: &'a Value,
+}
+
+/// `ExternalAction` implementation for one verb of a discovered adapter
+/// plugin. One instance per (plugin, verb) pair — a plugin declaring
+/// multiple verbs gets one `AdapterPluginAction` registered per verb, all
+/// sharing the same manifest/subprocess entrypoint.
+pub struct AdapterPluginAction {
+    verb: String,
+    plugin_name: String,
+    command: String,
+    args: Vec<String>,
+    work_dir: PathBuf,
+    timeout: Duration,
+}
+
+impl AdapterPluginAction {
+    pub fn new(verb: impl Into<String>, manifest: &PluginManifest, plugin_dir: &Path) -> Self {
+        Self {
+            verb: verb.into(),
+            plugin_name: manifest.name.clone(),
+            command: manifest.command.clone(),
+            args: manifest.args.clone(),
+            work_dir: plugin_dir.to_path_buf(),
+            timeout: manifest.timeout(30),
+        }
+    }
+
+    fn call(&self, method: &str, payload: &Value) -> Result<Value, ActionError> {
+        let request = PluginRequest::new(
+            method,
+            json!(VerbParams {
+                verb: &self.verb,
+                payload,
+            }),
+        );
+        let response: PluginResponse = ta_plugin::transport::call_json(
+            &self.plugin_name,
+            method,
+            &self.command,
+            &self.args,
+            &self.work_dir,
+            &request,
+            self.timeout,
+        )
+        .map_err(|e| {
+            ActionError::Execution(format!(
+                "adapter plugin '{}' verb '{}': {e}",
+                self.plugin_name, self.verb
+            ))
+        })?;
+
+        if !response.ok {
+            return Err(ActionError::Execution(format!(
+                "adapter plugin '{}' verb '{}' method '{method}' failed: {}",
+                self.plugin_name,
+                self.verb,
+                response.error.as_deref().unwrap_or("unknown error")
+            )));
+        }
+        Ok(response.result)
+    }
+}
+
+impl ExternalAction for AdapterPluginAction {
+    fn action_type(&self) -> &str {
+        &self.verb
+    }
+
+    fn payload_schema(&self) -> Value {
+        // Adapter plugins don't declare a JSON Schema in v1 — the plugin's
+        // own `risk_score`/`execute` methods are the validation surface.
+        json!({ "type": "object" })
+    }
+
+    fn validate(&self, _payload: &Value) -> Result<(), ActionError> {
+        Ok(())
+    }
+
+    fn risk_score(&self, payload: &Value) -> Result<RiskAssessment, ActionError> {
+        let result = self.call("risk_score", payload)?;
+        serde_json::from_value(result).map_err(|e| {
+            ActionError::Execution(format!(
+                "adapter plugin '{}' verb '{}': risk_score response did not match \
+                 {{risk_score: u32, confidence: f64}}: {e}",
+                self.plugin_name, self.verb
+            ))
+        })
+    }
+
+    fn execute(&self, payload: &Value) -> Result<Value, ActionError> {
+        self.call("execute", payload)
+    }
+}
+
+/// Discover every registered adapter plugin under `project_root` and return
+/// one boxed `ExternalAction` per declared verb, ready to hand to
+/// `ActionRegistry::register`.
+///
+/// Discovery itself never spawns a subprocess — it only reads
+/// `plugin.toml` files — so building the registry stays cheap even when
+/// most `ta_external_action` calls target an unrelated built-in type. A
+/// plugin's subprocess is only spawned when one of its verbs is actually
+/// dispatched via `risk_score`/`execute`.
+pub fn discover_adapter_actions(project_root: &Path) -> Vec<Box<dyn ExternalAction>> {
+    let mut actions: Vec<Box<dyn ExternalAction>> = Vec::new();
+    for discovered in discover_plugins(ADAPTER_PLUGIN_KIND, project_root) {
+        if let Err(e) = discovered.manifest.validate(ADAPTER_PLUGIN_KIND) {
+            tracing::warn!(
+                plugin = %discovered.manifest.name,
+                error = %e,
+                "skipping adapter plugin with invalid manifest"
+            );
+            continue;
+        }
+        let verbs = declared_verbs(&discovered.manifest);
+        if verbs.is_empty() {
+            tracing::warn!(
+                plugin = %discovered.manifest.name,
+                "adapter plugin declares no 'verb:<name>' capabilities — it handles no \
+                 action types and will never be dispatched to"
+            );
+            continue;
+        }
+        for verb in verbs {
+            actions.push(Box::new(AdapterPluginAction::new(
+                verb,
+                &discovered.manifest,
+                &discovered.plugin_dir,
+            )));
+        }
+    }
+    actions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Writes a mock adapter plugin under `.ta/plugins/adapter/<name>/` whose
+    /// `risk_score`/`execute` methods are driven by a small Python script —
+    /// no live external API, matching item 5's "no live external API
+    /// dependency in TA's own test suite" requirement.
+    fn write_mock_plugin(project_root: &Path, name: &str, verbs: &[&str], script: &str) -> PathBuf {
+        let plugin_dir = project_root
+            .join(".ta")
+            .join("plugins")
+            .join("adapter")
+            .join(name);
+        fs::create_dir_all(&plugin_dir).unwrap();
+        let script_path = plugin_dir.join("mock_plugin.py");
+        fs::write(&script_path, script).unwrap();
+
+        let capabilities: Vec<String> = verbs.iter().map(|v| format!("verb:{v}")).collect();
+        let manifest = format!(
+            "name = \"{name}\"\ntype = \"adapter\"\ncommand = \"python3\"\nargs = [\"{}\"]\ncapabilities = {:?}\n",
+            script_path.display(),
+            capabilities,
+        );
+        fs::write(plugin_dir.join("plugin.toml"), manifest).unwrap();
+        plugin_dir
+    }
+
+    const ECHO_RISK_PLUGIN: &str = r#"
+import json
+import sys
+
+line = sys.stdin.readline()
+req = json.loads(line)
+method = req["method"]
+params = req["params"]
+payload = params["payload"]
+
+if method == "risk_score":
+    amount = payload.get("amount", 0)
+    result = {"risk_score": min(100, int(amount / 10)), "confidence": 0.95}
+    print(json.dumps({"ok": True, "result": result}))
+elif method == "execute":
+    result = {"status": "filled", "amount": payload.get("amount", 0)}
+    print(json.dumps({"ok": True, "result": result}))
+else:
+    print(json.dumps({"ok": False, "error": f"unknown method {method}"}))
+"#;
+
+    #[test]
+    fn discovers_verbs_declared_via_verb_prefixed_capabilities() {
+        let dir = tempfile::tempdir().unwrap();
+        write_mock_plugin(
+            dir.path(),
+            "paper-trading",
+            &["trade.execute"],
+            ECHO_RISK_PLUGIN,
+        );
+
+        let actions = discover_adapter_actions(dir.path());
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].action_type(), "trade.execute");
+    }
+
+    #[test]
+    fn plugin_with_no_verb_capabilities_is_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        write_mock_plugin(dir.path(), "no-verbs", &[], ECHO_RISK_PLUGIN);
+
+        let actions = discover_adapter_actions(dir.path());
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn risk_score_calls_the_subprocess_and_returns_a_real_computed_score() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = write_mock_plugin(
+            dir.path(),
+            "paper-trading",
+            &["trade.execute"],
+            ECHO_RISK_PLUGIN,
+        );
+        let manifest = PluginManifest::load(&plugin_dir.join("plugin.toml")).unwrap();
+        let action = AdapterPluginAction::new("trade.execute", &manifest, &plugin_dir);
+
+        let assessment = action.risk_score(&json!({"amount": 500})).unwrap();
+        assert_eq!(assessment.risk_score, 50);
+        assert_eq!(assessment.confidence, 0.95);
+
+        // Not the hardcoded 0 the social adapter uses -- a different amount
+        // produces a different score.
+        let assessment_hi = action.risk_score(&json!({"amount": 2000})).unwrap();
+        assert_eq!(assessment_hi.risk_score, 100);
+    }
+
+    #[test]
+    fn execute_calls_the_subprocess_and_returns_its_result() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = write_mock_plugin(
+            dir.path(),
+            "paper-trading",
+            &["trade.execute"],
+            ECHO_RISK_PLUGIN,
+        );
+        let manifest = PluginManifest::load(&plugin_dir.join("plugin.toml")).unwrap();
+        let action = AdapterPluginAction::new("trade.execute", &manifest, &plugin_dir);
+
+        let result = action.execute(&json!({"amount": 250})).unwrap();
+        assert_eq!(result["status"], "filled");
+        assert_eq!(result["amount"], 250);
+    }
+
+    /// Exercises the actual shipped reference implementation
+    /// (`plugins/adapter/paper-trading/`, v0.17.5.3 item 5) rather than an
+    /// inline fixture -- proves the example in the repo really works, not
+    /// just prose describing it.
+    #[test]
+    fn shipped_paper_trading_reference_plugin_scores_risk_and_executes() {
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap();
+        let plugin_dir = repo_root
+            .join("plugins")
+            .join("adapter")
+            .join("paper-trading");
+        let manifest = PluginManifest::load(&plugin_dir.join("plugin.toml"))
+            .expect("plugins/adapter/paper-trading/plugin.toml must load");
+        let action = AdapterPluginAction::new("trade.execute", &manifest, &plugin_dir);
+
+        let low_risk = action
+            .risk_score(&json!({"symbol": "ACME", "amount": 200}))
+            .unwrap();
+        assert!(
+            low_risk.risk_score < 40,
+            "expected a low risk score, got {low_risk:?}"
+        );
+
+        let high_risk = action
+            .risk_score(&json!({"symbol": "X", "amount": 5000}))
+            .unwrap();
+        assert_eq!(high_risk.risk_score, 100);
+
+        let fill = action
+            .execute(&json!({"symbol": "ACME", "side": "buy", "amount": 200}))
+            .unwrap();
+        assert_eq!(fill["status"], "filled");
+        assert_eq!(fill["venue"], "paper-trading-mock");
+    }
+
+    #[test]
+    fn a_failing_plugin_call_surfaces_a_clear_execution_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let broken_script = "import sys\nsys.exit(1)\n";
+        let plugin_dir = write_mock_plugin(dir.path(), "broken", &["trade.execute"], broken_script);
+        let manifest = PluginManifest::load(&plugin_dir.join("plugin.toml")).unwrap();
+        let action = AdapterPluginAction::new("trade.execute", &manifest, &plugin_dir);
+
+        let err = action.execute(&json!({"amount": 1})).unwrap_err();
+        assert!(matches!(err, ActionError::Execution(_)));
+    }
+}

--- a/crates/ta-advisor/Cargo.toml
+++ b/crates/ta-advisor/Cargo.toml
@@ -17,12 +17,12 @@ tracing = { workspace = true }
 
 # Reuses the existing heuristic classifier as the substrate for the new
 # 4-way taxonomy rather than duplicating keyword-matching logic.
-ta-session = { path = "../ta-session", version = "0.17.5-alpha.2" }
+ta-session = { path = "../ta-session", version = "0.17.5-alpha.3" }
 # Team-coordinator capability (v0.17.0.12.20): reuses ta-intake's TriggerEvent
 # and ta-brain's routing/prioritization rather than a new persistent role —
 # see crates/ta-advisor/src/coordinator.rs for the decision rationale.
-ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.2" }
-ta-brain = { path = "../ta-brain", version = "0.17.5-alpha.2" }
+ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.3" }
+ta-brain = { path = "../ta-brain", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-brain/Cargo.toml
+++ b/crates/ta-brain/Cargo.toml
@@ -18,13 +18,13 @@ chrono = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
-ta-session = { path = "../ta-session", version = "0.17.5-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
-ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.2" }
+ta-session = { path = "../ta-session", version = "0.17.5-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
+ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.3" }
 # Folds ta-workflow's template-matching intent resolver in as one signal
 # route() consults (v0.17.0.12.23), rather than a second, parallel intent
 # system — see route.rs's resolve_workflow_template().
-ta-workflow = { path = "../ta-workflow", version = "0.17.5-alpha.2" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/comfyui/Cargo.toml
+++ b/crates/ta-connectors/comfyui/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.2" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/discord/Cargo.toml
+++ b/crates/ta-connectors/discord/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.5-alpha.2" }
+ta-events = { path = "../../ta-events", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/email/Cargo.toml
+++ b/crates/ta-connectors/email/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.5-alpha.2" }
+ta-events = { path = "../../ta-events", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/fs/Cargo.toml
+++ b/crates/ta-connectors/fs/Cargo.toml
@@ -16,10 +16,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.2" }
-ta-workspace = { path = "../../ta-workspace", version = "0.17.5-alpha.2" }
-ta-audit = { path = "../../ta-audit", version = "0.17.5-alpha.2" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.3" }
+ta-workspace = { path = "../../ta-workspace", version = "0.17.5-alpha.3" }
+ta-audit = { path = "../../ta-audit", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-ta-policy = { path = "../../ta-policy", version = "0.17.5-alpha.2" }
+ta-policy = { path = "../../ta-policy", version = "0.17.5-alpha.3" }

--- a/crates/ta-connectors/slack/Cargo.toml
+++ b/crates/ta-connectors/slack/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.5-alpha.2" }
+ta-events = { path = "../../ta-events", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/unreal/Cargo.toml
+++ b/crates/ta-connectors/unreal/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.2" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -31,23 +31,23 @@ async-stream = { workspace = true }
 sha2 = { workspace = true }
 
 # Internal crates
-ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.5-alpha.2" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
-ta-memory = { path = "../ta-memory", version = "0.17.5-alpha.2" }
-ta-events = { path = "../ta-events", version = "0.17.5-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
-ta-runtime = { path = "../ta-runtime", version = "0.17.5-alpha.2" }
-ta-audit = { path = "../ta-audit", version = "0.17.5-alpha.2" }
-ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.2" }
-ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.5-alpha.2" }
-ta-connector-email = { path = "../ta-connectors/email", version = "0.17.5-alpha.2" }
+ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.5-alpha.3" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
+ta-memory = { path = "../ta-memory", version = "0.17.5-alpha.3" }
+ta-events = { path = "../ta-events", version = "0.17.5-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
+ta-runtime = { path = "../ta-runtime", version = "0.17.5-alpha.3" }
+ta-audit = { path = "../ta-audit", version = "0.17.5-alpha.3" }
+ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.3" }
+ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.5-alpha.3" }
+ta-connector-email = { path = "../ta-connectors/email", version = "0.17.5-alpha.3" }
 reqwest = { workspace = true }
-ta-output-schema = { path = "../ta-output-schema", version = "0.17.5-alpha.2" }
-ta-extension = { path = "../ta-extension", version = "0.17.5-alpha.2" }
-ta-session = { path = "../ta-session", version = "0.17.5-alpha.2" }
-ta-advisor = { path = "../ta-advisor", version = "0.17.5-alpha.2" }
-ta-data-spec = { path = "../ta-data-spec", version = "0.17.5-alpha.2" }
+ta-output-schema = { path = "../ta-output-schema", version = "0.17.5-alpha.3" }
+ta-extension = { path = "../ta-extension", version = "0.17.5-alpha.3" }
+ta-session = { path = "../ta-session", version = "0.17.5-alpha.3" }
+ta-advisor = { path = "../ta-advisor", version = "0.17.5-alpha.3" }
+ta-data-spec = { path = "../ta-data-spec", version = "0.17.5-alpha.3" }
 which = "7"
 libc = { workspace = true }
 async-trait = "0.1"

--- a/crates/ta-data-spec/Cargo.toml
+++ b/crates/ta-data-spec/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 [dependencies]
 schemars = { workspace = true }
 serde_json = { workspace = true }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
-ta-brain = { path = "../ta-brain", version = "0.17.5-alpha.2" }
-ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
+ta-brain = { path = "../ta-brain", version = "0.17.5-alpha.3" }
+ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.3" }

--- a/crates/ta-db-proxy/Cargo.toml
+++ b/crates/ta-db-proxy/Cargo.toml
@@ -17,10 +17,10 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.5-alpha.2" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.2" }
-ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.2" }
-ta-actions = { path = "../ta-actions", version = "0.17.5-alpha.2" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.5-alpha.3" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.3" }
+ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.3" }
+ta-actions = { path = "../ta-actions", version = "0.17.5-alpha.3" }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ta-intake/Cargo.toml
+++ b/crates/ta-intake/Cargo.toml
@@ -19,8 +19,8 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 regex = { workspace = true }
-ta-submit = { path = "../ta-submit", version = "0.17.5-alpha.2" }
-ta-events = { path = "../ta-events", version = "0.17.5-alpha.2" }
+ta-submit = { path = "../ta-submit", version = "0.17.5-alpha.3" }
+ta-events = { path = "../ta-events", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -25,22 +25,22 @@ which = { workspace = true }
 toml = { workspace = true }
 
 # Internal crates
-ta-audit = { path = "../ta-audit", version = "0.17.5-alpha.2" }
-ta-events = { path = "../ta-events", version = "0.17.5-alpha.2" }
-ta-memory = { path = "../ta-memory", version = "0.17.5-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
-ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.5-alpha.2" }
-ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.5-alpha.2" }
-ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.5-alpha.2" }
-ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.5-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
-ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.2" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.2" }
-ta-workflow = { path = "../ta-workflow", version = "0.17.5-alpha.2" }
-ta-actions = { path = "../ta-actions", version = "0.17.5-alpha.2" }
-ta-submit = { path = "../ta-submit", version = "0.17.5-alpha.2" }
-ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.2" }
-ta-session = { path = "../ta-session", version = "0.17.5-alpha.2" }
+ta-audit = { path = "../ta-audit", version = "0.17.5-alpha.3" }
+ta-events = { path = "../ta-events", version = "0.17.5-alpha.3" }
+ta-memory = { path = "../ta-memory", version = "0.17.5-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
+ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.5-alpha.3" }
+ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.5-alpha.3" }
+ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.5-alpha.3" }
+ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.5-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
+ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.3" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.3" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.5-alpha.3" }
+ta-actions = { path = "../ta-actions", version = "0.17.5-alpha.3" }
+ta-submit = { path = "../ta-submit", version = "0.17.5-alpha.3" }
+ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.3" }
+ta-session = { path = "../ta-session", version = "0.17.5-alpha.3" }
 
 
 [dev-dependencies]

--- a/crates/ta-mcp-gateway/src/server.rs
+++ b/crates/ta-mcp-gateway/src/server.rs
@@ -301,6 +301,12 @@ pub struct ExternalActionParams {
     /// Use this to test workflow definitions without side effects.
     #[serde(default)]
     pub dry_run: bool,
+    /// A business-metric budget guardrail check to run against this action
+    /// before it may auto-execute (v0.17.5.3, reusing `ta_human_verify`'s
+    /// v0.17.5.2 budget mechanism). Only consulted for `ActionPolicy::Auto`
+    /// dispatch — absent for actions with no cost/quantity dimension.
+    #[serde(default)]
+    pub budget: Option<tools::human_verify::BudgetActionParams>,
 }
 
 /// Tracks an active agent session within the gateway (v0.9.6).

--- a/crates/ta-mcp-gateway/src/tools/action.rs
+++ b/crates/ta-mcp-gateway/src/tools/action.rs
@@ -19,6 +19,7 @@
 // Dry-run mode overrides all policies: action is logged but never executed
 // or captured for review. Useful for testing workflow definitions.
 
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use chrono::Utc;
@@ -27,12 +28,17 @@ use rmcp::ErrorData as McpError;
 use uuid::Uuid;
 
 use ta_actions::{
-    ActionCapture, ActionOutcome, ActionPolicies, ActionPolicy, ActionRegistry, CapturedAction,
-    DispatchResult, EmailDispatchGuard, RateLimitResult, SessionRateLimiter,
+    discover_adapter_actions, ActionCapture, ActionOutcome, ActionPolicies, ActionPolicy,
+    ActionRegistry, CapturedAction, DispatchResult, EmailDispatchGuard, RateLimitResult,
+    RiskAssessment, SessionRateLimiter,
 };
 use ta_changeset::draft_package::{ActionKind, ArtifactDisposition, PendingAction};
+use ta_decision::{decide, Decision, DecisionInput, Verdict};
+use ta_policy::business_budget::{self, BudgetCheckResult};
+use ta_session::workflow_session::AdvisorSecurity;
 
 use crate::server::GatewayState;
+use crate::tools::human_verify::{load_thresholds, resolve_workload_context, validate_ledger_path};
 use crate::validation::parse_uuid;
 
 // ── Handler ──────────────────────────────────────────────────────────────────
@@ -48,19 +54,32 @@ pub fn handle_external_action(
 
     let goal_run_id = params.goal_run_id.as_deref().map(parse_uuid).transpose()?;
 
-    // Validate the action type against the registry.
-    let registry = ActionRegistry::new();
+    // Validate the action type against the registry: the four built-in
+    // stubs plus every verb declared by a discovered adapter plugin under
+    // `.ta/plugins/adapter/<name>/plugin.toml` (v0.17.5.3) — this is the
+    // registry's first real production caller of plugin-backed actions.
+    // Discovery only reads manifests, it never spawns a subprocess, so this
+    // stays cheap even for calls targeting an unrelated built-in type.
+    let mut registry = ActionRegistry::new();
+    for plugin_action in discover_adapter_actions(&state.config.workspace_root) {
+        registry.register(plugin_action);
+    }
     let action_impl = registry.get(&params.action_type).ok_or_else(|| {
         McpError::invalid_params(
             format!(
-                "unknown action type '{}'. Registered types: {}",
+                "unknown action type '{}' — no adapter registered for this verb. \
+                 Registered types: {}. Author a plugin under \
+                 .ta/plugins/adapter/<name>/plugin.toml declaring \
+                 `capabilities = [\"verb:{}\"]` to handle it (see \
+                 docs/community-adapter-plugin.md).",
                 params.action_type,
                 registry
                     .list()
                     .iter()
                     .map(|t| t.action_type.as_str())
                     .collect::<Vec<_>>()
-                    .join(", ")
+                    .join(", "),
+                params.action_type,
             ),
             None,
         )
@@ -301,29 +320,7 @@ pub fn handle_external_action(
             }
 
             ActionPolicy::Auto => {
-                // Execute via plugin. Stubs return StubOnly error.
-                match action_impl.execute(&params.payload) {
-                    Ok(result) => (ActionOutcome::Executed { result }, None),
-                    Err(ta_actions::ActionError::StubOnly(_)) => {
-                        // Stub: log as executed with a clear placeholder result.
-                        let result = serde_json::json!({
-                            "status": "stub_executed",
-                            "message": format!(
-                                "Action type '{}' has no registered plugin executor. \
-                                 Register a plugin via the ActionRegistry to provide \
-                                 real execution. The action has been logged.",
-                                params.action_type
-                            )
-                        });
-                        (ActionOutcome::Executed { result }, None)
-                    }
-                    Err(e) => {
-                        return Err(McpError::internal_error(
-                            format!("action execution failed: {}", e),
-                            None,
-                        ));
-                    }
-                }
+                dispatch_auto_action(&state.config.workspace_root, &params, action_impl)?
             }
         }
     };
@@ -389,6 +386,170 @@ pub fn handle_external_action(
         .map_err(|e| {
             McpError::internal_error(e.to_string(), None)
         })?]))
+}
+
+/// Dispatch an `ActionPolicy::Auto` action through the risk/budget/security
+/// gate (v0.17.5.3 item 3): a plugin-computed risk score is scored via the
+/// same `ta_decision::gate::decide()` used by code drafts and
+/// `ta_human_verify` — one uniform `Commit`/`Reject`/`Rework`/`Escalate`
+/// contract regardless of domain — a business-metric budget guardrail
+/// (v0.17.5.2, item 4) is consulted when the caller supplies one, and
+/// `security_tier` gates whether the gate's own verdict is even allowed to
+/// auto-commit (item 3's "consults `security_tier` directly" requirement):
+/// this mirrors `check_advisor_auto_approve`'s Auto-only rule as this
+/// path's own live caller, rather than leaving that logic unwired like the
+/// real draft-apply path does today.
+fn dispatch_auto_action(
+    workspace_root: &Path,
+    params: &ExternalActionParams,
+    action_impl: &dyn ta_actions::ExternalAction,
+) -> Result<(ActionOutcome, Option<PendingAction>), McpError> {
+    // Business-metric budget hard-limit pre-gate — deterministic, runs
+    // before any risk scoring (mirrors `ta_human_verify`'s ordering: a
+    // hard limit is a workflow-declared rule with no confidence override).
+    let mut budget_soft_limit_reason: Option<String> = None;
+    if let Some(budget_params) = &params.budget {
+        validate_ledger_path(&budget_params.ledger_path)?;
+        let guardrails = budget_params.guardrails.clone().into();
+        let ledger_path = workspace_root.join(&budget_params.ledger_path);
+        let ledger_total_before = business_budget::ledger_running_total(&ledger_path);
+        match business_budget::check_budget(
+            &guardrails,
+            ledger_total_before,
+            budget_params.action_amount,
+        ) {
+            BudgetCheckResult::HardLimitExceeded(reason) => {
+                tracing::warn!(
+                    action_type = %params.action_type,
+                    amount = budget_params.action_amount,
+                    reason = %reason,
+                    "ta_external_action: business-metric budget hard limit exceeded, \
+                     blocking before risk scoring"
+                );
+                return Ok((ActionOutcome::Blocked { reason }, None));
+            }
+            BudgetCheckResult::SoftLimitCrossed(reason) => {
+                budget_soft_limit_reason = Some(reason);
+            }
+            BudgetCheckResult::Ok => {}
+        }
+    }
+
+    let RiskAssessment {
+        risk_score,
+        confidence,
+    } = action_impl.risk_score(&params.payload).map_err(|e| {
+        McpError::internal_error(
+            format!(
+                "risk scoring failed for action '{}': {e}",
+                params.action_type
+            ),
+            None,
+        )
+    })?;
+
+    let thresholds = load_thresholds(workspace_root, &params.action_type);
+    let input = DecisionInput {
+        verdict: Verdict::Pass,
+        risk_score,
+        confidence,
+    };
+    let mut decision = decide(&input, &thresholds);
+
+    if let Some(reason) = &budget_soft_limit_reason {
+        if decision != Decision::Escalate {
+            tracing::info!(
+                action_type = %params.action_type,
+                reason = %reason,
+                original_decision = ?decision,
+                "ta_external_action: forcing Escalate — business-metric budget soft \
+                 threshold crossed"
+            );
+        }
+        decision = Decision::Escalate;
+    }
+
+    // security_tier only ever downgrades autonomy, never upgrades it — same
+    // rule `ta-brain::route()`'s confidence-downgrade uses. An
+    // inferred/non-autonomous workload never gets to auto-commit an
+    // external side effect, no matter how low-risk the gate scored it.
+    let (_, security_tier) = resolve_workload_context(workspace_root);
+    if security_tier != AdvisorSecurity::Auto && decision == Decision::Commit {
+        tracing::info!(
+            action_type = %params.action_type,
+            security_tier = %security_tier,
+            "ta_external_action: security_tier != auto, downgrading Commit to Escalate"
+        );
+        decision = Decision::Escalate;
+    }
+
+    tracing::info!(
+        action_type = %params.action_type,
+        decision = ?decision,
+        risk_score,
+        confidence,
+        "ta_external_action: gate decision for auto-policy dispatch"
+    );
+
+    if !decision.is_auto_approvable() {
+        let action_id = Uuid::new_v4();
+        let description = format!(
+            "{} [gate: {decision:?}, risk_score={risk_score}, confidence={:.0}%]",
+            build_description(params),
+            confidence * 100.0,
+        );
+        let pending = PendingAction {
+            action_id,
+            tool_name: format!("ta_external_action:{}", params.action_type),
+            parameters: params.payload.clone(),
+            kind: ActionKind::StateChanging,
+            intercepted_at: Utc::now(),
+            description,
+            target_uri: params.target_uri.clone(),
+            disposition: ArtifactDisposition::Pending,
+        };
+        return Ok((ActionOutcome::CapturedForReview, Some(pending)));
+    }
+
+    match action_impl.execute(&params.payload) {
+        Ok(result) => {
+            if let Some(budget_params) = &params.budget {
+                let ledger_path = workspace_root.join(&budget_params.ledger_path);
+                if let Err(e) = business_budget::record_ledger_spend(
+                    &ledger_path,
+                    &budget_params.action_label,
+                    budget_params.action_amount,
+                ) {
+                    tracing::warn!(
+                        path = %ledger_path.display(),
+                        error = %e,
+                        "ta_external_action: failed to record business-metric budget \
+                         ledger entry"
+                    );
+                }
+            }
+            Ok((ActionOutcome::Executed { result }, None))
+        }
+        // Built-in stubs have no risk-scoring gate to fail (default is
+        // zero-risk/full-confidence, always `Commit`) so this is only
+        // reachable for the four built-ins, never a plugin-backed verb.
+        Err(ta_actions::ActionError::StubOnly(_)) => {
+            let result = serde_json::json!({
+                "status": "stub_executed",
+                "message": format!(
+                    "Action type '{}' has no registered plugin executor. \
+                     Register a plugin via the ActionRegistry to provide \
+                     real execution. The action has been logged.",
+                    params.action_type
+                )
+            });
+            Ok((ActionOutcome::Executed { result }, None))
+        }
+        Err(e) => Err(McpError::internal_error(
+            format!("action execution failed: {}", e),
+            None,
+        )),
+    }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -557,6 +718,28 @@ mod tests {
         Arc::new(Mutex::new(state))
     }
 
+    /// Logs a `RoutingDecision` with the given `security_tier`, the same
+    /// `.ta/routing-decisions.jsonl` fixture `human_verify.rs`'s tests use —
+    /// `dispatch_auto_action` resolves `security_tier` from this same log.
+    fn write_routing_decision(workspace_root: &std::path::Path, security_tier: &str) {
+        let log_path = workspace_root.join(".ta").join("routing-decisions.jsonl");
+        std::fs::create_dir_all(log_path.parent().unwrap()).unwrap();
+        let line = serde_json::json!({
+            "timestamp": "2026-07-10T00:00:00Z",
+            "goal_title": "test goal",
+            "decision": {
+                "team": "implementer",
+                "agent": "claude-code",
+                "security_tier": security_tier,
+                "priority": "normal",
+                "workload_type": "general",
+                "workload_confidence": 0.9,
+                "rationale": ["test"],
+            }
+        });
+        std::fs::write(&log_path, format!("{}\n", line)).unwrap();
+    }
+
     #[test]
     fn unknown_action_type_returns_error() {
         let dir = tempdir().unwrap();
@@ -568,6 +751,7 @@ mod tests {
             goal_run_id: None,
             target_uri: None,
             dry_run: false,
+            budget: None,
         };
 
         let result = handle_external_action(&state, params);
@@ -585,6 +769,7 @@ mod tests {
             goal_run_id: None,
             target_uri: None,
             dry_run: false,
+            budget: None,
         };
 
         let result = handle_external_action(&state, params);
@@ -602,6 +787,7 @@ mod tests {
             goal_run_id: None,
             target_uri: None,
             dry_run: true,
+            budget: None,
         };
 
         let result = handle_external_action(&state, params).unwrap();
@@ -636,6 +822,7 @@ mod tests {
             goal_run_id: Some(goal_id.to_string()),
             target_uri: None,
             dry_run: false,
+            budget: None,
         };
 
         let result = handle_external_action(&state, params).unwrap();
@@ -673,6 +860,7 @@ mod tests {
             goal_run_id: None,
             target_uri: None,
             dry_run: false,
+            budget: None,
         };
 
         let result = handle_external_action(&state, params).unwrap();
@@ -705,6 +893,7 @@ mod tests {
             goal_run_id: Some(goal_id.to_string()),
             target_uri: None,
             dry_run: false,
+            budget: None,
         };
 
         // First two should succeed (review).
@@ -724,8 +913,11 @@ mod tests {
         );
     }
 
+    /// With `security_tier: auto` logged, the gate's default zero-risk
+    /// score commits and the built-in stub's placeholder executes — same
+    /// observable behavior as before v0.17.5.3's gate existed.
     #[test]
-    fn auto_policy_stub_returns_stub_executed() {
+    fn auto_policy_stub_returns_stub_executed_when_security_tier_is_auto() {
         let dir = tempdir().unwrap();
 
         let ta_dir = dir.path().join(".ta");
@@ -735,6 +927,7 @@ mod tests {
             b"[actions.api_call]\npolicy = \"auto\"\n",
         )
         .unwrap();
+        write_routing_decision(dir.path(), "auto");
 
         let state = make_state(dir.path());
 
@@ -744,6 +937,7 @@ mod tests {
             goal_run_id: None,
             target_uri: None,
             dry_run: false,
+            budget: None,
         };
 
         let result = handle_external_action(&state, params).unwrap();
@@ -759,6 +953,199 @@ mod tests {
             text.contains("stub_executed"),
             "expected stub_executed status: {}",
             text
+        );
+    }
+
+    /// Without a logged `security_tier: auto` routing decision (the
+    /// unclassified-workload default, `Suggest`), `dispatch_auto_action`
+    /// never lets the gate's `Commit` verdict auto-execute — even a
+    /// zero-risk built-in stub is captured for review instead (v0.17.5.3
+    /// item 3: security_tier only ever downgrades autonomy).
+    #[test]
+    fn auto_policy_without_auto_security_tier_is_captured_for_review() {
+        let dir = tempdir().unwrap();
+
+        let ta_dir = dir.path().join(".ta");
+        std::fs::create_dir_all(&ta_dir).unwrap();
+        std::fs::write(
+            ta_dir.join("workflow.toml"),
+            b"[actions.api_call]\npolicy = \"auto\"\n",
+        )
+        .unwrap();
+        // No routing decision logged -- resolve_workload_context defaults
+        // to Suggest, not Auto.
+
+        let state = make_state(dir.path());
+
+        let params = ExternalActionParams {
+            action_type: "api_call".into(),
+            payload: json!({"method": "GET", "url": "https://api.example.com/status"}),
+            goal_run_id: None,
+            target_uri: None,
+            dry_run: false,
+            budget: None,
+        };
+
+        let result = handle_external_action(&state, params).unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+
+        let text = serde_json::to_string(&result.content[0]).unwrap();
+        assert!(
+            text.contains("captured_for_review"),
+            "expected captured_for_review outcome: {}",
+            text
+        );
+    }
+
+    // ── v0.17.5.3: adapter plugin end-to-end gate round-trip ──────────────
+
+    /// Writes a mock `trade.execute` adapter plugin under
+    /// `.ta/plugins/adapter/paper-trading/` whose risk score scales with the
+    /// trade's dollar `amount` -- a small Python script, no live brokerage
+    /// dependency (item 5/7's "no live external API dependency in TA's own
+    /// test suite" requirement).
+    fn write_paper_trading_plugin(workspace_root: &std::path::Path) {
+        let plugin_dir = workspace_root
+            .join(".ta")
+            .join("plugins")
+            .join("adapter")
+            .join("paper-trading");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        let script_path = plugin_dir.join("mock_plugin.py");
+        std::fs::write(
+            &script_path,
+            r#"
+import json
+import sys
+
+req = json.loads(sys.stdin.readline())
+method = req["method"]
+payload = req["params"]["payload"]
+amount = payload.get("amount", 0)
+
+if method == "risk_score":
+    # Real, non-hardcoded score: scales with trade notional size.
+    result = {"risk_score": min(100, int(amount / 10)), "confidence": 0.95}
+    print(json.dumps({"ok": True, "result": result}))
+elif method == "execute":
+    result = {"status": "filled", "amount": amount}
+    print(json.dumps({"ok": True, "result": result}))
+else:
+    print(json.dumps({"ok": False, "error": f"unknown method {method}"}))
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.toml"),
+            format!(
+                "name = \"paper-trading\"\ntype = \"adapter\"\ncommand = \"python3\"\n\
+                 args = [\"{}\"]\ncapabilities = [\"verb:trade.execute\"]\n",
+                script_path.display()
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn adapter_plugin_low_risk_trade_auto_executes() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".ta")).unwrap();
+        std::fs::write(
+            dir.path().join(".ta").join("workflow.toml"),
+            b"[actions.\"trade.execute\"]\npolicy = \"auto\"\n",
+        )
+        .unwrap();
+        write_paper_trading_plugin(dir.path());
+        write_routing_decision(dir.path(), "auto");
+
+        let state = make_state(dir.path());
+        let params = ExternalActionParams {
+            action_type: "trade.execute".into(),
+            // amount=100 -> risk_score=10, well under the default
+            // max_risk_score=40 threshold -> Commit.
+            payload: json!({"symbol": "ACME", "amount": 100}),
+            goal_run_id: None,
+            target_uri: None,
+            dry_run: false,
+            budget: None,
+        };
+
+        let result = handle_external_action(&state, params).unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+        let text = serde_json::to_string(&result.content[0]).unwrap();
+        assert!(
+            text.contains("executed") && !text.contains("captured_for_review"),
+            "expected executed outcome: {}",
+            text
+        );
+        assert!(
+            text.contains("filled"),
+            "expected the plugin's real execute() result: {}",
+            text
+        );
+    }
+
+    #[test]
+    fn adapter_plugin_high_risk_trade_is_captured_for_review_not_executed() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".ta")).unwrap();
+        std::fs::write(
+            dir.path().join(".ta").join("workflow.toml"),
+            b"[actions.\"trade.execute\"]\npolicy = \"auto\"\n",
+        )
+        .unwrap();
+        write_paper_trading_plugin(dir.path());
+        write_routing_decision(dir.path(), "auto");
+
+        let state = make_state(dir.path());
+        let params = ExternalActionParams {
+            action_type: "trade.execute".into(),
+            // amount=1000 -> risk_score=100, well over max_risk_score=40
+            // and escalate_risk_score=75 -> Escalate, never executed.
+            payload: json!({"symbol": "ACME", "amount": 1000}),
+            goal_run_id: None,
+            target_uri: None,
+            dry_run: false,
+            budget: None,
+        };
+
+        let result = handle_external_action(&state, params).unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+        let text = serde_json::to_string(&result.content[0]).unwrap();
+        assert!(
+            text.contains("captured_for_review"),
+            "expected captured_for_review outcome, not an executed trade: {}",
+            text
+        );
+        assert!(
+            !text.contains("filled"),
+            "the risky trade must not have actually executed: {}",
+            text
+        );
+    }
+
+    #[test]
+    fn unregistered_verb_returns_clear_no_adapter_error() {
+        let dir = tempdir().unwrap();
+        let state = make_state(dir.path());
+
+        let params = ExternalActionParams {
+            action_type: "trade.execute".into(),
+            payload: json!({"symbol": "ACME", "amount": 100}),
+            goal_run_id: None,
+            target_uri: None,
+            dry_run: false,
+            budget: None,
+        };
+
+        // No plugin registered under .ta/plugins/adapter/ -- must be a
+        // clear, actionable error, not a silent no-op.
+        let err = handle_external_action(&state, params).unwrap_err();
+        let message = err.message.to_string();
+        assert!(
+            message.contains("no adapter registered for this verb"),
+            "expected a clear 'no adapter registered' error, got: {}",
+            message
         );
     }
 }

--- a/crates/ta-mcp-gateway/src/tools/action.rs
+++ b/crates/ta-mcp-gateway/src/tools/action.rs
@@ -1035,13 +1035,28 @@ else:
 "#,
         )
         .unwrap();
+        // Serialize via toml::Table rather than hand-formatting the string:
+        // `script_path.display()` on Windows renders backslashes
+        // (`C:\Users\...`), and TOML string literals treat `\` as an
+        // escape-sequence introducer — `format!`-ing it in raw produced
+        // "invalid unicode 8-digit hex code" parse errors in Windows CI.
+        // toml::Table's Serialize impl escapes the path correctly for
+        // every platform.
+        let mut manifest = toml::Table::new();
+        manifest.insert("name".into(), "paper-trading".into());
+        manifest.insert("type".into(), "adapter".into());
+        manifest.insert("command".into(), "python3".into());
+        manifest.insert(
+            "args".into(),
+            toml::Value::Array(vec![script_path.to_string_lossy().to_string().into()]),
+        );
+        manifest.insert(
+            "capabilities".into(),
+            toml::Value::Array(vec!["verb:trade.execute".into()]),
+        );
         std::fs::write(
             plugin_dir.join("plugin.toml"),
-            format!(
-                "name = \"paper-trading\"\ntype = \"adapter\"\ncommand = \"python3\"\n\
-                 args = [\"{}\"]\ncapabilities = [\"verb:trade.execute\"]\n",
-                script_path.display()
-            ),
+            toml::to_string_pretty(&manifest).unwrap(),
         )
         .unwrap();
     }

--- a/crates/ta-mcp-gateway/src/tools/human_verify.rs
+++ b/crates/ta-mcp-gateway/src/tools/human_verify.rs
@@ -535,7 +535,7 @@ pub(crate) fn load_thresholds(workspace_root: &Path, workload_type: &str) -> Dec
 /// `("general", Suggest)` when no routing decision has ever been logged —
 /// deliberately *not* `Auto`, so an unclassified workload never silently
 /// gets the auto-confirm fast path.
-fn resolve_workload_context(workspace_root: &Path) -> (String, AdvisorSecurity) {
+pub(crate) fn resolve_workload_context(workspace_root: &Path) -> (String, AdvisorSecurity) {
     #[derive(Deserialize)]
     struct LoggedDecision {
         workload_type: String,
@@ -844,7 +844,7 @@ fn handle_human_verify_with_pipeline(
 /// check and `unity.rs`'s path-component validator — reused here rather
 /// than reinvented, adapted to allow the legitimate multi-segment relative
 /// paths this parameter needs (e.g. `.ta/team-sessions/<id>/budget-ledger.jsonl`).
-fn validate_ledger_path(path: &str) -> Result<(), McpError> {
+pub(crate) fn validate_ledger_path(path: &str) -> Result<(), McpError> {
     // `Path::is_absolute()` alone isn't platform-parity-safe here: a
     // Unix-style absolute path like "/etc/evil.jsonl" has no drive letter,
     // so on Windows `is_absolute()` returns false for it (it reads as

--- a/crates/ta-mediation/Cargo.toml
+++ b/crates/ta-mediation/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates for FsMediator
-ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-release/Cargo.toml
+++ b/crates/ta-release/Cargo.toml
@@ -18,7 +18,7 @@ toml = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true, features = ["multipart"] }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.2" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-runtime/Cargo.toml
+++ b/crates/ta-runtime/Cargo.toml
@@ -23,8 +23,8 @@ which = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
 
-ta-credentials = { path = "../ta-credentials", version = "0.17.5-alpha.2" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.2" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.5-alpha.3" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.3" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }
-ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.2" }
+ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-session/Cargo.toml
+++ b/crates/ta-session/Cargo.toml
@@ -25,9 +25,9 @@ notify = { workspace = true }
 toml = { workspace = true }
 
 # Workspace crates
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
-ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
+ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -16,11 +16,11 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.2" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.2" }
-ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.3" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.3" }
+ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.3" }
 toml = "0.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/ta-workflow/Cargo.toml
+++ b/crates/ta-workflow/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -21,8 +21,8 @@ reqwest = { workspace = true }
 anyhow = { workspace = true }
 sha2 = "0.10"
 base64 = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: 0.17.5-alpha.2
+**Version**: 0.17.5-alpha.3
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 
@@ -10019,6 +10019,7 @@ This section covers the **Plugin** category, unified onto one shared transport/m
 | `tool` | `.ta/plugins/tool/<name>/` | (community-defined; see `plugins/tool/*/plugin.toml` for examples) |
 | `db` | `.ta/plugins/db/<name>/` | (community-defined DB proxy adapter) |
 | `release` | `.ta/plugins/release/<name>/` | (community-defined release adapter) |
+| `adapter` | `.ta/plugins/adapter/<name>/` | `plugins/adapter/paper-trading/paper_trading_adapter.py` |
 
 **Discovery order:** project-local (`.ta/plugins/<kind>/<name>/plugin.toml`) is checked first, then user-global (`~/.config/ta/plugins/<kind>/<name>/plugin.toml`).
 
@@ -10083,6 +10084,45 @@ For `db`-kind plugins specifically — the full method list (`start_capture`/`st
 change-capture lifecycle, `apply_mutation` replay), the `db-overlay.jsonl` wire shape, and the
 network-policy/credential-vault guarantee a plugin author relies on — see
 [`docs/community-db-plugin.md`](community-db-plugin.md) and [Database Proxy](#database-proxy).
+
+**Domain-Action Adapters (`adapter` kind, v0.17.5.3).** Any external side effect an agent
+wants to take that isn't already one of the four built-in `ta_external_action` types
+(`email`/`social_post`/`api_call`/`db_query`) — placing a trade, filing a support ticket,
+triggering a CI pipeline, anything — is a user-authored `adapter`-kind plugin, not a TA core
+change. A plugin declares the verb(s) it handles as `capabilities` entries prefixed `verb:`
+(e.g. `capabilities = ["verb:trade.execute"]`), and implements two methods over the same
+canonical envelope every other Plugin-category kind uses:
+
+```toml
+# .ta/plugins/adapter/paper-trading/plugin.toml
+name = "paper-trading"
+type = "adapter"
+command = "python3"
+args = ["paper_trading_adapter.py"]
+capabilities = ["verb:trade.execute"]
+```
+
+```
+→ {"method":"risk_score","params":{"verb":"trade.execute","payload":{"symbol":"ACME","amount":500}}}
+← {"ok":true,"result":{"risk_score":25,"confidence":0.9}}
+
+→ {"method":"execute","params":{"verb":"trade.execute","payload":{"symbol":"ACME","amount":500}}}
+← {"ok":true,"result":{"status":"filled", ...}}
+```
+
+An agent calls `ta_external_action` with `action_type: "trade.execute"` exactly as it would
+for a built-in type; TA scores the trade's real, plugin-computed risk (never a hardcoded `0`),
+runs it through the same `ta_decision::gate::decide()` used by `ta_human_verify` and code
+drafts, consults the calling goal's `security_tier`, and checks any declared budget guardrail
+— only committing to the plugin's `execute` method when every gate passes. Anything else is
+captured for human review, never silently dropped. Calling `ta_external_action` with a verb no
+plugin has registered returns a clear "no adapter registered for this verb" error.
+
+See [`docs/community-adapter-plugin.md`](community-adapter-plugin.md) for the full authoring
+guide (the wire protocol in detail, the gating pipeline, and how to test a new adapter without
+a live external dependency) and `templates/workflows/trading-desk.yaml` for a worked
+end-to-end reference (an analyst/strategist/trader persistent team session dispatching through
+the shipped `plugins/adapter/paper-trading/` mock adapter).
 
 #### Channel Access Control
 

--- a/docs/community-adapter-plugin.md
+++ b/docs/community-adapter-plugin.md
@@ -1,0 +1,148 @@
+# Building a Trusted Autonomy Domain-Action Adapter Plugin
+
+This guide explains how to make a new external side effect available to agents via
+`ta_external_action` (v0.17.5.3) — placing a trade, filing a support ticket, triggering a CI
+pipeline, anything an agent might need to do outside TA itself. Today `ta_external_action`
+ships four built-in stub types (`email`, `social_post`, `api_call`, `db_query`) that only
+validate payloads — they don't perform real I/O. A domain-action adapter plugin is how you (or
+a community author) add a new, *real*, executable action type without a TA core change or
+recompile: an external executable plus a `plugin.toml` manifest, dropped into
+`.ta/plugins/adapter/<name>/`.
+
+This is the **Plugin** category from `docs/USAGE.md` → "Authoring a Plugin" — call/response
+over newline-delimited JSON on stdin/stdout, discovered by convention, same shared
+`ta-plugin` transport/manifest/discovery crate every other kind (VCS, release, db, ...) uses.
+If you haven't read that section yet, start there for the general manifest schema; this doc
+covers only what's specific to `adapter`-kind plugins.
+
+## Why a plugin, not a TA core action type
+
+`email`/`social_post`/`api_call`/`db_query` are built into `ta-actions` because they're
+close to universal — nearly every project eventually wants one of them. A brokerage trade,
+a support-desk ticket, a game-build trigger — these are project-specific, and often need a
+proprietary SDK or credential TA's own binary has no business bundling. Pushing them out to a
+plugin means your integration ships and iterates on its own schedule, independent of TA's
+release cadence — the same reasoning `docs/community-release-plugin.md` gives for Steam/App
+Store release adapters, applied to the action-dispatch side instead of the release side.
+
+## Declaring the verb(s) you handle
+
+Unlike other Plugin-category kinds, `adapter` plugins don't get a fixed set of methods per
+verb — one plugin can handle several verbs (`"trade.execute"`, `"trade.cancel"`, ...), and
+new verbs never require a TA core change. Declare each one as a `capabilities` entry prefixed
+`verb:` — the same prefix-convention idiom the `release` kind already uses for
+`"channel:<name>"` custom channel declarations:
+
+```toml
+capabilities = ["verb:trade.execute", "verb:trade.cancel"]
+```
+
+`ta_external_action` discovers every `verb:`-prefixed capability across every registered
+adapter plugin and adds it to the registry alongside the four built-in types — call
+`ta_external_action` with `action_type: "trade.execute"` and TA routes it to your plugin
+exactly like it would route `action_type: "email"` to the built-in email stub. Discovery only
+reads `plugin.toml` files; it never spawns your process just to build the list of registered
+verbs, so an unrelated `ta_external_action` call (e.g. `action_type: "email"`) never pays your
+plugin's startup cost.
+
+## The two methods, over the wire
+
+Your plugin's `plugin.toml` has `type = "adapter"`. Every call is one `{"method","params"}`
+JSON line in, one `{"ok":true,"result":{...}}` or `{"ok":false,"error":"..."}` JSON line out —
+fresh process per call, no persistent handshake required (unlike `release`/`vcs` plugins,
+`adapter` plugins are called directly; a malformed or unimplemented method simply returns a
+clear `{"ok":false,"error":...}`, which surfaces to the caller as an actionable error).
+
+| Method | Required? | Params | Result |
+|---|---|---|---|
+| `risk_score` | Yes | `{"verb": "<verb>", "payload": {...}}` | `{"risk_score": 0-100, "confidence": 0.0-1.0}` |
+| `execute` | Yes | `{"verb": "<verb>", "payload": {...}}` | Arbitrary JSON — whatever your action's real outcome looks like |
+
+Both methods receive the same `verb`/`payload` shape — `verb` tells you which of your
+declared verbs this call is for (useful if one plugin handles several), `payload` is exactly
+what the agent passed to `ta_external_action`'s `payload` field.
+
+### `risk_score`
+
+```
+→ {"method":"risk_score","params":{"verb":"trade.execute","payload":{"symbol":"ACME","amount":500}}}
+← {"ok":true,"result":{"risk_score":25,"confidence":0.9}}
+```
+
+This is the method that makes the score *real*. Compute it from the actual payload — trade
+notional size, ticket severity, blast radius, whatever "risk" means for your domain — never
+return a hardcoded value. (`ta-submit::social_adapter.rs`'s `publish()` hardcodes `risk_score:
+0` today; that's the anti-pattern this framework exists to avoid for new adapters.)
+`risk_score` (0-100, higher is riskier) and `confidence` (0.0-1.0, how much you trust your own
+score) feed directly into `ta_decision::gate::decide()` — the same gate `ta_human_verify` and
+code-draft approval use — so a well-calibrated score is what actually lets safe actions
+auto-execute and risky ones get held for a human.
+
+### `execute`
+
+```
+→ {"method":"execute","params":{"verb":"trade.execute","payload":{"symbol":"ACME","side":"buy","amount":500}}}
+← {"ok":true,"result":{"status":"filled","symbol":"ACME","fill_price":18.0,"quantity":27.7778}}
+```
+
+Only called after the gate below has already decided to commit — your `execute` method never
+needs to re-check risk itself, and never needs to implement a review/hold path; TA already did
+that before calling you. `result` is returned to the agent verbatim as `ActionOutcome::Executed
+{ result }`.
+
+## The gating pipeline your plugin participates in
+
+`ta_external_action` doesn't call your `execute` method directly off the back of
+`risk_score` — it runs the full v0.17.5.3 approval pipeline first:
+
+1. **Budget guardrail** (if the caller supplied one) — a hard per-action or total-budget limit
+   rejects the action before your `risk_score` method is even called; a soft threshold crossing
+   forces the eventual decision to `Escalate` regardless of what your score says.
+2. **Risk gate** — your `risk_score` result becomes a `ta_decision::DecisionInput` (with
+   `verdict: Pass`), scored against `DecisionThresholds` (configurable per-verb in
+   `.ta/workflow.toml`'s `[human_verify.<verb>]` table, the same config surface
+   `ta_human_verify` uses) via the shared `decide()` gate — one uniform `Commit`/`Reject`/
+   `Rework`/`Escalate` contract, regardless of domain.
+3. **Security tier** — the calling goal's `security_tier` (resolved from the most recent
+   `ta-brain::RoutingDecision`) can only *downgrade* a `Commit` to `Escalate`, never upgrade a
+   worse verdict. An inferred or non-autonomous workload never gets to auto-execute your
+   action, no matter how low-risk your plugin scored it.
+4. Only a surviving `Commit` calls your `execute` method. Everything else is captured for
+   human review — it appears in `ta draft view` under Pending Actions, with the gate's
+   decision and your risk score attached, never silently dropped.
+
+You don't implement any of this — it's the same pipeline for every registered verb from every
+plugin. Your job is just an honest `risk_score` and a correct `execute`.
+
+## Registering your plugin
+
+Drop `plugin.toml` + your executable into `.ta/plugins/adapter/<name>/` (project-local) or
+`~/.config/ta/plugins/adapter/<name>/` (user-global):
+
+```toml
+# .ta/plugins/adapter/paper-trading/plugin.toml
+name = "paper-trading"
+version = "0.1.0"
+type = "adapter"
+command = "python3"
+args = ["paper_trading_adapter.py"]
+capabilities = ["verb:trade.execute"]
+description = "Paper-trading only, no live brokerage API"
+timeout_secs = 30
+```
+
+Call `ta_external_action` with `action_type: "trade.execute"` and TA finds your plugin. An
+unregistered verb — no plugin declares a matching `verb:` capability — returns a clear
+`unknown action type '...' — no adapter registered for this verb` error, never a silent no-op.
+
+## Testing without a live external dependency
+
+You don't need a real brokerage/ticketing/CI API to validate the protocol contract or exercise
+the gating pipeline. `plugins/adapter/paper-trading/` in this repo is TA's own reference
+implementation — a small Python script that computes a real (non-hardcoded) risk score from
+trade notional size and simulates a fill, no network call anywhere. It's what
+`templates/workflows/trading-desk.yaml`'s analyst/strategist/trader persistent team session
+(v0.17.5.1) dispatches to, and what TA's own test suite (`crates/ta-actions/src/plugin_action.rs`,
+`crates/ta-mcp-gateway/src/tools/action.rs`) round-trips through both the auto-execute and
+captured-for-review paths. Copy its shape — read one JSON line, dispatch on `method`, write one
+JSON line back — as the starting point for your own adapter before wiring up a real API.

--- a/plugins/adapter/paper-trading/paper_trading_adapter.py
+++ b/plugins/adapter/paper-trading/paper_trading_adapter.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Reference domain-action adapter for TA v0.17.5.3 -- paper trading only.
+
+Handles the "trade.execute" verb declared in this directory's plugin.toml
+(`capabilities = ["verb:trade.execute"]`). No live brokerage API is called
+anywhere in this file -- every "execute" is a simulated fill, and every
+"risk_score" is computed from the request payload alone. This is what makes
+it safe to use as TA's own reference implementation and test fixture (see
+PLAN.md v0.17.5.3 item 5: "no live external API dependency in TA's own test
+suite").
+
+Wire protocol (one JSON line in on stdin, one JSON line out on stdout, per
+`ta_plugin::envelope`/`ta_plugin::transport::call_json` -- the same
+transport VCS and release plugins use):
+
+    in:  {"method": "risk_score", "params": {"verb": "trade.execute", "payload": {...}}}
+    out: {"ok": true, "result": {"risk_score": <0-100>, "confidence": <0.0-1.0>}}
+
+    in:  {"method": "execute", "params": {"verb": "trade.execute", "payload": {...}}}
+    out: {"ok": true, "result": {"status": "filled", ...}}
+
+`payload` fields: `symbol` (str), `side` ("buy"|"sell"), `amount` (usd,
+float). A missing/invalid `amount` is treated as a validation failure,
+returned as `{"ok": false, "error": ...}` -- never a silent default.
+"""
+import json
+import sys
+
+# Above this notional size a trade is scored maximally risky (100) --
+# deliberately a real, tunable formula, not the hardcoded `0` the social
+# adapter uses today (see ta-submit::social_adapter.rs::publish).
+MAX_RISK_NOTIONAL_USD = 2000.0
+
+# A mock adapter still has a bounded confidence in its own risk model --
+# never the same as a validator's self-reported certainty about a specific
+# trade's outcome, so it is fixed rather than derived.
+RISK_MODEL_CONFIDENCE = 0.9
+
+
+def compute_risk_score(payload):
+    amount = payload.get("amount")
+    if not isinstance(amount, (int, float)) or amount < 0:
+        raise ValueError(f"payload.amount must be a non-negative number, got {amount!r}")
+    symbol = payload.get("symbol", "")
+
+    notional_risk = min(100, round(100 * amount / MAX_RISK_NOTIONAL_USD))
+    # A very short ticker reads as a thinly-traded / speculative symbol in
+    # this mock model -- a small, explainable bump, not a hardcoded value.
+    illiquidity_bump = 10 if len(symbol) <= 2 else 0
+    return min(100, notional_risk + illiquidity_bump)
+
+
+def simulate_fill(payload):
+    symbol = payload.get("symbol", "UNKNOWN")
+    side = payload.get("side", "buy")
+    amount = payload.get("amount")
+    if not isinstance(amount, (int, float)) or amount < 0:
+        raise ValueError(f"payload.amount must be a non-negative number, got {amount!r}")
+
+    # Deterministic pseudo-price so repeated calls with the same symbol are
+    # reproducible in tests -- not a real market quote.
+    pseudo_price = 10.0 + (sum(ord(c) for c in symbol) % 90)
+    quantity = round(amount / pseudo_price, 4) if pseudo_price else 0.0
+
+    return {
+        "status": "filled",
+        "symbol": symbol,
+        "side": side,
+        "amount": amount,
+        "fill_price": pseudo_price,
+        "quantity": quantity,
+        "venue": "paper-trading-mock",
+    }
+
+
+def main():
+    line = sys.stdin.readline()
+    if not line.strip():
+        print(json.dumps({"ok": False, "error": "no request line on stdin"}))
+        return
+
+    try:
+        request = json.loads(line)
+        method = request["method"]
+        params = request.get("params", {})
+        payload = params.get("payload", {})
+    except (json.JSONDecodeError, KeyError) as e:
+        print(json.dumps({"ok": False, "error": f"malformed request: {e}"}))
+        return
+
+    try:
+        if method == "risk_score":
+            result = {
+                "risk_score": compute_risk_score(payload),
+                "confidence": RISK_MODEL_CONFIDENCE,
+            }
+        elif method == "execute":
+            result = simulate_fill(payload)
+        else:
+            print(json.dumps({"ok": False, "error": f"unknown method '{method}'"}))
+            return
+        print(json.dumps({"ok": True, "result": result}))
+    except ValueError as e:
+        print(json.dumps({"ok": False, "error": str(e)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/adapter/paper-trading/plugin.toml
+++ b/plugins/adapter/paper-trading/plugin.toml
@@ -1,0 +1,8 @@
+name = "paper-trading"
+version = "0.1.0"
+type = "adapter"
+command = "python3"
+args = ["paper_trading_adapter.py"]
+capabilities = ["verb:trade.execute"]
+description = "Reference domain-action adapter (v0.17.5.3) — paper-trading only, no live brokerage API. Computes a real risk score from trade notional size and simulates a fill; pairs with templates/workflows/trading-desk.yaml."
+timeout_secs = 30

--- a/templates/workflows/trading-desk.yaml
+++ b/templates/workflows/trading-desk.yaml
@@ -1,0 +1,85 @@
+# trading-desk.yaml — Reference persistent team session (v0.17.5.3).
+#
+# Proves the full pluggable-domain-action-adapter loop end-to-end: an
+# analyst/strategist/trader role chain (v0.17.5.1's persistent team-session
+# runtime) where the trader role calls `ta_external_action` with
+# action_type="trade.execute" — a verb handled entirely by the mock
+# `paper-trading` adapter plugin (`plugins/adapter/paper-trading/`,
+# installed at `.ta/plugins/adapter/paper-trading/` for this project), not a
+# live brokerage integration. Every trade is gated by the same
+# risk-score/security_tier/budget pipeline `ta_human_verify` uses.
+#
+# Usage:
+#   ta team-session start trading-desk \
+#     --workflow templates/workflows/trading-desk.yaml \
+#     --objective "Generate income > 2x within 6 months after fees"
+#
+# See docs/community-adapter-plugin.md for how to author your own domain
+# adapter, and docs/USAGE.md's "Domain-Action Adapters" section for the
+# `ta_external_action` gating pipeline this workflow exercises.
+
+name: trading-desk
+
+stages:
+  - name: analyze
+    roles: [analyst]
+    await_human: never
+
+  - name: decide
+    depends_on: [analyze]
+    roles: [strategist]
+    await_human: never
+
+  - name: execute
+    depends_on: [decide]
+    roles: [trader]
+    await_human: never
+
+roles:
+  analyst:
+    agent: claude-code
+    prompt: |
+      You are a market analyst. Review the session objective and current
+      market data available to you, then produce a short written analysis
+      of candidate trade opportunities with your reasoning. You never place
+      trades yourself — that is the trader role's job, two stages later.
+
+  strategist:
+    agent: claude-code
+    prompt: |
+      You are a trading strategist. Given the analyst's findings, decide
+      which candidate trades (if any) are worth acting on this cycle, and
+      size each one (symbol, side, dollar amount). Write your decision for
+      the trader role to execute. You never place trades yourself.
+
+  trader:
+    agent: claude-code
+    prompt: |
+      You are a trader. For each trade the strategist decided on, call the
+      `ta_external_action` MCP tool with:
+
+        action_type: "trade.execute"
+        payload: {"symbol": <symbol>, "side": <"buy"|"sell">, "amount": <usd>}
+        budget: {
+          guardrails: {metric: "usd", total: <session total>, ...},
+          action_amount: <usd>,
+          ledger_path: ".ta/team-sessions/trading-desk/budget-ledger.jsonl",
+          action_label: "<symbol> <side> <usd>"
+        }
+
+      TA scores the trade's real risk (via the paper-trading adapter's
+      risk_score method), checks it against the session's budget guardrail,
+      and only auto-executes when both the risk gate and your session's
+      security_tier allow it. A trade TA declines to auto-execute is
+      captured for human review instead — it is never silently dropped.
+      Never attempt to bypass this by calling a brokerage API directly.
+
+# Business-metric budget guardrail (v0.17.5.2) — enforced on every
+# `ta_external_action` call the trader role makes that supplies a
+# `budget` block referencing this session's ledger.
+budget:
+  metric: usd
+  total: 1000.0
+  per_action_max_pct: 10.0
+  soft_threshold_pct: 80.0
+  objective: "Generate income > 2x within 6 months after fees"


### PR DESCRIPTION
## Summary
Makes domain actions genuinely user-authorable without a TA core code change, closing the gap where every existing connector (Slack/Discord/email/social) is built into `ta-daemon` and the one generic hook meant for this (`StepAction::external_adapter()`) has zero production callers.

- New `ta-actions::plugin_action` module: `AdapterPluginAction` (implements `ExternalAction` over a subprocess via the same transport VCS/release plugins already use) and `discover_adapter_actions()` (scans `.ta/plugins/adapter/<name>/plugin.toml`, reading `verb:`-prefixed capabilities — same prefix-convention idiom as release adapters' `channel:<name>`, no new manifest field needed).
- Wired into the real, already-production-connected `ta_external_action` / `ActionRegistry` — **not** the disconnected `StepAction::external_adapter()`/`step_executor.rs` the plan text originally named (investigated and confirmed zero callers anywhere; wiring only that would have built a second unreachable island). This is the registry's first real production caller of a plugin-backed action.
- `dispatch_auto_action()`: budget hard/soft check (reusing v0.17.5.2's `business_budget`) runs before risk scoring; a plugin-computed risk score (never hardcoded `0`) is scored via the same `ta_decision::gate::decide()` used elsewhere; `security_tier` only ever downgrades a `Commit` to `Escalate`, never upgrades autonomy. Reuses `ta_human_verify`'s `validate_ledger_path`/`resolve_workload_context`/`load_thresholds` rather than duplicating security-sensitive logic.
- Reference implementation: `plugins/adapter/paper-trading/` (Python, no live brokerage API — real risk scoring, deterministic simulated fills) paired with `templates/workflows/trading-desk.yaml`, proving the full loop end-to-end.
- `docs/community-adapter-plugin.md`: adapter-plugin authoring guide.

## Review
Reviewed thoroughly (dispatch/gating logic, plugin subprocess transport, reference Python script for injection/safety) — no additional issues found this time.

## Test plan
- All tests passing, full workspace `build`/`test`/`clippy`/`fmt` clean