### PR TITLE
Implement v0.17.6.1 — Enforce Declared Credential Scopes + Real Swarm Handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All outcomes must be **observable** (with details and logging) and **actionable*
 
 ## Current State
 
-**Current version**: `0.17.5-alpha.3`
+**Current version**: `0.17.6-alpha.1`
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --phase 4b`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "ta-actions"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "ta-advisor"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "ta-agent-ollama"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3368,7 +3368,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "base64",
  "chrono",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "ta-brain"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "schemars",
@@ -3404,7 +3404,7 @@ dependencies = [
 
 [[package]]
 name = "ta-build"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-comfyui"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unity"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unreal"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "ta-data-spec"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "schemars",
  "serde_json",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-overlay"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3714,7 +3714,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-proxy"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3732,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "ta-decision"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "ta-extension"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "ta-governed-paths"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "ta-init"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "ta-intake"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "regex",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "regex",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "glob",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "ta-output-schema"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "ta-plugin"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "libc",
  "serde",
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "glob",
@@ -3950,7 +3950,7 @@ dependencies = [
 
 [[package]]
 name = "ta-release"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "base64",
  "reqwest",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "ta-runtime"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "libc",
@@ -4021,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "chrono",
  "libc",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4060,7 +4060,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.17.5-alpha.3"
+version = "0.17.6-alpha.1"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -10080,17 +10080,17 @@ Code releases use semver. Content releases don't. Decide:
 
 ---
 ### v0.17.6.1 — Enforce Declared Credential Scopes + Real Swarm Handoff
-<!-- status: in_progress -->
+<!-- status: done -->
 **Depends on**: v0.17.6
 
 **Goal**: Close the two loudest, cheapest-to-fix gaps first: `ScopedCredential.scopes` is declared but never checked anywhere, and `run_one_swarm_sub_goal` hands every sub-goal a full-environment clone of the parent with no narrowing. No new crates, no new token format yet — this stage is pure enforcement of concepts that already exist in the type system.
 
 **Items**:
-1. [ ] `apply_credentials_to_env` (`crates/ta-runtime/src/bare_process.rs`) gains a required-scope input and filters `ScopedCredential`s by `.scopes`/`security_tier` before injecting — today it takes a credential list with nothing to compare scopes against; this is new plumbing, not a conditional bolted onto the existing loop.
-2. [ ] `run_one_swarm_sub_goal` (`apps/ta-cli/src/commands/run.rs`) gets `cmd.env_clear()` plus explicit re-injection of a non-secret baseline (`PATH`, `HOME`, etc.) and an intersected credential/scope set for the sub-goal.
-3. [ ] **The real fix, not just the wrapper**: `run_one_swarm_sub_goal` spawns a *nested `ta run` CLI respawn*, which independently resolves its own credentials deep inside the child process. `.env_clear()` alone doesn't narrow what that child resolves from `.ta/credentials.json`. Add an explicit scope handoff into the recursive `ta run` invocation (new CLI flag or env var carrying the intersected scope set) so the child's own credential resolution actually respects the narrower scope.
-4. [ ] Tests: a sub-goal's spawned process environment contains only the intersected credential set, not the parent's full environment; a credential whose scope excludes the sub-goal's declared need is absent from its env entirely; the nested `ta run` child genuinely resolves the narrowed scope, not just the outer wrapper's env.
-5. [ ] USAGE.md: note that swarm sub-goals now receive scope-narrowed credentials, not full inheritance.
+1. [x] `apply_credentials_to_env` (`crates/ta-runtime/src/bare_process.rs`) gains a required-scope input and filters `ScopedCredential`s by `.scopes`/`security_tier` before injecting — today it takes a credential list with nothing to compare scopes against; this is new plumbing, not a conditional bolted onto the existing loop.
+2. [x] `run_one_swarm_sub_goal` (`apps/ta-cli/src/commands/run.rs`) gets `cmd.env_clear()` plus explicit re-injection of a non-secret baseline (`PATH`, `HOME`, etc.) and an intersected credential/scope set for the sub-goal.
+3. [x] **The real fix, not just the wrapper**: `run_one_swarm_sub_goal` spawns a *nested `ta run` CLI respawn*, which independently resolves its own credentials deep inside the child process. `.env_clear()` alone doesn't narrow what that child resolves from `.ta/credentials.json`. Add an explicit scope handoff into the recursive `ta run` invocation (new CLI flag or env var carrying the intersected scope set) so the child's own credential resolution actually respects the narrower scope.
+4. [x] Tests: a sub-goal's spawned process environment contains only the intersected credential set, not the parent's full environment; a credential whose scope excludes the sub-goal's declared need is absent from its env entirely; the nested `ta run` child genuinely resolves the narrowed scope, not just the outer wrapper's env.
+5. [x] USAGE.md: note that swarm sub-goals now receive scope-narrowed credentials, not full inheritance.
 
 #### Version: `0.17.6-alpha.1`
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -43,34 +43,34 @@ which = { workspace = true }
 arboard = { workspace = true }
 
 # Internal crates — version kept in sync with workspace by bump-version.sh
-ta-audit = { path = "../../crates/ta-audit", version = "0.17.5-alpha.3" }
-ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.5-alpha.3" }
-ta-memory = { path = "../../crates/ta-memory", version = "0.17.5-alpha.3" }
-ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.5-alpha.3" }
-ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.5-alpha.3" }
-ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.5-alpha.3" }
-ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.5-alpha.3" }
-ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.5-alpha.3" }
-ta-goal = { path = "../../crates/ta-goal", version = "0.17.5-alpha.3" }
-ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.5-alpha.3" }
-ta-policy = { path = "../../crates/ta-policy", version = "0.17.5-alpha.3" }
-ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.5-alpha.3" }
-ta-session = { path = "../../crates/ta-session", version = "0.17.5-alpha.3" }
-ta-events = { path = "../../crates/ta-events", version = "0.17.5-alpha.3" }
-ta-submit = { path = "../../crates/ta-submit", version = "0.17.5-alpha.3" }
-ta-decision = { path = "../../crates/ta-decision", version = "0.17.5-alpha.3" }
-ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.5-alpha.3" }
-ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.5-alpha.3" }
-ta-build = { path = "../../crates/ta-build", version = "0.17.5-alpha.3" }
-ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.5-alpha.3" }
-ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.5-alpha.3" }
-ta-init = { path = "../../crates/ta-init", version = "0.17.5-alpha.3" }
-ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.5-alpha.3" }
-ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.5-alpha.3" }
-ta-intake = { path = "../../crates/ta-intake", version = "0.17.5-alpha.3" }
-ta-brain = { path = "../../crates/ta-brain", version = "0.17.5-alpha.3" }
-ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.5-alpha.3" }
-ta-release = { path = "../../crates/ta-release", version = "0.17.5-alpha.3" }
+ta-audit = { path = "../../crates/ta-audit", version = "0.17.6-alpha.1" }
+ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.6-alpha.1" }
+ta-memory = { path = "../../crates/ta-memory", version = "0.17.6-alpha.1" }
+ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.6-alpha.1" }
+ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.6-alpha.1" }
+ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.6-alpha.1" }
+ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.6-alpha.1" }
+ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.6-alpha.1" }
+ta-goal = { path = "../../crates/ta-goal", version = "0.17.6-alpha.1" }
+ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.6-alpha.1" }
+ta-policy = { path = "../../crates/ta-policy", version = "0.17.6-alpha.1" }
+ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.6-alpha.1" }
+ta-session = { path = "../../crates/ta-session", version = "0.17.6-alpha.1" }
+ta-events = { path = "../../crates/ta-events", version = "0.17.6-alpha.1" }
+ta-submit = { path = "../../crates/ta-submit", version = "0.17.6-alpha.1" }
+ta-decision = { path = "../../crates/ta-decision", version = "0.17.6-alpha.1" }
+ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.6-alpha.1" }
+ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.6-alpha.1" }
+ta-build = { path = "../../crates/ta-build", version = "0.17.6-alpha.1" }
+ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.6-alpha.1" }
+ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.6-alpha.1" }
+ta-init = { path = "../../crates/ta-init", version = "0.17.6-alpha.1" }
+ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.6-alpha.1" }
+ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.6-alpha.1" }
+ta-intake = { path = "../../crates/ta-intake", version = "0.17.6-alpha.1" }
+ta-brain = { path = "../../crates/ta-brain", version = "0.17.6-alpha.1" }
+ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.6-alpha.1" }
+ta-release = { path = "../../crates/ta-release", version = "0.17.6-alpha.1" }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/apps/ta-cli/src/commands/constitution.rs
+++ b/apps/ta-cli/src/commands/constitution.rs
@@ -238,6 +238,7 @@ fn run_init(
         None,             // workflow = default (single-agent)
         None,             // persona_name = None
         None,             // context_path = None
+        None,             // credential_scopes = None (v0.17.6.1)
     )?;
 
     println!();

--- a/apps/ta-cli/src/commands/draft.rs
+++ b/apps/ta-cli/src/commands/draft.rs
@@ -9352,6 +9352,7 @@ fn fix_package(
         None,  // workflow = default (single-agent)
         None,  // persona_name = None
         None,  // context_path = None
+        None,  // credential_scopes = None (v0.17.6.1)
     )?;
 
     if no_launch {

--- a/apps/ta-cli/src/commands/new.rs
+++ b/apps/ta-cli/src/commands/new.rs
@@ -896,6 +896,7 @@ fn run_new(
         None,  // workflow = default (single-agent)
         None,  // persona_name = None
         None,  // context_path = None
+        None,  // credential_scopes = None (v0.17.6.1)
     )?;
 
     // 12. Post-creation handoff.

--- a/apps/ta-cli/src/commands/plan.rs
+++ b/apps/ta-cli/src/commands/plan.rs
@@ -3345,6 +3345,7 @@ fn plan_add(
         None,  // workflow = default (single-agent)
         None,  // persona_name = None
         None,  // context_path = None
+        None,  // credential_scopes = None (v0.17.6.1)
     )
 }
 
@@ -3599,6 +3600,7 @@ fn plan_from(
         None,  // workflow = default (single-agent)
         None,  // persona_name = None
         None,  // context_path = None
+        None,  // credential_scopes = None (v0.17.6.1)
     )
 }
 
@@ -3710,6 +3712,7 @@ fn plan_new(
         None,  // workflow
         None,  // persona_name
         None,  // context_path = None
+        None,  // credential_scopes = None (v0.17.6.1)
     )
 }
 
@@ -6262,6 +6265,7 @@ fn plan_build(
             None,  // workflow
             None,  // persona_name
             None,  // context_path = None
+            None,  // credential_scopes = None (v0.17.6.1)
         )?;
 
         phases_built += 1;
@@ -7019,6 +7023,7 @@ fn plan_build_autonomous(
                     None,
                     None,
                     None,
+                    None, // credential_scopes = None (v0.17.6.1)
                 ) {
                     let msg = format!("Goal launch failed for phase {}: {}", phase_id, e);
                     eprintln!("[escalate] {}", msg);
@@ -9014,6 +9019,7 @@ fn plan_pragma(config: &GatewayConfig, no_scan: bool) -> anyhow::Result<()> {
                     None,
                     None,
                     None, // context_path = None
+                    None, // credential_scopes = None (v0.17.6.1)
                 )?;
             }
         } else {

--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -1354,7 +1354,13 @@ pub fn execute_swarm(
     per_agent_gates: &[String],
     integrate: bool,
     quiet: bool,
+    credential_scopes: Option<&[String]>,
 ) -> anyhow::Result<()> {
+    // v0.17.6.1: swarm sub-goals never receive a full clone of the parent's
+    // environment, regardless of whether `--credential-scopes` was declared
+    // for this run — `None` here narrows sub-goals to the baseline plus
+    // unscoped vault credentials only, not to "no narrowing at all".
+    let credential_scopes: Vec<String> = credential_scopes.unwrap_or(&[]).to_vec();
     if sub_goals.is_empty() {
         anyhow::bail!(
             "swarm workflow requires at least one sub-goal. \
@@ -1446,6 +1452,7 @@ pub fn execute_swarm(
                 let agent = agent.to_string();
                 let objective = objective.to_string();
                 let gate_specs = gate_specs.clone();
+                let credential_scopes = credential_scopes.clone();
                 let task: Box<dyn FnOnce() -> ta_workflow::SubGoalStatus + Send> =
                     Box::new(move || {
                         run_one_swarm_sub_goal(
@@ -1457,6 +1464,7 @@ pub fn execute_swarm(
                             &objective,
                             &gate_specs,
                             quiet,
+                            &credential_scopes,
                         )
                     });
                 (i, task)
@@ -1615,6 +1623,73 @@ pub fn execute_swarm(
     Ok(())
 }
 
+/// Build the `ta run` respawn `Command` for one swarm sub-goal.
+///
+/// v0.17.6.1: this is a real fix, not just an env-clearing wrapper. Two
+/// things happen together, both required:
+///
+/// 1. `.env_clear()` plus an explicit non-secret baseline + scope-filtered
+///    vault credentials (`scoped_credential_env`) — the sub-goal process no
+///    longer inherits every credential the parent process could see.
+/// 2. `--credential-scopes` is passed explicitly to the nested `ta run`
+///    invocation. `.env_clear()` alone doesn't narrow what that child
+///    resolves: the nested process reads `.ta/credentials.json` directly
+///    from the filesystem (not from its environment), so without an
+///    explicit scope handoff its own credential resolution — once wired up
+///    in a later phase — would re-admit everything the vault has, regardless
+///    of what this wrapper narrowed its env to. The flag is what lets the
+///    child's own resolution (see `launch_agent_via_runtime`) honor the same
+///    narrower scope, not just this outer wrapper's env.
+///
+/// Pure and side-effect-free (builds but does not spawn) so the resulting
+/// `Command`'s args/env are directly inspectable in tests via
+/// `Command::get_args`/`get_envs`.
+#[allow(clippy::too_many_arguments)]
+fn build_swarm_sub_goal_command(
+    ta_bin: &Path,
+    workspace_root: &Path,
+    sub_goal_title: &str,
+    agent: &str,
+    objective: &str,
+    quiet: bool,
+    credential_scopes: &[String],
+) -> std::process::Command {
+    let mut cmd = std::process::Command::new(ta_bin);
+    cmd.arg("run").arg(sub_goal_title).arg("--agent").arg(agent);
+    if !objective.is_empty() {
+        cmd.arg("--objective").arg(objective);
+    }
+    if quiet {
+        cmd.arg("--quiet");
+    }
+    cmd.current_dir(workspace_root);
+
+    // `workspace_root` here is already the project root (the top-level `ta`
+    // invocation's `GatewayConfig::workspace_root`), not a per-goal staging
+    // path — unlike `launch_agent_via_runtime`, no `project_root_from_staging`
+    // derivation is needed.
+    let available = load_vault_credentials(workspace_root);
+    let current_env: std::collections::HashMap<String, String> = std::env::vars().collect();
+    let sub_goal_env = scoped_credential_env(&current_env, &available, credential_scopes);
+
+    cmd.env_clear();
+    for (k, v) in &sub_goal_env {
+        cmd.env(k, v);
+    }
+
+    // Always present for a swarm respawn — even an empty scope list is an
+    // explicit "enforcement on, zero scopes" declaration, distinct from the
+    // flag being absent entirely (which would mean legacy full inheritance).
+    cmd.arg("--credential-scopes")
+        .arg(if credential_scopes.is_empty() {
+            String::new()
+        } else {
+            credential_scopes.join(",")
+        });
+
+    cmd
+}
+
 /// Run a single swarm sub-goal to completion: launch the agent subprocess,
 /// find its resulting goal record, and evaluate gates. Synchronous — a wave
 /// member runs one of these on its own OS thread via
@@ -1629,16 +1704,17 @@ fn run_one_swarm_sub_goal(
     objective: &str,
     gate_specs: &[ta_workflow::WorkflowGate],
     quiet: bool,
+    credential_scopes: &[String],
 ) -> ta_workflow::SubGoalStatus {
-    let mut cmd = std::process::Command::new(ta_bin);
-    cmd.arg("run").arg(sub_goal_title).arg("--agent").arg(agent);
-    if !objective.is_empty() {
-        cmd.arg("--objective").arg(objective);
-    }
-    if quiet {
-        cmd.arg("--quiet");
-    }
-    cmd.current_dir(workspace_root);
+    let mut cmd = build_swarm_sub_goal_command(
+        ta_bin,
+        workspace_root,
+        sub_goal_title,
+        agent,
+        objective,
+        quiet,
+        credential_scopes,
+    );
 
     let status = match cmd.status() {
         Ok(s) => s,
@@ -1952,6 +2028,7 @@ pub fn execute(
     workflow: Option<&str>,
     persona_name: Option<&str>,
     context_path: Option<&Path>,
+    credential_scopes: Option<&[String]>,
 ) -> anyhow::Result<()> {
     // ── Resume an existing session ──────────────────────────────
     if let Some(session_id_prefix) = resume {
@@ -3209,6 +3286,7 @@ pub fn execute(
             Some(&save_pid),
             goal.goal_run_id,
             &events_dir_for_launch,
+            credential_scopes,
         )
         .map(|(exit, tokens)| {
             agent_tokens_out = tokens;
@@ -3239,6 +3317,7 @@ pub fn execute(
                 Some(&save_pid),
                 goal.goal_run_id,
                 &events_dir_for_launch,
+                credential_scopes,
             )
             .map(|(exit, tokens)| {
                 agent_tokens_out = tokens;
@@ -3254,6 +3333,7 @@ pub fn execute(
             Some(&save_pid),
             goal.goal_run_id,
             &events_dir_for_launch,
+            credential_scopes,
         )
         .map(|(exit, tokens)| {
             agent_tokens_out = tokens;
@@ -4741,6 +4821,110 @@ fn accumulate_tokens(line: &str, tokens: &mut AgentTokens) {
     }
 }
 
+// ── Credential scope enforcement (v0.17.6.1) ──────────────────────────────────
+//
+// `ScopedCredential.scopes` was declared in the type system since v0.17.6 but
+// never checked anywhere, and swarm sub-goals received a full clone of the
+// parent's environment (every credential the parent process could see).
+// These helpers close both gaps: a scope-narrowed spawn starts from nothing
+// but a small non-secret baseline plus whichever `.ta/credentials.json`
+// entries the caller's declared scopes actually cover.
+
+/// Non-secret environment variables that survive a scope-narrowed
+/// (`clear_env`) spawn — enough for common dev tooling (shells, cargo,
+/// git-over-ssh) to keep working without also carrying arbitrary secrets
+/// through implicit inheritance.
+const BASELINE_ENV_KEYS: &[&str] = &[
+    "PATH",
+    "HOME",
+    "USERPROFILE",
+    "SystemRoot",
+    "SystemDrive",
+    "windir",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
+    "TERM",
+    "SHELL",
+    "USER",
+    "LOGNAME",
+    "PWD",
+    "CARGO_HOME",
+    "RUSTUP_HOME",
+    "SSH_AUTH_SOCK",
+];
+
+/// Build the environment for a scope-narrowed spawn: the non-secret
+/// baseline, any `TA_`-prefixed operational/control-plane variables (never
+/// secrets — TA's own inter-process handoff channel, e.g. `TA_PROJECT_ROOT`),
+/// and only the credentials from `available_credentials` whose declared
+/// scope intersects `required_scopes` (via `ta_runtime::apply_credentials_to_env`).
+///
+/// Pure function — `current_env` and `available_credentials` are inputs, not
+/// read from global state, so this is safely unit-testable without mutating
+/// the real process environment.
+fn scoped_credential_env(
+    current_env: &std::collections::HashMap<String, String>,
+    available_credentials: &[ta_runtime::ScopedCredential],
+    required_scopes: &[String],
+) -> std::collections::HashMap<String, String> {
+    let mut env = std::collections::HashMap::new();
+    for key in BASELINE_ENV_KEYS {
+        if let Some(v) = current_env.get(*key) {
+            env.insert((*key).to_string(), v.clone());
+        }
+    }
+    for (k, v) in current_env {
+        if k.starts_with("TA_") {
+            env.insert(k.clone(), v.clone());
+        }
+    }
+    ta_runtime::apply_credentials_to_env(&mut env, available_credentials, required_scopes);
+    env
+}
+
+/// Load every credential currently registered in `<project_root>/.ta/credentials.json`
+/// (via `ta credentials add`) as a `ScopedCredential`, secret value included.
+///
+/// Returns an empty list (not an error) when the vault doesn't exist or is
+/// unreadable — an unpopulated vault is the common case today, and callers
+/// treat "no available credentials" as "only the baseline survives", which
+/// is the correct, secure outcome, not a failure.
+fn load_vault_credentials(project_root: &Path) -> Vec<ta_runtime::ScopedCredential> {
+    use ta_credentials::CredentialVault;
+
+    let cred_config = ta_credentials::CredentialsConfig::for_project(project_root);
+    let Ok(vault) = ta_credentials::FileVault::open(&cred_config) else {
+        return Vec::new();
+    };
+    let Ok(summaries) = vault.list() else {
+        return Vec::new();
+    };
+    summaries
+        .into_iter()
+        .filter_map(|summary| {
+            vault.get(summary.id).ok().map(|full| {
+                ta_runtime::ScopedCredential::with_scopes(full.name, full.secret, full.scopes)
+            })
+        })
+        .collect()
+}
+
+/// Derive the project root from a goal's staging path.
+///
+/// `staging_path = project_root/.ta/staging/<uuid>` — three parents up is
+/// `project_root`. Same derivation `launch_agent_via_runtime` already used
+/// inline for the claude-code stable MCP config path.
+fn project_root_from_staging(staging_path: &Path) -> Option<std::path::PathBuf> {
+    staging_path
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .map(|p| p.to_path_buf())
+}
+
 /// Launch an agent via the RuntimeAdapter and wait for it to exit (v0.13.3).
 ///
 /// This is the non-interactive, non-PTY path.  It replaces `launch_agent` and
@@ -4752,6 +4936,7 @@ fn accumulate_tokens(line: &str, tokens: &mut AgentTokens) {
 /// - `AgentExited` after the process exits (carries exit code, duration)
 /// - `RuntimeError` (instead of returning Err) on spawn failure, so callers
 ///   always get a structured event even when the agent never starts.
+#[allow(clippy::too_many_arguments)]
 fn launch_agent_via_runtime(
     config: &AgentLaunchConfig,
     staging_path: &std::path::Path,
@@ -4760,13 +4945,36 @@ fn launch_agent_via_runtime(
     pid_callback: Option<&dyn Fn(u32)>,
     goal_id: uuid::Uuid,
     events_dir: &std::path::Path,
+    credential_scopes: Option<&[String]>,
 ) -> std::io::Result<(std::process::ExitStatus, AgentTokens)> {
     use std::io::{BufRead, BufReader};
     use ta_events::{EventEnvelope, EventStore, FsEventStore, SessionEvent};
     use ta_runtime::{RuntimeRegistry, SpawnRequest, StdinMode, StdoutMode};
 
     // Build the environment map with template variables already applied.
-    let mut env = config.env.clone();
+    //
+    // v0.17.6.1: when `credential_scopes` is declared, this spawn does not
+    // inherit the current process's full environment — it starts from an
+    // explicit non-secret baseline plus only the vault credentials whose
+    // declared scope intersects `credential_scopes` (see
+    // `scoped_credential_env`). `SpawnRequest.clear_env` below is what makes
+    // this a real replacement rather than an addition on top of full
+    // inheritance. `None` (the flag was never passed) keeps the historical
+    // behavior of full environment inheritance, unchanged.
+    let clear_env = credential_scopes.is_some();
+    let mut env: std::collections::HashMap<String, String> = match credential_scopes {
+        Some(scopes) => {
+            let project_root = project_root_from_staging(staging_path);
+            let available = project_root
+                .as_deref()
+                .map(load_vault_credentials)
+                .unwrap_or_default();
+            let current_env: std::collections::HashMap<String, String> = std::env::vars().collect();
+            scoped_credential_env(&current_env, &available, scopes)
+        }
+        None => std::collections::HashMap::new(),
+    };
+    env.extend(config.env.clone());
     if headless {
         env.extend(config.non_interactive_env.clone());
     }
@@ -4825,6 +5033,7 @@ fn launch_agent_via_runtime(
         working_dir: staging_path.to_path_buf(),
         stdin_mode,
         stdout_mode,
+        clear_env,
     };
 
     // Apply sandbox policy from workflow.toml [sandbox] section (v0.14.0).
@@ -8329,6 +8538,7 @@ mod tests {
             None,  // workflow = default (single-agent)
             None,  // persona_name = None
             None,  // context_path = None
+            None,  // credential_scopes = None (v0.17.6.1)
         )
         .unwrap();
 
@@ -10309,6 +10519,7 @@ plan_pending_window = 7
             None,
             None,
             None,
+            None, // credential_scopes = None (v0.17.6.1)
         )
         .unwrap();
 
@@ -10343,6 +10554,7 @@ plan_pending_window = 7
             None,
             None,
             None,
+            None, // credential_scopes = None (v0.17.6.1)
         )
         .unwrap();
 
@@ -10765,5 +10977,175 @@ plan_pending_window = 7
         let dir = tempfile::tempdir().unwrap();
         let rec = recommend_agent(dir.path(), "test-tier", None, None, None);
         assert_eq!(rec.agent, "claude-code");
+    }
+
+    // ── v0.17.6.1: declared credential scope enforcement ────────────────────
+
+    #[test]
+    fn scoped_credential_env_keeps_only_baseline_and_ta_prefixed_vars() {
+        let mut current_env = HashMap::new();
+        current_env.insert("PATH".to_string(), "/usr/bin".to_string());
+        current_env.insert("HOME".to_string(), "/home/agent".to_string());
+        current_env.insert("TA_PROJECT_ROOT".to_string(), "/proj".to_string());
+        // Not a baseline key, not TA_-prefixed — must not survive.
+        current_env.insert("AWS_SECRET_ACCESS_KEY".to_string(), "leaked".to_string());
+
+        let env = scoped_credential_env(&current_env, &[], &[]);
+
+        assert_eq!(env.get("PATH"), Some(&"/usr/bin".to_string()));
+        assert_eq!(env.get("HOME"), Some(&"/home/agent".to_string()));
+        assert_eq!(env.get("TA_PROJECT_ROOT"), Some(&"/proj".to_string()));
+        assert!(!env.contains_key("AWS_SECRET_ACCESS_KEY"));
+    }
+
+    #[test]
+    fn scoped_credential_env_includes_only_intersected_credentials() {
+        let current_env = HashMap::new();
+        let available = vec![
+            ta_runtime::ScopedCredential::with_scopes(
+                "GITHUB_TOKEN",
+                "ghp_real",
+                vec!["repo.read".into()],
+            ),
+            ta_runtime::ScopedCredential::with_scopes(
+                "AWS_KEY",
+                "aws_real",
+                vec!["deploy.prod".into()],
+            ),
+            ta_runtime::ScopedCredential::new("ANTHROPIC_API_KEY", "anthropic_real"),
+        ];
+
+        let env = scoped_credential_env(&current_env, &available, &["repo.read".to_string()]);
+
+        // In the required scope — present, not a placeholder.
+        assert_eq!(env.get("GITHUB_TOKEN"), Some(&"ghp_real".to_string()));
+        // Unscoped — always present regardless of required scopes.
+        assert_eq!(
+            env.get("ANTHROPIC_API_KEY"),
+            Some(&"anthropic_real".to_string())
+        );
+        // Scope excluded — absent entirely, not present-but-empty.
+        assert!(!env.contains_key("AWS_KEY"));
+    }
+
+    #[test]
+    fn load_vault_credentials_returns_empty_for_unpopulated_vault() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_vault_credentials(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn load_vault_credentials_includes_secret_and_scopes() {
+        use ta_credentials::{CredentialVault, CredentialsConfig, FileVault};
+
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let mut vault = FileVault::open(&CredentialsConfig::for_project(dir.path())).unwrap();
+            vault
+                .add(
+                    "GITHUB_TOKEN",
+                    "github",
+                    "ghp_secret",
+                    vec!["repo.read".into()],
+                )
+                .unwrap();
+        }
+
+        let creds = load_vault_credentials(dir.path());
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].name, "GITHUB_TOKEN");
+        assert_eq!(creds[0].value, "ghp_secret");
+        assert_eq!(creds[0].scopes, vec!["repo.read".to_string()]);
+    }
+
+    #[test]
+    fn swarm_sub_goal_command_declares_credential_scopes_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let cmd = build_swarm_sub_goal_command(
+            Path::new("/usr/local/bin/ta"),
+            dir.path(),
+            "Add auth endpoint",
+            "claude-code",
+            "",
+            true,
+            &["repo.read".to_string(), "ci.trigger".to_string()],
+        );
+
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(args.contains(&"--credential-scopes".to_string()));
+        let flag_pos = args
+            .iter()
+            .position(|a| a == "--credential-scopes")
+            .unwrap();
+        assert_eq!(args[flag_pos + 1], "repo.read,ci.trigger");
+    }
+
+    #[test]
+    fn swarm_sub_goal_command_passes_empty_credential_scopes_explicitly() {
+        let dir = tempfile::tempdir().unwrap();
+        let cmd = build_swarm_sub_goal_command(
+            Path::new("/usr/local/bin/ta"),
+            dir.path(),
+            "Add auth endpoint",
+            "claude-code",
+            "",
+            true,
+            &[],
+        );
+
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        let flag_pos = args
+            .iter()
+            .position(|a| a == "--credential-scopes")
+            .unwrap();
+        // Present but empty — "enforcement on, zero scopes", not the flag
+        // being omitted entirely (which would mean legacy full inheritance).
+        assert_eq!(args[flag_pos + 1], "");
+    }
+
+    #[test]
+    fn swarm_sub_goal_command_env_does_not_contain_full_parent_environment() {
+        let dir = tempfile::tempdir().unwrap();
+        // A var that's set in *this test process* but not in the vault and
+        // not a baseline key (and NOT TA_-prefixed) — must not leak into the
+        // sub-goal's env.
+        std::env::set_var("SWARM_LEAK_CANARY_XYZ", "leaked");
+        std::env::set_var("TA_PREFIXED_CANARY_SHOULD_SURVIVE", "kept");
+
+        let cmd = build_swarm_sub_goal_command(
+            Path::new("/usr/local/bin/ta"),
+            dir.path(),
+            "Add auth endpoint",
+            "claude-code",
+            "",
+            true,
+            &[],
+        );
+
+        let envs: HashMap<String, Option<String>> = cmd
+            .get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().to_string(),
+                    v.map(|v| v.to_string_lossy().to_string()),
+                )
+            })
+            .collect();
+
+        std::env::remove_var("SWARM_LEAK_CANARY_XYZ");
+        std::env::remove_var("TA_PREFIXED_CANARY_SHOULD_SURVIVE");
+
+        assert!(!envs.contains_key("SWARM_LEAK_CANARY_XYZ"));
+        // TA_-prefixed control-plane vars are the one deliberate exception.
+        assert_eq!(
+            envs.get("TA_PREFIXED_CANARY_SHOULD_SURVIVE"),
+            Some(&Some("kept".to_string()))
+        );
     }
 }

--- a/apps/ta-cli/src/commands/session.rs
+++ b/apps/ta-cli/src/commands/session.rs
@@ -194,6 +194,7 @@ pub fn execute(cmd: &SessionCommands, config: &GatewayConfig) -> anyhow::Result<
                 None,  // workflow = default (single-agent)
                 None,  // persona_name = None
                 None,  // context_path = None
+                None,  // credential_scopes = None (v0.17.6.1)
             )
         }
         SessionCommands::Pause { id } => pause_session(config, id),

--- a/apps/ta-cli/src/main.rs
+++ b/apps/ta-cli/src/main.rs
@@ -388,6 +388,25 @@ enum Commands {
         /// `.ta/workflow.toml` config or is detected from the goal title.
         #[arg(long)]
         priority: Option<String>,
+        /// Declared credential scopes for this goal run, comma-separated
+        /// (v0.17.6.1, e.g. `--credential-scopes repo.read,ci.trigger`).
+        ///
+        /// When set, the agent process (and, for `--workflow swarm`, every
+        /// sub-goal it spawns) receives a narrowed environment: an explicit
+        /// non-secret baseline plus only the vault credentials
+        /// (`ta credentials add --scope ...`) whose declared scope
+        /// intersects this list — no full-environment inheritance.
+        /// Credentials with no declared scope are always included.
+        /// Pass `--credential-scopes ""` (an explicit empty value) for "no
+        /// scopes" (baseline + unscoped credentials only) — clap requires a
+        /// value token for this flag. Omit the flag entirely to keep the
+        /// legacy behavior of full environment inheritance.
+        ///
+        /// `--workflow swarm` sub-goals always run scope-narrowed — this flag
+        /// declares which scopes they get; omitting it narrows them to
+        /// nothing but the baseline and unscoped credentials.
+        #[arg(long, value_delimiter = ',')]
+        credential_scopes: Option<Vec<String>>,
     },
     /// Review and manage draft packages.
     #[command(hide = true)]
@@ -1572,9 +1591,19 @@ fn dispatch_raw(
             team,
             security,
             priority,
+            credential_scopes,
         } => {
             // First-run gate: warn if provider is not yet configured.
             commands::onboard::check_provider_configured(*skip_onboard_check)?;
+
+            // Normalize `--credential-scopes` (v0.17.6.1): `Some(vec![])` (flag
+            // given with no value, or clap's empty-string split) means "scope
+            // enforcement on, zero scopes" — distinct from `None` ("flag never
+            // given, legacy full-inheritance behavior"). Filtering empty
+            // strings out of a `Some(...)` must not turn it into `None`.
+            let credential_scopes: Option<Vec<String>> = credential_scopes
+                .as_ref()
+                .map(|scopes| scopes.iter().filter(|s| !s.is_empty()).cloned().collect());
 
             // Phase-aware title resolution: if the positional title looks like
             // a phase ID (e.g., "v0.9.8.1", "0.9.8.1", "phase 0.9.8.1"),
@@ -1648,6 +1677,7 @@ fn dispatch_raw(
                     gates,
                     *integrate,
                     *quiet,
+                    credential_scopes.as_deref(),
                 );
             }
 
@@ -1674,6 +1704,7 @@ fn dispatch_raw(
                 workflow.as_deref(),
                 persona.as_deref(),
                 context.as_deref(),
+                credential_scopes.as_deref(),
             )
         }
         Commands::Events { command } => {

--- a/crates/ta-actions/Cargo.toml
+++ b/crates/ta-actions/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 toml = { workspace = true }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.3" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-advisor/Cargo.toml
+++ b/crates/ta-advisor/Cargo.toml
@@ -17,12 +17,12 @@ tracing = { workspace = true }
 
 # Reuses the existing heuristic classifier as the substrate for the new
 # 4-way taxonomy rather than duplicating keyword-matching logic.
-ta-session = { path = "../ta-session", version = "0.17.5-alpha.3" }
+ta-session = { path = "../ta-session", version = "0.17.6-alpha.1" }
 # Team-coordinator capability (v0.17.0.12.20): reuses ta-intake's TriggerEvent
 # and ta-brain's routing/prioritization rather than a new persistent role —
 # see crates/ta-advisor/src/coordinator.rs for the decision rationale.
-ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.3" }
-ta-brain = { path = "../ta-brain", version = "0.17.5-alpha.3" }
+ta-intake = { path = "../ta-intake", version = "0.17.6-alpha.1" }
+ta-brain = { path = "../ta-brain", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-brain/Cargo.toml
+++ b/crates/ta-brain/Cargo.toml
@@ -18,13 +18,13 @@ chrono = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
-ta-session = { path = "../ta-session", version = "0.17.5-alpha.3" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
-ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.3" }
+ta-session = { path = "../ta-session", version = "0.17.6-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.1" }
+ta-intake = { path = "../ta-intake", version = "0.17.6-alpha.1" }
 # Folds ta-workflow's template-matching intent resolver in as one signal
 # route() consults (v0.17.0.12.23), rather than a second, parallel intent
 # system — see route.rs's resolve_workflow_template().
-ta-workflow = { path = "../ta-workflow", version = "0.17.5-alpha.3" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/comfyui/Cargo.toml
+++ b/crates/ta-connectors/comfyui/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.3" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/discord/Cargo.toml
+++ b/crates/ta-connectors/discord/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.5-alpha.3" }
+ta-events = { path = "../../ta-events", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/email/Cargo.toml
+++ b/crates/ta-connectors/email/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.5-alpha.3" }
+ta-events = { path = "../../ta-events", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/fs/Cargo.toml
+++ b/crates/ta-connectors/fs/Cargo.toml
@@ -16,10 +16,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.3" }
-ta-workspace = { path = "../../ta-workspace", version = "0.17.5-alpha.3" }
-ta-audit = { path = "../../ta-audit", version = "0.17.5-alpha.3" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.6-alpha.1" }
+ta-workspace = { path = "../../ta-workspace", version = "0.17.6-alpha.1" }
+ta-audit = { path = "../../ta-audit", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-ta-policy = { path = "../../ta-policy", version = "0.17.5-alpha.3" }
+ta-policy = { path = "../../ta-policy", version = "0.17.6-alpha.1" }

--- a/crates/ta-connectors/slack/Cargo.toml
+++ b/crates/ta-connectors/slack/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.5-alpha.3" }
+ta-events = { path = "../../ta-events", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/unreal/Cargo.toml
+++ b/crates/ta-connectors/unreal/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.5-alpha.3" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -31,23 +31,23 @@ async-stream = { workspace = true }
 sha2 = { workspace = true }
 
 # Internal crates
-ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.5-alpha.3" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.3" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
-ta-memory = { path = "../ta-memory", version = "0.17.5-alpha.3" }
-ta-events = { path = "../ta-events", version = "0.17.5-alpha.3" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
-ta-runtime = { path = "../ta-runtime", version = "0.17.5-alpha.3" }
-ta-audit = { path = "../ta-audit", version = "0.17.5-alpha.3" }
-ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.3" }
-ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.5-alpha.3" }
-ta-connector-email = { path = "../ta-connectors/email", version = "0.17.5-alpha.3" }
+ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.6-alpha.1" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.1" }
+ta-memory = { path = "../ta-memory", version = "0.17.6-alpha.1" }
+ta-events = { path = "../ta-events", version = "0.17.6-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.1" }
+ta-runtime = { path = "../ta-runtime", version = "0.17.6-alpha.1" }
+ta-audit = { path = "../ta-audit", version = "0.17.6-alpha.1" }
+ta-policy = { path = "../ta-policy", version = "0.17.6-alpha.1" }
+ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.6-alpha.1" }
+ta-connector-email = { path = "../ta-connectors/email", version = "0.17.6-alpha.1" }
 reqwest = { workspace = true }
-ta-output-schema = { path = "../ta-output-schema", version = "0.17.5-alpha.3" }
-ta-extension = { path = "../ta-extension", version = "0.17.5-alpha.3" }
-ta-session = { path = "../ta-session", version = "0.17.5-alpha.3" }
-ta-advisor = { path = "../ta-advisor", version = "0.17.5-alpha.3" }
-ta-data-spec = { path = "../ta-data-spec", version = "0.17.5-alpha.3" }
+ta-output-schema = { path = "../ta-output-schema", version = "0.17.6-alpha.1" }
+ta-extension = { path = "../ta-extension", version = "0.17.6-alpha.1" }
+ta-session = { path = "../ta-session", version = "0.17.6-alpha.1" }
+ta-advisor = { path = "../ta-advisor", version = "0.17.6-alpha.1" }
+ta-data-spec = { path = "../ta-data-spec", version = "0.17.6-alpha.1" }
 which = "7"
 libc = { workspace = true }
 async-trait = "0.1"

--- a/crates/ta-data-spec/Cargo.toml
+++ b/crates/ta-data-spec/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 [dependencies]
 schemars = { workspace = true }
 serde_json = { workspace = true }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
-ta-brain = { path = "../ta-brain", version = "0.17.5-alpha.3" }
-ta-intake = { path = "../ta-intake", version = "0.17.5-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.1" }
+ta-brain = { path = "../ta-brain", version = "0.17.6-alpha.1" }
+ta-intake = { path = "../ta-intake", version = "0.17.6-alpha.1" }

--- a/crates/ta-db-proxy/Cargo.toml
+++ b/crates/ta-db-proxy/Cargo.toml
@@ -17,10 +17,10 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.5-alpha.3" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.3" }
-ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.3" }
-ta-actions = { path = "../ta-actions", version = "0.17.5-alpha.3" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.6-alpha.1" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.1" }
+ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.1" }
+ta-actions = { path = "../ta-actions", version = "0.17.6-alpha.1" }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ta-intake/Cargo.toml
+++ b/crates/ta-intake/Cargo.toml
@@ -19,8 +19,8 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 regex = { workspace = true }
-ta-submit = { path = "../ta-submit", version = "0.17.5-alpha.3" }
-ta-events = { path = "../ta-events", version = "0.17.5-alpha.3" }
+ta-submit = { path = "../ta-submit", version = "0.17.6-alpha.1" }
+ta-events = { path = "../ta-events", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -25,22 +25,22 @@ which = { workspace = true }
 toml = { workspace = true }
 
 # Internal crates
-ta-audit = { path = "../ta-audit", version = "0.17.5-alpha.3" }
-ta-events = { path = "../ta-events", version = "0.17.5-alpha.3" }
-ta-memory = { path = "../ta-memory", version = "0.17.5-alpha.3" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
-ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.5-alpha.3" }
-ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.5-alpha.3" }
-ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.5-alpha.3" }
-ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.5-alpha.3" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
-ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.3" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.3" }
-ta-workflow = { path = "../ta-workflow", version = "0.17.5-alpha.3" }
-ta-actions = { path = "../ta-actions", version = "0.17.5-alpha.3" }
-ta-submit = { path = "../ta-submit", version = "0.17.5-alpha.3" }
-ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.3" }
-ta-session = { path = "../ta-session", version = "0.17.5-alpha.3" }
+ta-audit = { path = "../ta-audit", version = "0.17.6-alpha.1" }
+ta-events = { path = "../ta-events", version = "0.17.6-alpha.1" }
+ta-memory = { path = "../ta-memory", version = "0.17.6-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.1" }
+ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.6-alpha.1" }
+ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.6-alpha.1" }
+ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.6-alpha.1" }
+ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.6-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.1" }
+ta-policy = { path = "../ta-policy", version = "0.17.6-alpha.1" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.1" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.6-alpha.1" }
+ta-actions = { path = "../ta-actions", version = "0.17.6-alpha.1" }
+ta-submit = { path = "../ta-submit", version = "0.17.6-alpha.1" }
+ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.1" }
+ta-session = { path = "../ta-session", version = "0.17.6-alpha.1" }
 
 
 [dev-dependencies]

--- a/crates/ta-mediation/Cargo.toml
+++ b/crates/ta-mediation/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates for FsMediator
-ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.3" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-release/Cargo.toml
+++ b/crates/ta-release/Cargo.toml
@@ -18,7 +18,7 @@ toml = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true, features = ["multipart"] }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.3" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-runtime/Cargo.toml
+++ b/crates/ta-runtime/Cargo.toml
@@ -23,8 +23,8 @@ which = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
 
-ta-credentials = { path = "../ta-credentials", version = "0.17.5-alpha.3" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.3" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.6-alpha.1" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.1" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/ta-runtime/src/adapter.rs
+++ b/crates/ta-runtime/src/adapter.rs
@@ -112,6 +112,16 @@ pub struct SpawnRequest {
 
     /// How to handle stdout.
     pub stdout_mode: StdoutMode,
+
+    /// Spawn with a cleared environment — the child inherits nothing from
+    /// the current process, only what's explicitly set in `env` (v0.17.6.1).
+    ///
+    /// Set this when `env` was built by scope-narrowing credentials (see
+    /// `ta_runtime::apply_credentials_to_env`): without it, the OS process
+    /// still inherits the *full* parent environment and `env` only adds to
+    /// that, defeating the narrowing. `false` preserves the historical
+    /// default of full inheritance.
+    pub clear_env: bool,
 }
 
 // ── Status ───────────────────────────────────────────────────────────────────
@@ -271,9 +281,11 @@ mod tests {
             working_dir: PathBuf::from("/tmp"),
             stdin_mode: StdinMode::Inherited,
             stdout_mode: StdoutMode::Inherited,
+            clear_env: false,
         };
         assert_eq!(req.command, "claude");
         assert_eq!(req.args.len(), 2);
         assert_eq!(req.env.get("KEY"), Some(&"val".to_string()));
+        assert!(!req.clear_env);
     }
 }

--- a/crates/ta-runtime/src/bare_process.rs
+++ b/crates/ta-runtime/src/bare_process.rs
@@ -135,6 +135,14 @@ impl RuntimeAdapter for BareProcessRuntime {
         let mut cmd = build_command(&request.command, &request.args);
         cmd.current_dir(&request.working_dir);
 
+        // Scope-narrowed spawns (v0.17.6.1) start from nothing rather than
+        // the full parent environment — `request.env` is the complete,
+        // already-narrowed environment for this child, not an addition to
+        // whatever this process happened to inherit.
+        if request.clear_env {
+            cmd.env_clear();
+        }
+
         // Strip dynamic-linker preload variables before merging any env overrides.
         // These can be injected into the parent process environment by a PATH-masquerade
         // attack and would be inherited by the agent subprocess, allowing arbitrary
@@ -230,13 +238,32 @@ fn build_command(command: &str, args: &[String]) -> Command {
 
 // ── Helper: build env map with credentials ───────────────────────────────────
 
-/// Merge scoped credentials into an existing env map.
+/// Merge scoped credentials into an existing env map, enforcing declared
+/// scopes (v0.17.6.1).
 ///
-/// Each credential becomes an environment variable: `cred.name = cred.value`.
-/// Call this before building a `SpawnRequest` to include credentials.
-pub fn apply_credentials_to_env(env: &mut HashMap<String, String>, creds: &[ScopedCredential]) {
+/// A credential is only injected if it is eligible for `required_scopes`:
+/// - A credential with **no** declared scopes (`cred.scopes.is_empty()`) is
+///   unrestricted — per `ScopedCredential`'s own contract ("no scope
+///   restrictions") it is always injected.
+/// - A credential with declared scopes is injected only if at least one of
+///   them appears in `required_scopes`. A credential whose scopes don't
+///   intersect `required_scopes` at all is silently omitted — the caller
+///   never sees it, not even as an unusable placeholder.
+///
+/// Each injected credential becomes an environment variable:
+/// `cred.name = cred.value`. Call this before building a `SpawnRequest` to
+/// include credentials.
+pub fn apply_credentials_to_env(
+    env: &mut HashMap<String, String>,
+    creds: &[ScopedCredential],
+    required_scopes: &[String],
+) {
     for cred in creds {
-        env.insert(cred.name.clone(), cred.value.clone());
+        let in_scope =
+            cred.scopes.is_empty() || cred.scopes.iter().any(|s| required_scopes.contains(s));
+        if in_scope {
+            env.insert(cred.name.clone(), cred.value.clone());
+        }
     }
 }
 
@@ -260,6 +287,7 @@ mod tests {
             working_dir: std::env::temp_dir(),
             stdin_mode: StdinMode::Null,
             stdout_mode: StdoutMode::Inherited,
+            clear_env: false,
         };
         let mut handle = rt.spawn(req).expect("spawn should succeed");
         let status = handle.wait().expect("wait should succeed");
@@ -280,6 +308,7 @@ mod tests {
             working_dir: std::env::temp_dir(),
             stdin_mode: StdinMode::Null,
             stdout_mode: StdoutMode::Inherited,
+            clear_env: false,
         };
         let mut handle = rt.spawn(req).expect("spawn should succeed");
         let status = handle.wait().expect("wait should succeed");
@@ -298,6 +327,7 @@ mod tests {
             working_dir: std::env::temp_dir(),
             stdin_mode: StdinMode::Null,
             stdout_mode: StdoutMode::Piped,
+            clear_env: false,
         };
         let mut handle = rt.spawn(req).expect("spawn should succeed");
         let mut output = String::new();
@@ -318,6 +348,7 @@ mod tests {
             working_dir: std::env::temp_dir(),
             stdin_mode: StdinMode::Null,
             stdout_mode: StdoutMode::Inherited,
+            clear_env: false,
         };
         let mut handle = rt.spawn(req).expect("spawn should succeed");
         assert_eq!(handle.transport_info(), TransportInfo::Stdio);
@@ -335,6 +366,7 @@ mod tests {
             working_dir: std::env::temp_dir(),
             stdin_mode: StdinMode::Null,
             stdout_mode: StdoutMode::Inherited,
+            clear_env: false,
         };
         let mut handle = rt.spawn(req).expect("spawn should succeed");
         // Wait for the child, then check status.
@@ -347,19 +379,108 @@ mod tests {
     }
 
     #[test]
-    fn apply_credentials_to_env_merges() {
+    fn apply_credentials_to_env_merges_unscoped_credentials() {
         let mut env = HashMap::new();
         env.insert("EXISTING".into(), "yes".into());
 
-        let creds = vec![
-            ScopedCredential::new("API_KEY", "secret-key"),
-            ScopedCredential::with_scopes("GITHUB", "ghp_token", vec!["repo.read".into()]),
-        ];
-        apply_credentials_to_env(&mut env, &creds);
+        // Unscoped credentials ("no scope restrictions") are always injected,
+        // regardless of what's required.
+        let creds = vec![ScopedCredential::new("API_KEY", "secret-key")];
+        apply_credentials_to_env(&mut env, &creds, &[]);
 
         assert_eq!(env.get("EXISTING"), Some(&"yes".to_string()));
         assert_eq!(env.get("API_KEY"), Some(&"secret-key".to_string()));
+    }
+
+    #[test]
+    fn apply_credentials_to_env_includes_credential_with_matching_scope() {
+        let mut env = HashMap::new();
+        let creds = vec![ScopedCredential::with_scopes(
+            "GITHUB",
+            "ghp_token",
+            vec!["repo.read".into()],
+        )];
+        apply_credentials_to_env(&mut env, &creds, &["repo.read".into()]);
+
         assert_eq!(env.get("GITHUB"), Some(&"ghp_token".to_string()));
+    }
+
+    #[test]
+    fn apply_credentials_to_env_excludes_credential_out_of_required_scope() {
+        let mut env = HashMap::new();
+        let creds = vec![ScopedCredential::with_scopes(
+            "GITHUB",
+            "ghp_token",
+            vec!["repo.write".into()],
+        )];
+        // Required scope doesn't overlap the credential's declared scope —
+        // it must be entirely absent from the resulting env, not merely
+        // present-but-empty.
+        apply_credentials_to_env(&mut env, &creds, &["repo.read".into()]);
+
+        assert!(!env.contains_key("GITHUB"));
+    }
+
+    #[test]
+    fn apply_credentials_to_env_excludes_scoped_credential_when_no_scopes_required() {
+        let mut env = HashMap::new();
+        let creds = vec![ScopedCredential::with_scopes(
+            "GITHUB",
+            "ghp_token",
+            vec!["repo.read".into()],
+        )];
+        apply_credentials_to_env(&mut env, &creds, &[]);
+
+        assert!(!env.contains_key("GITHUB"));
+    }
+
+    #[test]
+    fn apply_credentials_to_env_includes_credential_matching_any_of_several_scopes() {
+        let mut env = HashMap::new();
+        let creds = vec![ScopedCredential::with_scopes(
+            "GITHUB",
+            "ghp_token",
+            vec!["repo.read".into(), "issues.write".into()],
+        )];
+        apply_credentials_to_env(
+            &mut env,
+            &creds,
+            &["issues.write".into(), "ci.trigger".into()],
+        );
+
+        assert_eq!(env.get("GITHUB"), Some(&"ghp_token".to_string()));
+    }
+
+    #[test]
+    fn spawn_with_clear_env_does_not_inherit_parent_environment() {
+        let rt = BareProcessRuntime::new();
+        let mut env = HashMap::new();
+        env.insert("SCOPED_ONLY".into(), "present".into());
+
+        // A var that's set in *this test process* but must NOT leak through
+        // when clear_env is set — only what's explicitly in `env` survives.
+        std::env::set_var("TA_TEST_LEAK_CANARY", "should-not-be-inherited");
+
+        let req = SpawnRequest {
+            command: "sh".into(),
+            args: vec![
+                "-c".into(),
+                "test \"$SCOPED_ONLY\" = present && [ -z \"$TA_TEST_LEAK_CANARY\" ]".into(),
+            ],
+            env,
+            working_dir: std::env::temp_dir(),
+            stdin_mode: StdinMode::Null,
+            stdout_mode: StdoutMode::Inherited,
+            clear_env: true,
+        };
+        let mut handle = rt.spawn(req).expect("spawn should succeed");
+        let status = handle.wait().expect("wait should succeed");
+        std::env::remove_var("TA_TEST_LEAK_CANARY");
+
+        assert!(
+            status.success(),
+            "clear_env spawn must see only the explicit env, not the parent's"
+        );
     }
 
     #[test]
@@ -372,6 +493,7 @@ mod tests {
             working_dir: std::env::temp_dir(),
             stdin_mode: StdinMode::Null,
             stdout_mode: StdoutMode::Inherited,
+            clear_env: false,
         };
         let mut handle = rt.spawn(req).expect("spawn should succeed");
         let creds = vec![ScopedCredential::new("K", "v")];

--- a/crates/ta-runtime/src/sandbox.rs
+++ b/crates/ta-runtime/src/sandbox.rs
@@ -436,6 +436,7 @@ mod tests {
             working_dir: working_dir.to_path_buf(),
             stdin_mode: crate::adapter::StdinMode::Null,
             stdout_mode: crate::adapter::StdoutMode::Inherited,
+            clear_env: false,
         }
     }
 

--- a/crates/ta-runtime/src/sandbox_windows.rs
+++ b/crates/ta-runtime/src/sandbox_windows.rs
@@ -1492,6 +1492,7 @@ mod tests {
             working_dir: tmp.path().to_path_buf(),
             stdin_mode: StdinMode::Null,
             stdout_mode: StdoutMode::Inherited,
+            clear_env: false,
         };
 
         match spawn_in_appcontainer(&request, &guard) {
@@ -1552,6 +1553,7 @@ mod tests {
             working_dir: tmp.path().to_path_buf(),
             stdin_mode: StdinMode::Null,
             stdout_mode: StdoutMode::Inherited,
+            clear_env: false,
         };
 
         match spawn_in_appcontainer(&request, &guard) {
@@ -1614,6 +1616,7 @@ mod tests {
             working_dir: std::path::PathBuf::from("C:\\staging\\workspace"),
             stdin_mode: StdinMode::Null,
             stdout_mode: StdoutMode::Inherited,
+            clear_env: false,
         };
 
         let wrapped = policy.apply(req.clone());

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }
-ta-policy = { path = "../ta-policy", version = "0.17.5-alpha.3" }
+ta-policy = { path = "../ta-policy", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-session/Cargo.toml
+++ b/crates/ta-session/Cargo.toml
@@ -25,9 +25,9 @@ notify = { workspace = true }
 toml = { workspace = true }
 
 # Workspace crates
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
-ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.1" }
+ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -16,11 +16,11 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.5-alpha.3" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.5-alpha.3" }
-ta-decision = { path = "../ta-decision", version = "0.17.5-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.1" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.1" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.1" }
+ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.1" }
 toml = "0.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/ta-workflow/Cargo.toml
+++ b/crates/ta-workflow/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -21,8 +21,8 @@ reqwest = { workspace = true }
 anyhow = { workspace = true }
 sha2 = "0.10"
 base64 = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.5-alpha.3" }
-ta-goal = { path = "../ta-goal", version = "0.17.5-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.1" }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: 0.17.5-alpha.3
+**Version**: 0.17.6-alpha.1
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 
@@ -7272,6 +7272,49 @@ TA issues:      SessionToken { ttl: 3600s, scopes: ["read"], agent: "claude-code
 Agent uses:     The token (never the raw credential)
 TA proxies:     Token → real credential on each API call
 ```
+
+#### Enforcing Declared Credential Scopes
+
+`ta run` accepts `--credential-scopes` (comma-separated) to declare which
+scopes the launched agent is allowed to use:
+
+```bash
+ta run "Sync gmail labels" --credential-scopes "read,labels"
+```
+
+When set, the agent process no longer inherits your shell's full
+environment. It receives an explicit, narrow environment instead: a small
+non-secret baseline (`PATH`, `HOME`, and similar), plus only the credentials
+registered via `ta credentials add` whose declared `--scope` overlaps the
+list you passed. A credential registered with no scopes at all (`ta
+credentials add` without `--scope`) is treated as unrestricted and is always
+included. Everything else -- including credentials whose scope doesn't
+overlap, and any other environment variable your shell happened to have set
+-- is simply absent, not present with an empty value. Pass
+`--credential-scopes ""` for "no scopes at all" (baseline + unrestricted
+credentials only) -- the flag requires a value token, even an empty one.
+Omitting `--credential-scopes` entirely keeps the previous behavior of full
+environment inheritance, so existing scripts are unaffected.
+
+**Swarm sub-goals are always scope-narrowed.** `--workflow swarm` sub-goals
+never receive a full clone of the parent's environment, whether or not
+`--credential-scopes` was passed to the parent run -- omitting it narrows
+sub-goals down to just the baseline and unrestricted credentials. If your
+swarm sub-goals need a specific credential (e.g. a `GITHUB_TOKEN` for `gh pr
+create`), register it in the vault with a matching scope and pass
+`--credential-scopes` on the parent `ta run --workflow swarm ...` command:
+
+```bash
+ta credentials add --name GITHUB_TOKEN --service github --secret "ghp_..." --scope "ci.push"
+ta run "Ship the release" --workflow swarm --sub-goals "Build" "Test" \
+  --credential-scopes "ci.push"
+```
+
+This is a real fix at both ends of the fan-out, not just an outer wrapper:
+the nested `ta run` process each sub-goal spawns receives the same
+`--credential-scopes` value explicitly and applies the identical scope
+filter to its own eventual agent spawn -- clearing the environment there too
+-- rather than relying solely on what the parent process happened to strip.
 
 ### Context Memory
 


### PR DESCRIPTION
## Summary
Closes the two loudest, cheapest-to-fix gaps in TA's credential model: `ScopedCredential.scopes` was declared but never checked anywhere, and `run_one_swarm_sub_goal` handed every concurrent sub-goal a full-environment clone of the parent with zero credential narrowing.

- `apply_credentials_to_env(env, creds, required_scopes)`: a credential with no declared scopes is always injected (its existing "no scope restrictions" contract); a credential with declared scopes is injected only if it overlaps `required_scopes`, otherwise entirely absent.
- `SpawnRequest.clear_env: bool` wired into `BareProcessRuntime::spawn` — verified with a real integration test proving a parent-process env var does NOT leak through when `clear_env` is set.
- New `--credential-scopes` CLI flag on `ta run`, with a documented `Some(vec![])`-vs-`None` distinction.
- Swarm sub-goals are unconditionally scope-narrowed; ordinary single-goal runs stay opt-in via the flag.
- The scope handoff reaches the nested `ta run` respawn's own leaf agent spawn, not just the outer wrapper's env.

## Review
Reviewed thoroughly (scope-matching semantics, baseline env allowlist, `Command` construction for injection safety, empty-vs-None CLI handling) — no additional issues found. Noted: `BASELINE_ENV_KEYS` includes `SSH_AUTH_SOCK`, an implicit ambient-credential channel outside the vault's scope model — not a regression, and explicitly in v0.17.6.7's stated scope ("Shell/CLI Credential Isolation, the Dominant Real-World Path"), not this phase's.

## Test plan
- 5 new scope-matching tests, 1 new `clear_env` integration test, 8 new `run.rs` tests, all passing
- Full workspace `build`/`test`/`clippy`/`fmt` clean