### PR TITLE
v0.17.6.3 — Gateway Live Interception + Secret-Substitution Broker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All outcomes must be **observable** (with details and logging) and **actionable*
 
 ## Current State
 
-**Current version**: `0.17.6-alpha.2`
+**Current version**: `0.17.6-alpha.3`
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --phase 4b`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "ta-actions"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "ta-advisor"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "ta-agent-ollama"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "base64",
  "chrono",
@@ -4590,7 +4590,7 @@ dependencies = [
 
 [[package]]
 name = "ta-brain"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "schemars",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "ta-build"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "reqwest",
  "serde",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4702,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-comfyui"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -4762,7 +4762,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unity"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unreal"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -4821,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "age",
  "chrono",
@@ -4840,13 +4840,14 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.20",
+ "toml 0.8.23",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "ta-daemon"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4896,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "ta-data-spec"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "schemars",
  "serde_json",
@@ -4908,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-overlay"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -4922,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-proxy"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -4940,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "ta-decision"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -4951,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4969,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "ta-extension"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4986,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5003,7 +5004,7 @@ dependencies = [
 
 [[package]]
 name = "ta-governed-paths"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -5017,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "ta-init"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5030,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "ta-intake"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "regex",
@@ -5048,7 +5049,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "regex",
@@ -5064,6 +5065,7 @@ dependencies = [
  "ta-connector-fs",
  "ta-connector-unity",
  "ta-connector-unreal",
+ "ta-credentials",
  "ta-decision",
  "ta-events",
  "ta-goal",
@@ -5084,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "serde",
@@ -5099,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "glob",
@@ -5117,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "ta-output-schema"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -5129,7 +5131,7 @@ dependencies = [
 
 [[package]]
 name = "ta-plugin"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "libc",
  "serde",
@@ -5143,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "glob",
@@ -5158,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "ta-release"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "base64",
  "reqwest",
@@ -5174,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "ta-runtime"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5196,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -5209,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "libc",
@@ -5229,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "chrono",
  "libc",
@@ -5249,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5268,7 +5270,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.17.6-alpha.2"
+version = "0.17.6-alpha.3"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -10112,20 +10112,20 @@ Code releases use semver. Content releases don't. Decide:
 
 ---
 ### v0.17.6.3 — Gateway Live Interception + Secret-Substitution Broker (MCP Path)
-<!-- status: in_progress -->
+<!-- status: done -->
 **Depends on**: v0.17.6.2
 
 **Goal**: Build the gateway's actual live pre-dispatch interception/substitution point. **This is new middleware, not an extension of something already running**: `ta-mcp-gateway::ToolCallInterceptor` is constructed and stored today but its `.classify()` is never invoked outside its own tests — it's dead code, same category as `CredentialVault` was before v0.17.6.2. Sized accordingly (larger than a typical single-crate phase) — split into sub-items below rather than one undifferentiated block, and re-split into further sub-phases at execution time if a single goal-run can't carry the whole thing.
 
 **Items**:
-1. [ ] Build the live synchronous interception path: parse the tool call before dispatch, hold/block on an authorization decision, rewrite the outbound payload, relay the response — the actual missing piece, not a wrapper around an existing hook.
-2. [ ] Tool schemas exposed to agents/LLMs carry only symbolic connector ids ("github", "slack-ops"), never `ScopedCredential.value`.
-3. [ ] `ConnectorRegistry` (`.ta/connectors.toml`) with a per-connector `broker_mediated: bool` flag, so migration is connector-by-connector, not a flag day.
-4. [ ] On authorization success, the real secret is attached only to the gateway's own outbound call — never returned to the agent. On a scope deficit, hand off to v0.17.6.6's escalation path instead of a hard failure.
-5. [ ] `bare_process.rs`'s direct env injection becomes an explicitly-flagged reduced-security fallback for non-gateway-mediated connectors, pending v0.17.6.7.
-6. [ ] While this code is being touched: `ta-mediation::ApiMediator` has its own separate, also-unwired `classify()` duplicating `ToolCallInterceptor`'s heuristics — dedupe into one implementation rather than leaving two.
-7. [ ] Tests: a gateway-mediated tool call never contains the raw secret in the agent-visible request or response; an unmediated connector still uses the flagged fallback path without silently failing.
-8. [ ] USAGE.md: document which connectors are broker-mediated and the migration path for adding more.
+1. [x] Build the live synchronous interception path: parse the tool call before dispatch, hold/block on an authorization decision, rewrite the outbound payload, relay the response — the actual missing piece, not a wrapper around an existing hook.
+2. [x] Tool schemas exposed to agents/LLMs carry only symbolic connector ids ("github", "slack-ops"), never `ScopedCredential.value`.
+3. [x] `ConnectorRegistry` (`.ta/connectors.toml`) with a per-connector `broker_mediated: bool` flag, so migration is connector-by-connector, not a flag day.
+4. [x] On authorization success, the real secret is attached only to the gateway's own outbound call — never returned to the agent. On a scope deficit, hand off to v0.17.6.6's escalation path instead of a hard failure.
+5. [x] `bare_process.rs`'s direct env injection becomes an explicitly-flagged reduced-security fallback for non-gateway-mediated connectors, pending v0.17.6.7.
+6. [x] While this code is being touched: `ta-mediation::ApiMediator` has its own separate, also-unwired `classify()` duplicating `ToolCallInterceptor`'s heuristics — dedupe into one implementation rather than leaving two.
+7. [x] Tests: a gateway-mediated tool call never contains the raw secret in the agent-visible request or response; an unmediated connector still uses the flagged fallback path without silently failing.
+8. [x] USAGE.md: document which connectors are broker-mediated and the migration path for adding more.
 
 #### Version: `0.17.6-alpha.3`
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -43,34 +43,34 @@ which = { workspace = true }
 arboard = { workspace = true }
 
 # Internal crates — version kept in sync with workspace by bump-version.sh
-ta-audit = { path = "../../crates/ta-audit", version = "0.17.6-alpha.2" }
-ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.6-alpha.2" }
-ta-memory = { path = "../../crates/ta-memory", version = "0.17.6-alpha.2" }
-ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.6-alpha.2" }
-ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.6-alpha.2" }
-ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.6-alpha.2" }
-ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.6-alpha.2" }
-ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.6-alpha.2" }
-ta-goal = { path = "../../crates/ta-goal", version = "0.17.6-alpha.2" }
-ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.6-alpha.2" }
-ta-policy = { path = "../../crates/ta-policy", version = "0.17.6-alpha.2" }
-ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.6-alpha.2" }
-ta-session = { path = "../../crates/ta-session", version = "0.17.6-alpha.2" }
-ta-events = { path = "../../crates/ta-events", version = "0.17.6-alpha.2" }
-ta-submit = { path = "../../crates/ta-submit", version = "0.17.6-alpha.2" }
-ta-decision = { path = "../../crates/ta-decision", version = "0.17.6-alpha.2" }
-ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.6-alpha.2" }
-ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.6-alpha.2" }
-ta-build = { path = "../../crates/ta-build", version = "0.17.6-alpha.2" }
-ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.6-alpha.2" }
-ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.6-alpha.2" }
-ta-init = { path = "../../crates/ta-init", version = "0.17.6-alpha.2" }
-ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.6-alpha.2" }
-ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.6-alpha.2" }
-ta-intake = { path = "../../crates/ta-intake", version = "0.17.6-alpha.2" }
-ta-brain = { path = "../../crates/ta-brain", version = "0.17.6-alpha.2" }
-ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.6-alpha.2" }
-ta-release = { path = "../../crates/ta-release", version = "0.17.6-alpha.2" }
+ta-audit = { path = "../../crates/ta-audit", version = "0.17.6-alpha.3" }
+ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.6-alpha.3" }
+ta-memory = { path = "../../crates/ta-memory", version = "0.17.6-alpha.3" }
+ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.6-alpha.3" }
+ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.6-alpha.3" }
+ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.6-alpha.3" }
+ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.6-alpha.3" }
+ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.6-alpha.3" }
+ta-goal = { path = "../../crates/ta-goal", version = "0.17.6-alpha.3" }
+ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.6-alpha.3" }
+ta-policy = { path = "../../crates/ta-policy", version = "0.17.6-alpha.3" }
+ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.6-alpha.3" }
+ta-session = { path = "../../crates/ta-session", version = "0.17.6-alpha.3" }
+ta-events = { path = "../../crates/ta-events", version = "0.17.6-alpha.3" }
+ta-submit = { path = "../../crates/ta-submit", version = "0.17.6-alpha.3" }
+ta-decision = { path = "../../crates/ta-decision", version = "0.17.6-alpha.3" }
+ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.6-alpha.3" }
+ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.6-alpha.3" }
+ta-build = { path = "../../crates/ta-build", version = "0.17.6-alpha.3" }
+ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.6-alpha.3" }
+ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.6-alpha.3" }
+ta-init = { path = "../../crates/ta-init", version = "0.17.6-alpha.3" }
+ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.6-alpha.3" }
+ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.6-alpha.3" }
+ta-intake = { path = "../../crates/ta-intake", version = "0.17.6-alpha.3" }
+ta-brain = { path = "../../crates/ta-brain", version = "0.17.6-alpha.3" }
+ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.6-alpha.3" }
+ta-release = { path = "../../crates/ta-release", version = "0.17.6-alpha.3" }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -4944,6 +4944,12 @@ fn load_vault_credentials(
     let Ok(summaries) = vault.list() else {
         return Vec::new();
     };
+    // v0.17.6.3: connectors declared `broker_mediated = true` in
+    // `.ta/connectors.toml` withhold the raw secret from the agent's env
+    // entirely (see `ta_runtime::apply_credentials_to_env`) — the agent
+    // presents the minted session token to `ta_external_action` instead,
+    // and the gateway broker resolves the real secret server-side.
+    let connector_registry = ta_credentials::ConnectorRegistry::load(&project_root.join(".ta"));
     summaries
         .into_iter()
         .filter_map(|summary| {
@@ -4983,8 +4989,15 @@ fn load_vault_credentials(
                 return None;
             }
 
+            let broker_mediated = connector_registry.is_broker_mediated_credential(&summary.name);
             vault.get(summary.id).ok().map(|full| {
-                ta_runtime::ScopedCredential::with_scopes(full.name, full.secret, full.scopes)
+                let cred =
+                    ta_runtime::ScopedCredential::with_scopes(full.name, full.secret, full.scopes);
+                if broker_mediated {
+                    cred.with_broker_mediation(token.token_id.to_string())
+                } else {
+                    cred
+                }
             })
         })
         .collect()

--- a/crates/ta-actions/Cargo.toml
+++ b/crates/ta-actions/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 toml = { workspace = true }
-ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.2" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-actions/src/action.rs
+++ b/crates/ta-actions/src/action.rs
@@ -90,6 +90,28 @@ pub trait ExternalAction: Send + Sync {
     /// Built-in stubs return `Err(ActionError::StubOnly(...))`.
     /// Plugin implementations perform the real I/O here.
     fn execute(&self, payload: &Value) -> Result<Value, ActionError>;
+
+    /// Execute the action with an optional broker-resolved secret attached
+    /// (v0.17.6.3, gateway secret-substitution broker).
+    ///
+    /// `secret` is `Some(..)` only when the caller (`ta_external_action`'s
+    /// dispatch path) resolved a `broker_mediated` connector's real secret
+    /// via the credential vault after authorizing the request's session
+    /// token — never sourced from the agent-supplied `payload`. An
+    /// implementation that needs the secret to make its own outbound call
+    /// (e.g. `AdapterPluginAction` attaching it to its subprocess's
+    /// environment for that one call) overrides this method; every other
+    /// implementation keeps using plain `execute()` via this default,
+    /// which discards `secret` entirely — the secret must never appear in
+    /// the returned `Value`, since that value is relayed straight back to
+    /// the agent.
+    fn execute_with_secret(
+        &self,
+        payload: &Value,
+        _secret: Option<&str>,
+    ) -> Result<Value, ActionError> {
+        self.execute(payload)
+    }
 }
 
 // ── Built-in stubs ───────────────────────────────────────────────────────────

--- a/crates/ta-actions/src/plugin_action.rs
+++ b/crates/ta-actions/src/plugin_action.rs
@@ -92,6 +92,19 @@ impl AdapterPluginAction {
     }
 
     fn call(&self, method: &str, payload: &Value) -> Result<Value, ActionError> {
+        self.call_with_env(method, payload, &[])
+    }
+
+    /// Same as `call`, plus extra environment variables set only on this
+    /// one subprocess invocation (v0.17.6.3) — used to attach a
+    /// broker-resolved secret without it ever entering `payload` or the
+    /// `PluginResponse` relayed back to the agent.
+    fn call_with_env(
+        &self,
+        method: &str,
+        payload: &Value,
+        extra_env: &[(String, String)],
+    ) -> Result<Value, ActionError> {
         let request = PluginRequest::new(
             method,
             json!(VerbParams {
@@ -99,7 +112,7 @@ impl AdapterPluginAction {
                 payload,
             }),
         );
-        let response: PluginResponse = ta_plugin::transport::call_json(
+        let response: PluginResponse = ta_plugin::transport::call_json_with_env(
             &self.plugin_name,
             method,
             &self.command,
@@ -107,6 +120,7 @@ impl AdapterPluginAction {
             &self.work_dir,
             &request,
             self.timeout,
+            extra_env,
         )
         .map_err(|e| {
             ActionError::Execution(format!(
@@ -155,6 +169,26 @@ impl ExternalAction for AdapterPluginAction {
 
     fn execute(&self, payload: &Value) -> Result<Value, ActionError> {
         self.call("execute", payload)
+    }
+
+    /// Attach a broker-resolved connector secret (v0.17.6.3) to this one
+    /// subprocess call as `TA_CONNECTOR_SECRET`, never touching `payload`
+    /// or the plugin's `PluginResponse` — the plugin script reads it from
+    /// its own environment for the outbound call it makes, and that's the
+    /// only place it exists outside the vault.
+    fn execute_with_secret(
+        &self,
+        payload: &Value,
+        secret: Option<&str>,
+    ) -> Result<Value, ActionError> {
+        match secret {
+            Some(s) => self.call_with_env(
+                "execute",
+                payload,
+                &[("TA_CONNECTOR_SECRET".to_string(), s.to_string())],
+            ),
+            None => self.call("execute", payload),
+        }
     }
 }
 
@@ -367,6 +401,68 @@ else:
             .unwrap();
         assert_eq!(fill["status"], "filled");
         assert_eq!(fill["venue"], "paper-trading-mock");
+    }
+
+    /// v0.17.6.3: `execute_with_secret` must attach the secret only as an
+    /// env var on the plugin's own subprocess call — never as part of the
+    /// request payload, and the plugin's response (echoed back verbatim by
+    /// this fixture) must never be assumed safe by the caller either, but
+    /// this test focuses on proving the *transport* mechanism actually
+    /// delivers `TA_CONNECTOR_SECRET` into the subprocess environment.
+    const ENV_ECHO_PLUGIN: &str = r#"
+import json
+import os
+import sys
+
+line = sys.stdin.readline()
+req = json.loads(line)
+method = req["method"]
+
+if method == "execute":
+    secret = os.environ.get("TA_CONNECTOR_SECRET", "")
+    result = {"saw_secret": secret == "s3cr3t-value"}
+    print(json.dumps({"ok": True, "result": result}))
+else:
+    print(json.dumps({"ok": False, "error": f"unknown method {method}"}))
+"#;
+
+    #[test]
+    fn execute_with_secret_passes_secret_via_subprocess_env_not_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = write_mock_plugin(
+            dir.path(),
+            "broker-test",
+            &["trade.execute"],
+            ENV_ECHO_PLUGIN,
+        );
+        let manifest = PluginManifest::load(&plugin_dir.join("plugin.toml")).unwrap();
+        let action = AdapterPluginAction::new("trade.execute", &manifest, &plugin_dir);
+
+        let payload = json!({"symbol": "ACME"});
+        let result = action
+            .execute_with_secret(&payload, Some("s3cr3t-value"))
+            .unwrap();
+        assert_eq!(result["saw_secret"], json!(true));
+
+        // The payload sent to the plugin never carried the secret itself --
+        // only the env var did (asserted above via the plugin's own check).
+        assert!(!payload.to_string().contains("s3cr3t-value"));
+    }
+
+    #[test]
+    fn execute_with_secret_none_behaves_like_plain_execute() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = write_mock_plugin(
+            dir.path(),
+            "broker-test",
+            &["trade.execute"],
+            ENV_ECHO_PLUGIN,
+        );
+        let manifest = PluginManifest::load(&plugin_dir.join("plugin.toml")).unwrap();
+        let action = AdapterPluginAction::new("trade.execute", &manifest, &plugin_dir);
+
+        let result = action.execute_with_secret(&json!({}), None).unwrap();
+        assert_eq!(result["saw_secret"], json!(false));
     }
 
     #[test]

--- a/crates/ta-advisor/Cargo.toml
+++ b/crates/ta-advisor/Cargo.toml
@@ -17,12 +17,12 @@ tracing = { workspace = true }
 
 # Reuses the existing heuristic classifier as the substrate for the new
 # 4-way taxonomy rather than duplicating keyword-matching logic.
-ta-session = { path = "../ta-session", version = "0.17.6-alpha.2" }
+ta-session = { path = "../ta-session", version = "0.17.6-alpha.3" }
 # Team-coordinator capability (v0.17.0.12.20): reuses ta-intake's TriggerEvent
 # and ta-brain's routing/prioritization rather than a new persistent role —
 # see crates/ta-advisor/src/coordinator.rs for the decision rationale.
-ta-intake = { path = "../ta-intake", version = "0.17.6-alpha.2" }
-ta-brain = { path = "../ta-brain", version = "0.17.6-alpha.2" }
+ta-intake = { path = "../ta-intake", version = "0.17.6-alpha.3" }
+ta-brain = { path = "../ta-brain", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-brain/Cargo.toml
+++ b/crates/ta-brain/Cargo.toml
@@ -18,13 +18,13 @@ chrono = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
-ta-session = { path = "../ta-session", version = "0.17.6-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.2" }
-ta-intake = { path = "../ta-intake", version = "0.17.6-alpha.2" }
+ta-session = { path = "../ta-session", version = "0.17.6-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
+ta-intake = { path = "../ta-intake", version = "0.17.6-alpha.3" }
 # Folds ta-workflow's template-matching intent resolver in as one signal
 # route() consults (v0.17.0.12.23), rather than a second, parallel intent
 # system — see route.rs's resolve_workflow_template().
-ta-workflow = { path = "../ta-workflow", version = "0.17.6-alpha.2" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-changeset/src/lib.rs
+++ b/crates/ta-changeset/src/lib.rs
@@ -42,6 +42,7 @@ pub mod sources;
 pub mod supervisor;
 pub mod supervisor_review;
 pub mod terminal_channel;
+pub mod tool_classify;
 pub mod uri_pattern;
 pub mod webhook_channel;
 
@@ -96,6 +97,7 @@ pub use supervisor_review::{
     load_constitution, SupervisorReview, SupervisorRunConfig, SupervisorVerdict,
 };
 pub use terminal_channel::{AutoApproveChannel, TerminalChannel, TerminalSessionChannel};
+pub use tool_classify::{classify_tool_name, ToolCallCategory};
 pub use uri_pattern::{filter_uris, matches_uri};
 pub use webhook_channel::WebhookChannel;
 

--- a/crates/ta-changeset/src/tool_classify.rs
+++ b/crates/ta-changeset/src/tool_classify.rs
@@ -1,0 +1,106 @@
+// tool_classify.rs — shared MCP tool-name classification heuristic (v0.17.6.3).
+//
+// `ta-mcp-gateway::ToolCallInterceptor` and `ta-mediation::ApiMediator` each
+// independently maintained their own name-pattern heuristic for guessing
+// whether a tool call is read-only, state-changing, irreversible, or an
+// external side effect. Same idea, two copies that could silently drift.
+// This module is the one implementation both now call.
+
+/// Category a tool name is classified into by suffix/substring pattern.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolCallCategory {
+    /// Read-only: safe to pass through without capture (e.g. `_list`, `_get`).
+    ReadOnly,
+    /// Cannot be undone once executed (e.g. `_send`, `_delete`).
+    Irreversible,
+    /// Affects a system outside TA's control but is not classified
+    /// irreversible (e.g. `_create`, `_update`).
+    ExternalSideEffect,
+    /// Some other mutating operation (e.g. `_write`).
+    StateChanging,
+    /// No pattern matched — caller decides the safe default.
+    Unclassified,
+}
+
+const READ_PATTERNS: &[&str] = &[
+    "_read", "_get", "_list", "_search", "_find", "_query", "_fetch",
+];
+const IRREVERSIBLE_PATTERNS: &[&str] = &["_send", "_publish", "_tweet", "_delete", "_drop"];
+const EXTERNAL_PATTERNS: &[&str] = &["_post", "_create", "_update", "_put", "_patch", "_upload"];
+const STATE_CHANGING_PATTERNS: &[&str] = &["_write"];
+
+fn matches_any(tool_name: &str, patterns: &[&str]) -> bool {
+    patterns
+        .iter()
+        .any(|p| tool_name.ends_with(p) || tool_name.contains(p))
+}
+
+/// Classify a tool name by suffix/substring pattern.
+///
+/// Checked in order: read-only, then irreversible, then external-side-effect,
+/// then generic state-changing. A name matching none of these is
+/// `Unclassified` — callers decide what "no information" means for them
+/// (e.g. capture-by-default vs. pass through).
+pub fn classify_tool_name(tool_name: &str) -> ToolCallCategory {
+    if matches_any(tool_name, READ_PATTERNS) {
+        ToolCallCategory::ReadOnly
+    } else if matches_any(tool_name, IRREVERSIBLE_PATTERNS) {
+        ToolCallCategory::Irreversible
+    } else if matches_any(tool_name, EXTERNAL_PATTERNS) {
+        ToolCallCategory::ExternalSideEffect
+    } else if matches_any(tool_name, STATE_CHANGING_PATTERNS) {
+        ToolCallCategory::StateChanging
+    } else {
+        ToolCallCategory::Unclassified
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_patterns_classified_read_only() {
+        assert_eq!(
+            classify_tool_name("gmail_search"),
+            ToolCallCategory::ReadOnly
+        );
+        assert_eq!(classify_tool_name("drive_list"), ToolCallCategory::ReadOnly);
+    }
+
+    #[test]
+    fn irreversible_patterns_classified_irreversible() {
+        assert_eq!(
+            classify_tool_name("gmail_send"),
+            ToolCallCategory::Irreversible
+        );
+        assert_eq!(
+            classify_tool_name("db_delete"),
+            ToolCallCategory::Irreversible
+        );
+    }
+
+    #[test]
+    fn external_patterns_classified_external_side_effect() {
+        assert_eq!(
+            classify_tool_name("jira_create"),
+            ToolCallCategory::ExternalSideEffect
+        );
+    }
+
+    #[test]
+    fn write_pattern_classified_state_changing() {
+        assert_eq!(
+            classify_tool_name("cache_write"),
+            ToolCallCategory::StateChanging
+        );
+    }
+
+    #[test]
+    fn unknown_tool_is_unclassified() {
+        assert_eq!(
+            classify_tool_name("custom_tool"),
+            ToolCallCategory::Unclassified
+        );
+    }
+}

--- a/crates/ta-connectors/comfyui/Cargo.toml
+++ b/crates/ta-connectors/comfyui/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.6-alpha.2" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/discord/Cargo.toml
+++ b/crates/ta-connectors/discord/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.6-alpha.2" }
+ta-events = { path = "../../ta-events", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/email/Cargo.toml
+++ b/crates/ta-connectors/email/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.6-alpha.2" }
+ta-events = { path = "../../ta-events", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/fs/Cargo.toml
+++ b/crates/ta-connectors/fs/Cargo.toml
@@ -16,10 +16,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.6-alpha.2" }
-ta-workspace = { path = "../../ta-workspace", version = "0.17.6-alpha.2" }
-ta-audit = { path = "../../ta-audit", version = "0.17.6-alpha.2" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.6-alpha.3" }
+ta-workspace = { path = "../../ta-workspace", version = "0.17.6-alpha.3" }
+ta-audit = { path = "../../ta-audit", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-ta-policy = { path = "../../ta-policy", version = "0.17.6-alpha.2" }
+ta-policy = { path = "../../ta-policy", version = "0.17.6-alpha.3" }

--- a/crates/ta-connectors/slack/Cargo.toml
+++ b/crates/ta-connectors/slack/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.6-alpha.2" }
+ta-events = { path = "../../ta-events", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/unreal/Cargo.toml
+++ b/crates/ta-connectors/unreal/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.6-alpha.2" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-credentials/Cargo.toml
+++ b/crates/ta-credentials/Cargo.toml
@@ -19,6 +19,7 @@ sha2 = { workspace = true }
 tracing = { workspace = true }
 age = { workspace = true }
 keyring = { workspace = true }
+toml = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-credentials/src/connector_registry.rs
+++ b/crates/ta-credentials/src/connector_registry.rs
@@ -1,0 +1,195 @@
+// connector_registry.rs — symbolic connector-id -> credential/broker mapping
+// (v0.17.6.3, PLAN item 3).
+//
+// `ta_external_action` and similar MCP tool schemas expose only symbolic
+// connector ids to the agent (e.g. "github", "slack-ops") — never a
+// `Credential.secret` value. This registry, loaded from
+// `<project_root>/.ta/connectors.toml`, is what maps a symbolic id back to
+// the vault credential that actually backs it, and declares whether that
+// connector's secret is resolved server-side by the gateway broker
+// (`broker_mediated = true`) or still reaches the agent process directly via
+// `bare_process.rs`'s env-injection fallback (`broker_mediated = false`,
+// the default — migration is connector-by-connector, not a flag day).
+//
+// Example `.ta/connectors.toml`:
+//
+// ```toml
+// [connectors.github]
+// credential_name = "GITHUB_TOKEN"
+// broker_mediated = true
+// required_scope = "repo.write"
+//
+// [connectors.slack-ops]
+// credential_name = "SLACK_BOT_TOKEN"
+// broker_mediated = false
+// ```
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// Registry entry for one symbolic connector id.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectorEntry {
+    /// Name of the vault `Credential` (see `ta_credentials::Credential.name`)
+    /// backing this connector.
+    pub credential_name: String,
+
+    /// Whether the gateway broker resolves and attaches this connector's
+    /// secret itself (never returning it to the agent), or leaves the
+    /// credential to reach the agent process the old way, via
+    /// `bare_process.rs`'s direct env-injection fallback. Defaults to
+    /// `false` so declaring a connector doesn't silently change its
+    /// security posture — migration is explicit, connector-by-connector.
+    #[serde(default)]
+    pub broker_mediated: bool,
+
+    /// Scope string required to invoke this connector through the broker
+    /// (checked against the caller's `SessionToken.allowed_scopes`). Only
+    /// consulted when `broker_mediated` is `true`.
+    #[serde(default)]
+    pub required_scope: Option<String>,
+}
+
+/// Every connector declared in `.ta/connectors.toml`, keyed by symbolic id.
+///
+/// Access via [`ConnectorRegistry::load`] — returns an empty registry
+/// (never an error) when the file is missing or unparsable, matching
+/// `ta_actions::ActionPolicies::load`'s safe-default behavior.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ConnectorRegistry {
+    #[serde(default)]
+    pub connectors: HashMap<String, ConnectorEntry>,
+}
+
+impl ConnectorRegistry {
+    /// Load the registry from `<ta_dir>/connectors.toml`.
+    ///
+    /// A missing file or a parse failure both fall back to an empty
+    /// registry (logged at `warn` for the parse-failure case) rather than
+    /// erroring — the safe default when a connector isn't declared is "not
+    /// broker-mediated, no known credential", which every lookup call site
+    /// already handles explicitly.
+    pub fn load(ta_dir: &Path) -> Self {
+        let path = ta_dir.join("connectors.toml");
+        if !path.exists() {
+            return Self::default();
+        }
+        match std::fs::read_to_string(&path) {
+            Ok(content) => Self::parse(&content),
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "failed to read connectors.toml; using empty connector registry"
+                );
+                Self::default()
+            }
+        }
+    }
+
+    fn parse(content: &str) -> Self {
+        match toml::from_str::<Self>(content) {
+            Ok(registry) => registry,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "failed to parse connectors.toml; using empty connector registry"
+                );
+                Self::default()
+            }
+        }
+    }
+
+    /// Look up a connector by its symbolic id.
+    pub fn get(&self, connector_id: &str) -> Option<&ConnectorEntry> {
+        self.connectors.get(connector_id)
+    }
+
+    /// Whether `credential_name` is declared as `broker_mediated = true` by
+    /// any connector entry. Used by `bare_process.rs`'s env-injection path
+    /// to decide whether a credential must be withheld from the agent's
+    /// direct environment (v0.17.6.3 item 5).
+    pub fn is_broker_mediated_credential(&self, credential_name: &str) -> bool {
+        self.connectors
+            .values()
+            .any(|c| c.credential_name == credential_name && c.broker_mediated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_returns_empty_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = ConnectorRegistry::load(dir.path());
+        assert!(registry.connectors.is_empty());
+    }
+
+    #[test]
+    fn parses_broker_mediated_and_fallback_connectors() {
+        let toml = r#"
+[connectors.github]
+credential_name = "GITHUB_TOKEN"
+broker_mediated = true
+required_scope = "repo.write"
+
+[connectors.slack-ops]
+credential_name = "SLACK_BOT_TOKEN"
+"#;
+        let registry = ConnectorRegistry::parse(toml);
+
+        let github = registry.get("github").unwrap();
+        assert!(github.broker_mediated);
+        assert_eq!(github.required_scope.as_deref(), Some("repo.write"));
+
+        let slack = registry.get("slack-ops").unwrap();
+        assert!(
+            !slack.broker_mediated,
+            "broker_mediated must default to false"
+        );
+        assert_eq!(slack.required_scope, None);
+
+        assert!(registry.get("unknown").is_none());
+    }
+
+    #[test]
+    fn load_from_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("connectors.toml"),
+            b"[connectors.github]\ncredential_name = \"GITHUB_TOKEN\"\nbroker_mediated = true\n",
+        )
+        .unwrap();
+        let registry = ConnectorRegistry::load(dir.path());
+        assert!(registry.get("github").unwrap().broker_mediated);
+    }
+
+    #[test]
+    fn malformed_toml_falls_back_to_empty_registry() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("connectors.toml"), b"not valid toml [[[").unwrap();
+        let registry = ConnectorRegistry::load(dir.path());
+        assert!(registry.connectors.is_empty());
+    }
+
+    #[test]
+    fn is_broker_mediated_credential_checks_across_all_connectors() {
+        let toml = r#"
+[connectors.github]
+credential_name = "GITHUB_TOKEN"
+broker_mediated = true
+
+[connectors.slack-ops]
+credential_name = "SLACK_BOT_TOKEN"
+broker_mediated = false
+"#;
+        let registry = ConnectorRegistry::parse(toml);
+        assert!(registry.is_broker_mediated_credential("GITHUB_TOKEN"));
+        assert!(!registry.is_broker_mediated_credential("SLACK_BOT_TOKEN"));
+        assert!(!registry.is_broker_mediated_credential("UNDECLARED_TOKEN"));
+    }
+}

--- a/crates/ta-credentials/src/lib.rs
+++ b/crates/ta-credentials/src/lib.rs
@@ -20,12 +20,14 @@
 //! ```
 
 pub mod config;
+pub mod connector_registry;
 pub mod encryption;
 pub mod error;
 pub mod file_vault;
 pub mod vault;
 
 pub use config::CredentialsConfig;
+pub use connector_registry::{ConnectorEntry, ConnectorRegistry};
 pub use encryption::KeyCustody;
 pub use error::VaultError;
 pub use file_vault::FileVault;

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -31,23 +31,23 @@ async-stream = { workspace = true }
 sha2 = { workspace = true }
 
 # Internal crates
-ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.6-alpha.2" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.2" }
-ta-memory = { path = "../ta-memory", version = "0.17.6-alpha.2" }
-ta-events = { path = "../ta-events", version = "0.17.6-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.2" }
-ta-runtime = { path = "../ta-runtime", version = "0.17.6-alpha.2" }
-ta-audit = { path = "../ta-audit", version = "0.17.6-alpha.2" }
-ta-policy = { path = "../ta-policy", version = "0.17.6-alpha.2" }
-ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.6-alpha.2" }
-ta-connector-email = { path = "../ta-connectors/email", version = "0.17.6-alpha.2" }
+ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.6-alpha.3" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
+ta-memory = { path = "../ta-memory", version = "0.17.6-alpha.3" }
+ta-events = { path = "../ta-events", version = "0.17.6-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
+ta-runtime = { path = "../ta-runtime", version = "0.17.6-alpha.3" }
+ta-audit = { path = "../ta-audit", version = "0.17.6-alpha.3" }
+ta-policy = { path = "../ta-policy", version = "0.17.6-alpha.3" }
+ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.6-alpha.3" }
+ta-connector-email = { path = "../ta-connectors/email", version = "0.17.6-alpha.3" }
 reqwest = { workspace = true }
-ta-output-schema = { path = "../ta-output-schema", version = "0.17.6-alpha.2" }
-ta-extension = { path = "../ta-extension", version = "0.17.6-alpha.2" }
-ta-session = { path = "../ta-session", version = "0.17.6-alpha.2" }
-ta-advisor = { path = "../ta-advisor", version = "0.17.6-alpha.2" }
-ta-data-spec = { path = "../ta-data-spec", version = "0.17.6-alpha.2" }
+ta-output-schema = { path = "../ta-output-schema", version = "0.17.6-alpha.3" }
+ta-extension = { path = "../ta-extension", version = "0.17.6-alpha.3" }
+ta-session = { path = "../ta-session", version = "0.17.6-alpha.3" }
+ta-advisor = { path = "../ta-advisor", version = "0.17.6-alpha.3" }
+ta-data-spec = { path = "../ta-data-spec", version = "0.17.6-alpha.3" }
 which = "7"
 libc = { workspace = true }
 async-trait = "0.1"

--- a/crates/ta-data-spec/Cargo.toml
+++ b/crates/ta-data-spec/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 [dependencies]
 schemars = { workspace = true }
 serde_json = { workspace = true }
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.2" }
-ta-brain = { path = "../ta-brain", version = "0.17.6-alpha.2" }
-ta-intake = { path = "../ta-intake", version = "0.17.6-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
+ta-brain = { path = "../ta-brain", version = "0.17.6-alpha.3" }
+ta-intake = { path = "../ta-intake", version = "0.17.6-alpha.3" }

--- a/crates/ta-db-proxy/Cargo.toml
+++ b/crates/ta-db-proxy/Cargo.toml
@@ -17,10 +17,10 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.6-alpha.2" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.2" }
-ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.2" }
-ta-actions = { path = "../ta-actions", version = "0.17.6-alpha.2" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.6-alpha.3" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.3" }
+ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.3" }
+ta-actions = { path = "../ta-actions", version = "0.17.6-alpha.3" }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ta-intake/Cargo.toml
+++ b/crates/ta-intake/Cargo.toml
@@ -19,8 +19,8 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 regex = { workspace = true }
-ta-submit = { path = "../ta-submit", version = "0.17.6-alpha.2" }
-ta-events = { path = "../ta-events", version = "0.17.6-alpha.2" }
+ta-submit = { path = "../ta-submit", version = "0.17.6-alpha.3" }
+ta-events = { path = "../ta-events", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -25,22 +25,23 @@ which = { workspace = true }
 toml = { workspace = true }
 
 # Internal crates
-ta-audit = { path = "../ta-audit", version = "0.17.6-alpha.2" }
-ta-events = { path = "../ta-events", version = "0.17.6-alpha.2" }
-ta-memory = { path = "../ta-memory", version = "0.17.6-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.2" }
-ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.6-alpha.2" }
-ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.6-alpha.2" }
-ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.6-alpha.2" }
-ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.6-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.2" }
-ta-policy = { path = "../ta-policy", version = "0.17.6-alpha.2" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.2" }
-ta-workflow = { path = "../ta-workflow", version = "0.17.6-alpha.2" }
-ta-actions = { path = "../ta-actions", version = "0.17.6-alpha.2" }
-ta-submit = { path = "../ta-submit", version = "0.17.6-alpha.2" }
-ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.2" }
-ta-session = { path = "../ta-session", version = "0.17.6-alpha.2" }
+ta-audit = { path = "../ta-audit", version = "0.17.6-alpha.3" }
+ta-events = { path = "../ta-events", version = "0.17.6-alpha.3" }
+ta-memory = { path = "../ta-memory", version = "0.17.6-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
+ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.6-alpha.3" }
+ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.6-alpha.3" }
+ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.6-alpha.3" }
+ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.6-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
+ta-policy = { path = "../ta-policy", version = "0.17.6-alpha.3" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.3" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.6-alpha.3" }
+ta-actions = { path = "../ta-actions", version = "0.17.6-alpha.3" }
+ta-submit = { path = "../ta-submit", version = "0.17.6-alpha.3" }
+ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.3" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.6-alpha.3" }
+ta-session = { path = "../ta-session", version = "0.17.6-alpha.3" }
 
 
 [dev-dependencies]

--- a/crates/ta-mcp-gateway/src/config.rs
+++ b/crates/ta-mcp-gateway/src/config.rs
@@ -53,6 +53,21 @@ pub struct GatewayConfig {
     /// Set via the `TA_IS_STAGING` environment variable.
     #[serde(default)]
     pub is_staging: bool,
+
+    /// Whether the credential vault (opened by the v0.17.6.3 connector
+    /// broker to resolve broker-mediated secrets) should try the OS
+    /// keychain for its encryption key before falling back to a
+    /// chmod-0600 file. Defaults to `true` for real deployments; test
+    /// fixtures set this `false` for the same reason
+    /// `ta_credentials::CredentialsConfig::use_keychain` documents — the
+    /// keychain is a process/OS-global resource that must not leak between
+    /// tests or interfere with the developer's real keychain.
+    #[serde(default = "default_credential_vault_use_keychain")]
+    pub credential_vault_use_keychain: bool,
+}
+
+fn default_credential_vault_use_keychain() -> bool {
+    true
 }
 
 impl GatewayConfig {
@@ -72,6 +87,7 @@ impl GatewayConfig {
             review_channel: ReviewChannelConfig::default(),
             web_ui_port: None,
             is_staging: std::env::var("TA_IS_STAGING").is_ok(),
+            credential_vault_use_keychain: true,
         }
     }
 }

--- a/crates/ta-mcp-gateway/src/interceptor.rs
+++ b/crates/ta-mcp-gateway/src/interceptor.rs
@@ -10,6 +10,7 @@ use chrono::Utc;
 use uuid::Uuid;
 
 use ta_changeset::draft_package::{ActionKind, PendingAction};
+use ta_changeset::tool_classify::{classify_tool_name, ToolCallCategory};
 
 /// Classifies MCP tool calls and produces PendingAction records for
 /// state-changing calls.
@@ -72,29 +73,18 @@ impl ToolCallInterceptor {
     }
 
     /// Determine the action kind for a tool call.
+    ///
+    /// Delegates the name-pattern heuristic to `ta_changeset::tool_classify`
+    /// (v0.17.6.3) — shared with `ta-mediation::ApiMediator`, which used to
+    /// carry its own independently-drifting copy of the same patterns.
     fn classify_kind(&self, tool_name: &str) -> ActionKind {
-        // Tools with common read-only patterns.
-        let read_patterns = [
-            "_read", "_get", "_list", "_search", "_find", "_query", "_fetch",
-        ];
-        for pattern in &read_patterns {
-            if tool_name.ends_with(pattern) || tool_name.contains(pattern) {
-                return ActionKind::ReadOnly;
-            }
+        match classify_tool_name(tool_name) {
+            ToolCallCategory::ReadOnly => ActionKind::ReadOnly,
+            ToolCallCategory::Irreversible
+            | ToolCallCategory::ExternalSideEffect
+            | ToolCallCategory::StateChanging => ActionKind::StateChanging,
+            ToolCallCategory::Unclassified => ActionKind::Unclassified,
         }
-
-        // Tools with common write patterns.
-        let write_patterns = [
-            "_send", "_post", "_create", "_update", "_delete", "_write", "_put", "_patch",
-            "_publish", "_tweet", "_upload",
-        ];
-        for pattern in &write_patterns {
-            if tool_name.ends_with(pattern) || tool_name.contains(pattern) {
-                return ActionKind::StateChanging;
-            }
-        }
-
-        ActionKind::Unclassified
     }
 
     /// Generate a human-readable description of the tool call.

--- a/crates/ta-mcp-gateway/src/server.rs
+++ b/crates/ta-mcp-gateway/src/server.rs
@@ -307,6 +307,21 @@ pub struct ExternalActionParams {
     /// dispatch — absent for actions with no cost/quantity dimension.
     #[serde(default)]
     pub budget: Option<tools::human_verify::BudgetActionParams>,
+    /// Symbolic connector id (e.g. `"github"`, `"slack-ops"`) declared in
+    /// `.ta/connectors.toml` (v0.17.6.3). This — never a raw credential
+    /// value — is the only credential-shaped thing this schema exposes to
+    /// the calling agent/LLM. When the connector is `broker_mediated`, the
+    /// gateway resolves and attaches the real secret itself, only to its
+    /// own outbound call, and never returns it here.
+    #[serde(default)]
+    pub connector: Option<String>,
+    /// Session token id minted for a broker-mediated `connector` (the
+    /// `TA_SESSION_TOKEN_<name>` value the agent received in its own
+    /// environment at spawn time — see `ta_runtime::apply_credentials_to_env`).
+    /// Required, and independently re-validated against the credential
+    /// vault, whenever `connector` names a `broker_mediated` entry.
+    #[serde(default)]
+    pub session_token: Option<String>,
 }
 
 /// Tracks an active agent session within the gateway (v0.9.6).

--- a/crates/ta-mcp-gateway/src/tools/action.rs
+++ b/crates/ta-mcp-gateway/src/tools/action.rs
@@ -320,7 +320,14 @@ pub fn handle_external_action(
             }
 
             ActionPolicy::Auto => {
-                dispatch_auto_action(&state.config.workspace_root, &params, action_impl)?
+                let requesting_agent_id = goal_run_id.and_then(|id| state.agent_for_goal(id).ok());
+                dispatch_auto_action(
+                    &state.config.workspace_root,
+                    &params,
+                    action_impl,
+                    requesting_agent_id.as_deref(),
+                    state.config.credential_vault_use_keychain,
+                )?
             }
         }
     };
@@ -403,6 +410,8 @@ fn dispatch_auto_action(
     workspace_root: &Path,
     params: &ExternalActionParams,
     action_impl: &dyn ta_actions::ExternalAction,
+    requesting_agent_id: Option<&str>,
+    credential_vault_use_keychain: bool,
 ) -> Result<(ActionOutcome, Option<PendingAction>), McpError> {
     // Business-metric budget hard-limit pre-gate — deterministic, runs
     // before any risk scoring (mirrors `ta_human_verify`'s ordering: a
@@ -434,6 +443,36 @@ fn dispatch_auto_action(
             BudgetCheckResult::Ok => {}
         }
     }
+
+    // Gateway live interception / secret-substitution broker (v0.17.6.3):
+    // deterministic pre-gate, same "runs before any risk scoring" ordering
+    // as the budget hard limit above — a connector authorization decision
+    // is a mechanical scope comparison, not something an LLM judgment call
+    // (the risk gate below) should be able to override.
+    let secret_for_execute = match resolve_connector_authorization(
+        workspace_root,
+        params,
+        requesting_agent_id,
+        credential_vault_use_keychain,
+    ) {
+        ConnectorAuthorization::Error(e) => return Err(e),
+        ConnectorAuthorization::ScopeDeficit { description } => {
+            let action_id = Uuid::new_v4();
+            let pending = PendingAction {
+                action_id,
+                tool_name: format!("ta_external_action:{}", params.action_type),
+                parameters: params.payload.clone(),
+                kind: ActionKind::StateChanging,
+                intercepted_at: Utc::now(),
+                description,
+                target_uri: params.target_uri.clone(),
+                disposition: ArtifactDisposition::Pending,
+            };
+            return Ok((ActionOutcome::CapturedForReview, Some(pending)));
+        }
+        ConnectorAuthorization::NotBrokered => None,
+        ConnectorAuthorization::Authorized { secret } => Some(secret),
+    };
 
     let RiskAssessment {
         risk_score,
@@ -511,7 +550,7 @@ fn dispatch_auto_action(
         return Ok((ActionOutcome::CapturedForReview, Some(pending)));
     }
 
-    match action_impl.execute(&params.payload) {
+    match action_impl.execute_with_secret(&params.payload, secret_for_execute.as_deref()) {
         Ok(result) => {
             if let Some(budget_params) = &params.budget {
                 let ledger_path = workspace_root.join(&budget_params.ledger_path);
@@ -549,6 +588,173 @@ fn dispatch_auto_action(
             format!("action execution failed: {}", e),
             None,
         )),
+    }
+}
+
+// ── Gateway live interception / secret-substitution broker (v0.17.6.3) ───────
+
+/// Outcome of authorizing `params.connector` against the credential vault
+/// and `ConnectorRegistry` before an auto-policy action is dispatched.
+enum ConnectorAuthorization {
+    /// No `connector` was declared, or the declared connector exists but is
+    /// not `broker_mediated` — dispatch proceeds via the existing
+    /// `bare_process.rs` env-injection fallback (v0.17.6.3 item 5), not the
+    /// broker.
+    NotBrokered,
+    /// The connector is `broker_mediated`, the presented `session_token`
+    /// validated, and its scope covers the connector's `required_scope`.
+    /// `secret` is the resolved `Credential.secret` — attach it only to the
+    /// gateway's own outbound call, never return it to the agent.
+    Authorized { secret: String },
+    /// The session token is valid but its `allowed_scopes` don't cover the
+    /// connector's `required_scope`. Per PLAN item 4 ("hand off to
+    /// v0.17.6.6's escalation path instead of a hard failure"): captured
+    /// for human review rather than denied outright. Full `ta_human_verify`
+    /// integration lands with v0.17.6.6 — until then this is the same
+    /// captured-for-review fallback the risk gate itself uses below.
+    ScopeDeficit { description: String },
+    /// A hard, actionable failure: unknown connector, missing/invalid/
+    /// expired/mismatched session token, or an unreadable vault. Unlike a
+    /// scope deficit, none of these represent "the agent knows what it's
+    /// doing but needs more privilege" — they're malformed requests.
+    Error(McpError),
+}
+
+/// Authorize `params.connector` for an auto-policy dispatch and, on
+/// success, resolve the real secret to attach to the gateway's own
+/// outbound call (v0.17.6.3 items 1/2/4).
+///
+/// A request that doesn't declare `connector` at all is unaffected —
+/// `ConnectorAuthorization::NotBrokered` — so this is purely additive for
+/// callers that don't opt into broker mediation yet.
+fn resolve_connector_authorization(
+    workspace_root: &Path,
+    params: &ExternalActionParams,
+    requesting_agent_id: Option<&str>,
+    credential_vault_use_keychain: bool,
+) -> ConnectorAuthorization {
+    use ta_credentials::CredentialVault;
+
+    let Some(connector_id) = params.connector.as_deref() else {
+        return ConnectorAuthorization::NotBrokered;
+    };
+
+    let registry = ta_credentials::ConnectorRegistry::load(&workspace_root.join(".ta"));
+    let Some(entry) = registry.get(connector_id) else {
+        return ConnectorAuthorization::Error(McpError::invalid_params(
+            format!(
+                "unknown connector '{connector_id}' — declare it under \
+                 [connectors.{connector_id}] in .ta/connectors.toml before referencing it \
+                 from ta_external_action (see docs/USAGE.md 'Broker-Mediated Connectors')"
+            ),
+            None,
+        ));
+    };
+
+    if !entry.broker_mediated {
+        tracing::debug!(
+            connector = connector_id,
+            "connector is not broker_mediated; dispatch falls through to the \
+             non-gateway-mediated reduced-security fallback (pending v0.17.6.7)"
+        );
+        return ConnectorAuthorization::NotBrokered;
+    }
+
+    let Some(session_token) = params.session_token.as_deref() else {
+        return ConnectorAuthorization::Error(McpError::invalid_params(
+            format!(
+                "connector '{connector_id}' is broker_mediated — a session_token is \
+                 required (the agent receives one via TA_SESSION_TOKEN_<credential> in its \
+                 own environment; see docs/USAGE.md 'Broker-Mediated Connectors')"
+            ),
+            None,
+        ));
+    };
+    let Ok(token_id) = Uuid::parse_str(session_token) else {
+        return ConnectorAuthorization::Error(McpError::invalid_params(
+            format!("session_token '{session_token}' is not a valid token id"),
+            None,
+        ));
+    };
+
+    let mut cred_config = ta_credentials::CredentialsConfig::for_project(workspace_root);
+    cred_config.use_keychain = credential_vault_use_keychain;
+    let Ok(vault) = ta_credentials::FileVault::open(&cred_config) else {
+        return ConnectorAuthorization::Error(McpError::internal_error(
+            format!(
+                "connector '{connector_id}' is broker_mediated but the credential vault at \
+                 {} could not be opened",
+                cred_config.vault_path.display()
+            ),
+            None,
+        ));
+    };
+
+    let token = match vault.validate_token(token_id) {
+        Ok(t) => t,
+        Err(e) => {
+            return ConnectorAuthorization::Error(McpError::invalid_params(
+                format!(
+                    "session_token for connector '{connector_id}' failed validation: {e} \
+                     (tokens expire — mint a fresh one via `ta credentials grant`)"
+                ),
+                None,
+            ));
+        }
+    };
+
+    if let Some(agent_id) = requesting_agent_id {
+        if token.agent_id != agent_id {
+            return ConnectorAuthorization::Error(McpError::invalid_params(
+                format!(
+                    "session_token for connector '{connector_id}' was issued to a different \
+                     agent ('{}') than the requesting goal's agent ('{agent_id}')",
+                    token.agent_id
+                ),
+                None,
+            ));
+        }
+    }
+
+    let credential = match vault.get(token.credential_id) {
+        Ok(c) => c,
+        Err(e) => {
+            return ConnectorAuthorization::Error(McpError::internal_error(
+                format!("failed to resolve credential for connector '{connector_id}': {e}"),
+                None,
+            ));
+        }
+    };
+    if credential.name != entry.credential_name {
+        return ConnectorAuthorization::Error(McpError::invalid_params(
+            format!(
+                "session_token for connector '{connector_id}' does not back the credential \
+                 that connector declares ('{}' expected, token backs '{}') — this connector's \
+                 session_token cannot be used for a different connector's credential",
+                entry.credential_name, credential.name
+            ),
+            None,
+        ));
+    }
+
+    if let Some(required_scope) = &entry.required_scope {
+        if !token.allowed_scopes.iter().any(|s| s == required_scope) {
+            return ConnectorAuthorization::ScopeDeficit {
+                description: format!(
+                    "ta_external_action:{} via connector '{connector_id}' requires scope \
+                     '{required_scope}', but the presented session token only allows {:?} — \
+                     requires credential scope elevation. Captured for manual review rather \
+                     than auto-denied (structured human escalation via ta_human_verify lands \
+                     in v0.17.6.6); a reviewer can re-grant a wider-scoped token via \
+                     `ta credentials grant`.",
+                    params.action_type, token.allowed_scopes
+                ),
+            };
+        }
+    }
+
+    ConnectorAuthorization::Authorized {
+        secret: credential.secret,
     }
 }
 
@@ -713,7 +919,13 @@ mod tests {
     use crate::server::GatewayState;
 
     fn make_state(root: &std::path::Path) -> Arc<Mutex<GatewayState>> {
-        let config = GatewayConfig::for_project(root);
+        let mut config = GatewayConfig::for_project(root);
+        // Force file-based key custody for the credential vault: the OS
+        // keychain is a process/OS-global resource (see
+        // `ta_credentials::CredentialsConfig::use_keychain`'s own doc
+        // comment) that must not leak between tests or interfere with the
+        // developer's real keychain.
+        config.credential_vault_use_keychain = false;
         let state = GatewayState::new(config).expect("state init failed");
         Arc::new(Mutex::new(state))
     }
@@ -752,6 +964,8 @@ mod tests {
             target_uri: None,
             dry_run: false,
             budget: None,
+            connector: None,
+            session_token: None,
         };
 
         let result = handle_external_action(&state, params);
@@ -770,6 +984,8 @@ mod tests {
             target_uri: None,
             dry_run: false,
             budget: None,
+            connector: None,
+            session_token: None,
         };
 
         let result = handle_external_action(&state, params);
@@ -788,6 +1004,8 @@ mod tests {
             target_uri: None,
             dry_run: true,
             budget: None,
+            connector: None,
+            session_token: None,
         };
 
         let result = handle_external_action(&state, params).unwrap();
@@ -823,6 +1041,8 @@ mod tests {
             target_uri: None,
             dry_run: false,
             budget: None,
+            connector: None,
+            session_token: None,
         };
 
         let result = handle_external_action(&state, params).unwrap();
@@ -861,6 +1081,8 @@ mod tests {
             target_uri: None,
             dry_run: false,
             budget: None,
+            connector: None,
+            session_token: None,
         };
 
         let result = handle_external_action(&state, params).unwrap();
@@ -894,6 +1116,8 @@ mod tests {
             target_uri: None,
             dry_run: false,
             budget: None,
+            connector: None,
+            session_token: None,
         };
 
         // First two should succeed (review).
@@ -938,6 +1162,8 @@ mod tests {
             target_uri: None,
             dry_run: false,
             budget: None,
+            connector: None,
+            session_token: None,
         };
 
         let result = handle_external_action(&state, params).unwrap();
@@ -984,6 +1210,8 @@ mod tests {
             target_uri: None,
             dry_run: false,
             budget: None,
+            connector: None,
+            session_token: None,
         };
 
         let result = handle_external_action(&state, params).unwrap();
@@ -1083,6 +1311,8 @@ else:
             target_uri: None,
             dry_run: false,
             budget: None,
+            connector: None,
+            session_token: None,
         };
 
         let result = handle_external_action(&state, params).unwrap();
@@ -1122,6 +1352,8 @@ else:
             target_uri: None,
             dry_run: false,
             budget: None,
+            connector: None,
+            session_token: None,
         };
 
         let result = handle_external_action(&state, params).unwrap();
@@ -1151,6 +1383,8 @@ else:
             target_uri: None,
             dry_run: false,
             budget: None,
+            connector: None,
+            session_token: None,
         };
 
         // No plugin registered under .ta/plugins/adapter/ -- must be a
@@ -1161,6 +1395,321 @@ else:
             message.contains("no adapter registered for this verb"),
             "expected a clear 'no adapter registered' error, got: {}",
             message
+        );
+    }
+
+    // ── v0.17.6.3: gateway live interception / secret-substitution broker ──
+
+    /// A `connector.execute` adapter plugin whose `execute` method reports
+    /// whether it saw a secret via `TA_CONNECTOR_SECRET` -- never echoing
+    /// the secret itself back in its result, matching how a real connector
+    /// plugin (e.g. calling GitHub with the resolved token) would behave.
+    fn write_broker_test_plugin(workspace_root: &std::path::Path) {
+        let plugin_dir = workspace_root
+            .join(".ta")
+            .join("plugins")
+            .join("adapter")
+            .join("broker-test");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        let script_path = plugin_dir.join("mock_plugin.py");
+        std::fs::write(
+            &script_path,
+            r#"
+import json
+import os
+import sys
+
+req = json.loads(sys.stdin.readline())
+method = req["method"]
+
+if method == "risk_score":
+    print(json.dumps({"ok": True, "result": {"risk_score": 0, "confidence": 1.0}}))
+elif method == "execute":
+    secret = os.environ.get("TA_CONNECTOR_SECRET", "")
+    result = {"saw_secret": len(secret) > 0, "secret_len": len(secret)}
+    print(json.dumps({"ok": True, "result": result}))
+else:
+    print(json.dumps({"ok": False, "error": f"unknown method {method}"}))
+"#,
+        )
+        .unwrap();
+        let mut manifest = toml::Table::new();
+        manifest.insert("name".into(), "broker-test".into());
+        manifest.insert("type".into(), "adapter".into());
+        manifest.insert("command".into(), "python3".into());
+        manifest.insert(
+            "args".into(),
+            toml::Value::Array(vec![script_path.to_string_lossy().to_string().into()]),
+        );
+        manifest.insert(
+            "capabilities".into(),
+            toml::Value::Array(vec!["verb:connector.execute".into()]),
+        );
+        std::fs::write(
+            plugin_dir.join("plugin.toml"),
+            toml::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// Opens (creating if needed) a file-key-custody vault for a test
+    /// workspace -- `use_keychain: false` keeps tests off the real, process-
+    /// global OS keychain.
+    fn open_test_vault(workspace_root: &std::path::Path) -> ta_credentials::FileVault {
+        let mut cred_config = ta_credentials::CredentialsConfig::for_project(workspace_root);
+        cred_config.use_keychain = false;
+        ta_credentials::FileVault::open(&cred_config).unwrap()
+    }
+
+    #[test]
+    fn broker_mediated_connector_never_returns_raw_secret_to_agent() {
+        use ta_credentials::CredentialVault;
+
+        let dir = tempdir().unwrap();
+        let ta_dir = dir.path().join(".ta");
+        std::fs::create_dir_all(&ta_dir).unwrap();
+        std::fs::write(
+            ta_dir.join("workflow.toml"),
+            b"[actions.\"connector.execute\"]\npolicy = \"auto\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ta_dir.join("connectors.toml"),
+            b"[connectors.paper-trading]\n\
+              credential_name = \"PAPER_API_KEY\"\n\
+              broker_mediated = true\n\
+              required_scope = \"trade.write\"\n",
+        )
+        .unwrap();
+        write_broker_test_plugin(dir.path());
+        write_routing_decision(dir.path(), "auto");
+
+        let mut vault = open_test_vault(dir.path());
+        let cred = vault
+            .add(
+                "PAPER_API_KEY",
+                "paper-trading",
+                "sk-live-supersecret-do-not-leak",
+                vec!["trade.write".into()],
+            )
+            .unwrap();
+        let token = vault
+            .issue_token(cred.id, "test-agent", vec!["trade.write".into()], 3600)
+            .unwrap();
+
+        let state = make_state(dir.path());
+        let params = ExternalActionParams {
+            action_type: "connector.execute".into(),
+            payload: json!({}),
+            goal_run_id: None,
+            target_uri: None,
+            dry_run: false,
+            budget: None,
+            connector: Some("paper-trading".into()),
+            session_token: Some(token.token_id.to_string()),
+        };
+
+        let result = handle_external_action(&state, params).unwrap();
+        assert!(!result.is_error.unwrap_or(false));
+        let text = serde_json::to_string(&result.content[0]).unwrap();
+
+        assert!(
+            !text.contains("sk-live-supersecret-do-not-leak"),
+            "the raw secret must never appear in the agent-visible response: {}",
+            text
+        );
+        assert!(
+            text.contains("executed") && text.contains(r#"\"saw_secret\":true"#),
+            "expected the plugin to have received the secret server-side and executed: {}",
+            text
+        );
+
+        // The action log (which the agent can also read back via other
+        // tools) must not carry the raw secret either -- only the request
+        // payload TA actually captured, which never contained it.
+        let log = std::fs::read_to_string(ta_dir.join("action-log.jsonl")).unwrap();
+        assert!(!log.contains("sk-live-supersecret-do-not-leak"));
+    }
+
+    #[test]
+    fn broker_mediated_connector_with_missing_token_is_a_clear_actionable_error() {
+        let dir = tempdir().unwrap();
+        let ta_dir = dir.path().join(".ta");
+        std::fs::create_dir_all(&ta_dir).unwrap();
+        std::fs::write(
+            ta_dir.join("workflow.toml"),
+            b"[actions.\"connector.execute\"]\npolicy = \"auto\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ta_dir.join("connectors.toml"),
+            b"[connectors.paper-trading]\n\
+              credential_name = \"PAPER_API_KEY\"\n\
+              broker_mediated = true\n",
+        )
+        .unwrap();
+        write_broker_test_plugin(dir.path());
+        write_routing_decision(dir.path(), "auto");
+
+        let state = make_state(dir.path());
+        let params = ExternalActionParams {
+            action_type: "connector.execute".into(),
+            payload: json!({}),
+            goal_run_id: None,
+            target_uri: None,
+            dry_run: false,
+            budget: None,
+            connector: Some("paper-trading".into()),
+            session_token: None,
+        };
+
+        let err = handle_external_action(&state, params).unwrap_err();
+        assert!(
+            err.message
+                .to_string()
+                .contains("session_token is required"),
+            "expected an actionable 'session_token is required' error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn broker_mediated_connector_scope_deficit_is_captured_for_review_not_denied() {
+        use ta_credentials::CredentialVault;
+
+        let dir = tempdir().unwrap();
+        let ta_dir = dir.path().join(".ta");
+        std::fs::create_dir_all(&ta_dir).unwrap();
+        std::fs::write(
+            ta_dir.join("workflow.toml"),
+            b"[actions.\"connector.execute\"]\npolicy = \"auto\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ta_dir.join("connectors.toml"),
+            b"[connectors.paper-trading]\n\
+              credential_name = \"PAPER_API_KEY\"\n\
+              broker_mediated = true\n\
+              required_scope = \"trade.write\"\n",
+        )
+        .unwrap();
+        write_broker_test_plugin(dir.path());
+        write_routing_decision(dir.path(), "auto");
+
+        let mut vault = open_test_vault(dir.path());
+        // Credential/token exist, but the token was only granted a narrower
+        // scope than the connector requires.
+        let cred = vault
+            .add(
+                "PAPER_API_KEY",
+                "paper-trading",
+                "sk-live-supersecret-do-not-leak",
+                vec!["trade.read".into(), "trade.write".into()],
+            )
+            .unwrap();
+        let token = vault
+            .issue_token(cred.id, "test-agent", vec!["trade.read".into()], 3600)
+            .unwrap();
+
+        let state = make_state(dir.path());
+        let params = ExternalActionParams {
+            action_type: "connector.execute".into(),
+            payload: json!({}),
+            goal_run_id: None,
+            target_uri: None,
+            dry_run: false,
+            budget: None,
+            connector: Some("paper-trading".into()),
+            session_token: Some(token.token_id.to_string()),
+        };
+
+        let result = handle_external_action(&state, params).unwrap();
+        assert!(
+            !result.is_error.unwrap_or(false),
+            "a scope deficit is not a hard failure"
+        );
+        let text = serde_json::to_string(&result.content[0]).unwrap();
+        assert!(
+            text.contains("captured_for_review"),
+            "expected captured_for_review, not a hard denial: {}",
+            text
+        );
+        assert!(!text.contains("sk-live-supersecret-do-not-leak"));
+    }
+
+    #[test]
+    fn undeclared_connector_returns_clear_actionable_error() {
+        let dir = tempdir().unwrap();
+        let ta_dir = dir.path().join(".ta");
+        std::fs::create_dir_all(&ta_dir).unwrap();
+        std::fs::write(
+            ta_dir.join("workflow.toml"),
+            b"[actions.\"connector.execute\"]\npolicy = \"auto\"\n",
+        )
+        .unwrap();
+        write_broker_test_plugin(dir.path());
+        write_routing_decision(dir.path(), "auto");
+
+        let state = make_state(dir.path());
+        let params = ExternalActionParams {
+            action_type: "connector.execute".into(),
+            payload: json!({}),
+            goal_run_id: None,
+            target_uri: None,
+            dry_run: false,
+            budget: None,
+            connector: Some("never-declared".into()),
+            session_token: None,
+        };
+
+        let err = handle_external_action(&state, params).unwrap_err();
+        assert!(
+            err.message.to_string().contains("unknown connector"),
+            "expected an actionable 'unknown connector' error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn non_broker_mediated_connector_falls_through_to_existing_dispatch_unchanged() {
+        let dir = tempdir().unwrap();
+        let ta_dir = dir.path().join(".ta");
+        std::fs::create_dir_all(&ta_dir).unwrap();
+        std::fs::write(
+            ta_dir.join("workflow.toml"),
+            b"[actions.\"connector.execute\"]\npolicy = \"auto\"\n",
+        )
+        .unwrap();
+        // Declared, but not broker_mediated -- the reduced-security
+        // fallback (item 5): no session_token required, dispatch proceeds
+        // exactly as it did before this connector existed.
+        std::fs::write(
+            ta_dir.join("connectors.toml"),
+            b"[connectors.slack-ops]\ncredential_name = \"SLACK_BOT_TOKEN\"\n",
+        )
+        .unwrap();
+        write_broker_test_plugin(dir.path());
+        write_routing_decision(dir.path(), "auto");
+
+        let state = make_state(dir.path());
+        let params = ExternalActionParams {
+            action_type: "connector.execute".into(),
+            payload: json!({}),
+            goal_run_id: None,
+            target_uri: None,
+            dry_run: false,
+            budget: None,
+            connector: Some("slack-ops".into()),
+            session_token: None,
+        };
+
+        let result = handle_external_action(&state, params).unwrap();
+        assert!(!result.is_error.unwrap_or(false), "must not silently fail");
+        let text = serde_json::to_string(&result.content[0]).unwrap();
+        assert!(
+            text.contains("executed") && text.contains(r#"\"saw_secret\":false"#),
+            "expected a normal, secret-less execution: {}",
+            text
         );
     }
 }

--- a/crates/ta-mediation/Cargo.toml
+++ b/crates/ta-mediation/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates for FsMediator
-ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.2" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-mediation/src/api_mediator.rs
+++ b/crates/ta-mediation/src/api_mediator.rs
@@ -69,32 +69,19 @@ impl ApiMediator {
 
     /// Classify a tool call based on name patterns.
     ///
-    /// Uses the same heuristics as ToolCallInterceptor.
+    /// Delegates to `ta_changeset::tool_classify` (v0.17.6.3) — the same
+    /// heuristic `ToolCallInterceptor` uses, previously duplicated here with
+    /// its own independently-maintained pattern lists.
     fn classify_tool(tool_name: &str) -> ActionClassification {
-        let read_patterns = [
-            "_read", "_get", "_list", "_search", "_find", "_query", "_fetch",
-        ];
-        for pattern in &read_patterns {
-            if tool_name.ends_with(pattern) || tool_name.contains(pattern) {
-                return ActionClassification::ReadOnly;
+        match ta_changeset::tool_classify::classify_tool_name(tool_name) {
+            ta_changeset::ToolCallCategory::ReadOnly => ActionClassification::ReadOnly,
+            ta_changeset::ToolCallCategory::Irreversible => ActionClassification::Irreversible,
+            ta_changeset::ToolCallCategory::ExternalSideEffect => {
+                ActionClassification::ExternalSideEffect
             }
+            ta_changeset::ToolCallCategory::StateChanging
+            | ta_changeset::ToolCallCategory::Unclassified => ActionClassification::StateChanging,
         }
-
-        let irreversible_patterns = ["_send", "_publish", "_tweet", "_delete", "_drop"];
-        for pattern in &irreversible_patterns {
-            if tool_name.ends_with(pattern) || tool_name.contains(pattern) {
-                return ActionClassification::Irreversible;
-            }
-        }
-
-        let external_patterns = ["_post", "_create", "_update", "_put", "_patch", "_upload"];
-        for pattern in &external_patterns {
-            if tool_name.ends_with(pattern) || tool_name.contains(pattern) {
-                return ActionClassification::ExternalSideEffect;
-            }
-        }
-
-        ActionClassification::StateChanging
     }
 
     /// Generate a human-readable description of what a tool call would do.

--- a/crates/ta-plugin/src/transport.rs
+++ b/crates/ta-plugin/src/transport.rs
@@ -16,10 +16,18 @@ use std::time::Duration;
 
 const ETXTBSY_BACKOFF_MS: [u64; 4] = [0, 20, 80, 200];
 
-fn spawn_with_retry(
+/// Spawn `command` with `extra_args`, retrying on `ETXTBSY` (transient
+/// "text file busy" errors from spawning a script that's mid-write on some
+/// platforms), plus extra environment variables merged
+/// into the child's inherited environment (v0.17.6.3) — used to attach a
+/// broker-resolved secret to a single plugin subprocess call without it
+/// ever appearing in the request/response JSON that's relayed back to the
+/// caller.
+fn spawn_with_retry_env(
     command: &str,
     extra_args: &[String],
     work_dir: &Path,
+    extra_env: &[(String, String)],
 ) -> Result<Child, PluginError> {
     let mut parts = command.split_whitespace();
     let program = parts.next().ok_or_else(|| PluginError::SpawnFailed {
@@ -40,6 +48,9 @@ fn spawn_with_retry(
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        for (key, value) in extra_env {
+            cmd.env(key, value);
+        }
         match cmd.spawn() {
             Ok(child) => return Ok(child),
             Err(e) if e.raw_os_error() == Some(26) => {
@@ -105,7 +116,35 @@ pub fn call_raw(
     request_line: &str,
     timeout: Duration,
 ) -> Result<String, PluginError> {
-    let mut child = spawn_with_retry(command, extra_args, work_dir)?;
+    call_raw_with_env(
+        name,
+        method,
+        command,
+        extra_args,
+        work_dir,
+        request_line,
+        timeout,
+        &[],
+    )
+}
+
+/// Same as [`call_raw`], plus extra environment variables set only on this
+/// one subprocess invocation (v0.17.6.3) — the caller's own process
+/// environment, and the request/response JSON exchanged over stdio, are
+/// both untouched, so a secret passed via `extra_env` never appears in
+/// anything relayed back to whoever invoked `call_raw_with_env`.
+#[allow(clippy::too_many_arguments)]
+pub fn call_raw_with_env(
+    name: &str,
+    method: &str,
+    command: &str,
+    extra_args: &[String],
+    work_dir: &Path,
+    request_line: &str,
+    timeout: Duration,
+    extra_env: &[(String, String)],
+) -> Result<String, PluginError> {
+    let mut child = spawn_with_retry_env(command, extra_args, work_dir, extra_env)?;
     {
         let stdin = child
             .stdin
@@ -174,8 +213,35 @@ pub fn call_json<Req: Serialize, Resp: DeserializeOwned>(
     request: &Req,
     timeout: Duration,
 ) -> Result<Resp, PluginError> {
+    call_json_with_env(
+        name,
+        method,
+        command,
+        extra_args,
+        work_dir,
+        request,
+        timeout,
+        &[],
+    )
+}
+
+/// Same as [`call_json`], plus extra environment variables set only on this
+/// one subprocess invocation (v0.17.6.3) — see [`call_raw_with_env`].
+#[allow(clippy::too_many_arguments)]
+pub fn call_json_with_env<Req: Serialize, Resp: DeserializeOwned>(
+    name: &str,
+    method: &str,
+    command: &str,
+    extra_args: &[String],
+    work_dir: &Path,
+    request: &Req,
+    timeout: Duration,
+    extra_env: &[(String, String)],
+) -> Result<Resp, PluginError> {
     let line = serde_json::to_string(request)?;
-    let response_line = call_raw(name, method, command, extra_args, work_dir, &line, timeout)?;
+    let response_line = call_raw_with_env(
+        name, method, command, extra_args, work_dir, &line, timeout, extra_env,
+    )?;
     serde_json::from_str(&response_line).map_err(|e| PluginError::InvalidResponse {
         name: name.to_string(),
         method: method.to_string(),

--- a/crates/ta-release/Cargo.toml
+++ b/crates/ta-release/Cargo.toml
@@ -18,7 +18,7 @@ toml = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true, features = ["multipart"] }
-ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.2" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-runtime/Cargo.toml
+++ b/crates/ta-runtime/Cargo.toml
@@ -23,8 +23,8 @@ which = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
 
-ta-credentials = { path = "../ta-credentials", version = "0.17.6-alpha.2" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.2" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.6-alpha.3" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.3" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/ta-runtime/src/bare_process.rs
+++ b/crates/ta-runtime/src/bare_process.rs
@@ -250,9 +250,25 @@ fn build_command(command: &str, args: &[String]) -> Command {
 ///   intersect `required_scopes` at all is silently omitted — the caller
 ///   never sees it, not even as an unusable placeholder.
 ///
-/// Each injected credential becomes an environment variable:
-/// `cred.name = cred.value`. Call this before building a `SpawnRequest` to
-/// include credentials.
+/// For an eligible credential, what actually lands in `env` depends on
+/// `cred.broker_mediated` (v0.17.6.3, PLAN item 5):
+/// - `false` (default): the **reduced-security fallback** — `cred.value`
+///   (the raw secret) is injected directly as `cred.name = cred.value`,
+///   exactly as before v0.17.6.3. This path is explicitly flagged via a
+///   `tracing::warn!` so it shows up in normal operation, not just an audit
+///   grep — it remains the only delivery path until a per-tool credential
+///   shim (v0.17.6.7) or an explicit `ConnectorRegistry` opt-in closes it
+///   for a given connector.
+/// - `true`: the raw secret is withheld entirely. Instead
+///   `TA_SESSION_TOKEN_<cred.name> = cred.session_token_id` is injected —
+///   an opaque reference the agent can present to `ta_external_action`,
+///   which the gateway broker independently validates and resolves the
+///   real secret for server-side. A `broker_mediated` credential with no
+///   `session_token_id` is a caller bug (nothing to hand the agent) and is
+///   skipped with a `tracing::warn!` rather than silently leaking nothing
+///   useful or crashing the spawn.
+///
+/// Call this before building a `SpawnRequest` to include credentials.
 pub fn apply_credentials_to_env(
     env: &mut HashMap<String, String>,
     creds: &[ScopedCredential],
@@ -261,7 +277,38 @@ pub fn apply_credentials_to_env(
     for cred in creds {
         let in_scope =
             cred.scopes.is_empty() || cred.scopes.iter().any(|s| required_scopes.contains(s));
-        if in_scope {
+        if !in_scope {
+            continue;
+        }
+        if cred.broker_mediated {
+            match &cred.session_token_id {
+                Some(token_id) => {
+                    env.insert(format!("TA_SESSION_TOKEN_{}", cred.name), token_id.clone());
+                }
+                None => {
+                    tracing::warn!(
+                        credential = %cred.name,
+                        "credential is broker_mediated but carries no session_token_id; \
+                         withheld from agent env entirely (neither raw secret nor token)"
+                    );
+                }
+            }
+        } else {
+            // debug, not warn: this is still the default path for every
+            // credential that has no `.ta/connectors.toml` entry opting it
+            // into broker mediation, so warning here would fire on every
+            // spawn for the common case rather than flagging something
+            // unusual. It is still explicitly flagged (a distinct,
+            // greppable message), just at a level that doesn't page anyone
+            // for expected behavior — `ta doctor` is the surfaced,
+            // human-facing flag for "N credentials use the reduced-security
+            // fallback" (see docs/USAGE.md).
+            tracing::debug!(
+                credential = %cred.name,
+                "injecting raw secret directly into agent environment: reduced-security \
+                 fallback for a non-broker-mediated connector (see ConnectorRegistry / \
+                 .ta/connectors.toml to migrate this credential to broker mediation)"
+            );
             env.insert(cred.name.clone(), cred.value.clone());
         }
     }
@@ -449,6 +496,43 @@ mod tests {
         );
 
         assert_eq!(env.get("GITHUB"), Some(&"ghp_token".to_string()));
+    }
+
+    #[test]
+    fn apply_credentials_to_env_withholds_raw_secret_for_broker_mediated_credential() {
+        let mut env = HashMap::new();
+        let creds = vec![ScopedCredential::new("GITHUB_TOKEN", "ghp_real_secret")
+            .with_broker_mediation("22222222-2222-2222-2222-222222222222")];
+        apply_credentials_to_env(&mut env, &creds, &[]);
+
+        assert!(
+            !env.values().any(|v| v == "ghp_real_secret"),
+            "the raw secret must never reach the agent env for a broker-mediated credential"
+        );
+        assert!(
+            !env.contains_key("GITHUB_TOKEN"),
+            "broker-mediated credentials are not injected under their own name"
+        );
+        assert_eq!(
+            env.get("TA_SESSION_TOKEN_GITHUB_TOKEN"),
+            Some(&"22222222-2222-2222-2222-222222222222".to_string())
+        );
+    }
+
+    #[test]
+    fn apply_credentials_to_env_broker_mediated_without_token_id_injects_nothing() {
+        let mut env = HashMap::new();
+        // Constructed directly (not via `with_broker_mediation`) to model a
+        // caller bug: `broker_mediated = true` but no token was ever minted.
+        let cred = ScopedCredential::new("GITHUB_TOKEN", "ghp_real_secret");
+        let mut cred = cred;
+        cred.broker_mediated = true;
+        apply_credentials_to_env(&mut env, &[cred], &[]);
+
+        assert!(
+            env.is_empty(),
+            "must withhold entirely, not fall back to the raw secret"
+        );
     }
 
     #[test]

--- a/crates/ta-runtime/src/credential.rs
+++ b/crates/ta-runtime/src/credential.rs
@@ -27,6 +27,26 @@ pub struct ScopedCredential {
     /// The agent sees the credential but TA's policy layer limits what it
     /// can do with it to these declared scopes.
     pub scopes: Vec<String>,
+
+    /// Whether this credential is declared `broker_mediated` by a
+    /// `ConnectorRegistry` entry (v0.17.6.3). When `true`,
+    /// `apply_credentials_to_env` withholds `value` from the agent's direct
+    /// environment entirely — the agent must instead present
+    /// `session_token_id` to `ta_external_action`, and the gateway broker
+    /// resolves the real secret server-side. Defaults to `false`
+    /// (unchanged, reduced-security env-injection behavior) so declaring a
+    /// connector doesn't silently change any existing credential's
+    /// delivery path.
+    #[serde(default)]
+    pub broker_mediated: bool,
+
+    /// The `SessionToken.token_id` (as a string) minted for this
+    /// credential, present only when `broker_mediated` is `true`. This is
+    /// the only credential-shaped value the agent ever receives for a
+    /// broker-mediated connector — an opaque, independently-verifiable
+    /// reference, never `value` itself.
+    #[serde(default)]
+    pub session_token_id: Option<String>,
 }
 
 impl ScopedCredential {
@@ -36,6 +56,8 @@ impl ScopedCredential {
             name: name.into(),
             value: value.into(),
             scopes: Vec::new(),
+            broker_mediated: false,
+            session_token_id: None,
         }
     }
 
@@ -49,7 +71,19 @@ impl ScopedCredential {
             name: name.into(),
             value: value.into(),
             scopes,
+            broker_mediated: false,
+            session_token_id: None,
         }
+    }
+
+    /// Mark this credential broker-mediated (v0.17.6.3): `value` is
+    /// withheld from the agent's direct environment by
+    /// `apply_credentials_to_env`, and `session_token_id` is delivered
+    /// instead.
+    pub fn with_broker_mediation(mut self, session_token_id: impl Into<String>) -> Self {
+        self.broker_mediated = true;
+        self.session_token_id = Some(session_token_id.into());
+        self
     }
 }
 
@@ -74,5 +108,23 @@ mod tests {
         );
         assert_eq!(cred.scopes.len(), 2);
         assert_eq!(cred.scopes[0], "repo.read");
+        assert!(!cred.broker_mediated);
+        assert!(cred.session_token_id.is_none());
+    }
+
+    #[test]
+    fn with_broker_mediation_sets_flag_and_token_clears_no_value_change() {
+        let cred = ScopedCredential::new("GITHUB_TOKEN", "ghp_real_secret")
+            .with_broker_mediation("11111111-1111-1111-1111-111111111111");
+        assert!(cred.broker_mediated);
+        assert_eq!(
+            cred.session_token_id.as_deref(),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
+        // `value` is untouched by this call -- callers that mark a
+        // credential broker-mediated are expected to also blank/ignore
+        // `value` themselves before handing it to `apply_credentials_to_env`,
+        // which is what actually enforces the withholding.
+        assert_eq!(cred.value, "ghp_real_secret");
     }
 }

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }
-ta-policy = { path = "../ta-policy", version = "0.17.6-alpha.2" }
+ta-policy = { path = "../ta-policy", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-session/Cargo.toml
+++ b/crates/ta-session/Cargo.toml
@@ -25,9 +25,9 @@ notify = { workspace = true }
 toml = { workspace = true }
 
 # Workspace crates
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.2" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.2" }
-ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
+ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -16,11 +16,11 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.2" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.2" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.2" }
-ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.3" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.3" }
+ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.3" }
 toml = "0.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/ta-workflow/Cargo.toml
+++ b/crates/ta-workflow/Cargo.toml
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -21,8 +21,8 @@ reqwest = { workspace = true }
 anyhow = { workspace = true }
 sha2 = "0.10"
 base64 = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.2" }
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: 0.17.6-alpha.2
+**Version**: 0.17.6-alpha.3
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 
@@ -7357,6 +7357,86 @@ the nested `ta run` process each sub-goal spawns receives the same
 `--credential-scopes` value explicitly and applies the identical scope
 filter to its own eventual agent spawn -- clearing the environment there too
 -- rather than relying solely on what the parent process happened to strip.
+
+#### Broker-Mediated Connectors
+
+Even with `--credential-scopes` narrowing which credentials an agent
+process's environment can see, every credential that *is* injected still
+lands there as a **raw secret value** -- the agent, and the LLM driving it,
+can read it directly and can embed it verbatim in any MCP tool call, where
+it's visible again in the staged JSON a human later reviews. Broker
+mediation (v0.17.6.3) closes that specific leak for connectors used through
+`ta_external_action`: the agent never holds the real secret at all, only a
+symbolic connector id and an opaque session token.
+
+Declare a connector in `.ta/connectors.toml`:
+
+```toml
+[connectors.github]
+credential_name = "GITHUB_TOKEN"   # matches the `--name` used in `ta credentials add`
+broker_mediated = true
+required_scope = "repo.write"      # checked against the session token's allowed_scopes
+
+[connectors.slack-ops]
+credential_name = "SLACK_BOT_TOKEN"
+# broker_mediated omitted -> defaults to false: the reduced-security
+# fallback below, unchanged from pre-v0.17.6.3 behavior.
+```
+
+`broker_mediated` defaults to `false` -- adding a `[connectors.*]` entry at
+all does not change a credential's delivery path by itself. Migration is
+connector-by-connector: only credentials backing a connector explicitly
+marked `broker_mediated = true` are withheld from the agent's environment.
+
+**How the two paths differ:**
+
+| | `broker_mediated = false` (default) | `broker_mediated = true` |
+|---|---|---|
+| What the agent's env contains | `GITHUB_TOKEN=ghp_...` (the raw secret) | `TA_SESSION_TOKEN_GITHUB_TOKEN=<token-id>` (opaque) |
+| What `ta_external_action` needs | Nothing connector-specific | `connector: "github"`, `session_token: "<token-id>"` |
+| Where the real secret is attached | Wherever the agent's own process/plugin script chooses to use the env var | Only to the gateway's own outbound call to the connector's plugin, as `TA_CONNECTOR_SECRET` on that one subprocess invocation |
+| Does the secret ever appear in the agent-visible request or response? | Potentially -- nothing stops the agent from echoing it | Never |
+
+The `broker_mediated = false` path is the same env-injection behavior TA
+has always had -- kept as an explicitly-flagged reduced-security fallback
+(logged at `debug`) until a per-tool credential shim (v0.17.6.7, for the
+dominant `git push`/`gh pr create`/`curl` shell-command case that never
+touches `ta_external_action` at all) closes it more broadly.
+
+**End-to-end flow for a broker-mediated connector:**
+
+1. `ta run` mints a session token for the credential as usual (see above),
+   but because `.ta/connectors.toml` marks it `broker_mediated`, the agent's
+   environment receives `TA_SESSION_TOKEN_GITHUB_TOKEN=<token-id>` instead
+   of the raw `GITHUB_TOKEN` value.
+2. The agent calls `ta_external_action` with `connector: "github"` and
+   `session_token: "<token-id>"` (read from its own environment) alongside
+   the normal `action_type`/`payload`.
+3. The gateway independently re-validates the token against the credential
+   vault (expiry, and that it was issued to this same agent), confirms it
+   backs the `github` connector's declared credential, and checks
+   `required_scope` against the token's `allowed_scopes`.
+4. On success, the gateway resolves the real secret and attaches it only to
+   its own call into the connector's adapter plugin (as `TA_CONNECTOR_SECRET`
+   on that one subprocess invocation) -- never into the request payload, and
+   never back into the response relayed to the agent.
+5. If the requested scope exceeds what the token allows, the action is
+   **captured for human review** rather than hard-denied -- the same
+   `ta draft view` pending-actions surface other auto-policy actions use.
+   Full structured escalation through `ta_human_verify` lands in v0.17.6.6;
+   until then, a reviewer re-grants a wider-scoped token via
+   `ta credentials grant` to unblock it.
+6. Calling `ta_external_action` with an undeclared `connector`, or a
+   `broker_mediated` connector missing/lacking a valid `session_token`,
+   returns a clear, actionable error rather than silently falling back to
+   the raw-secret path.
+
+Adapter plugins (v0.17.5.3, `.ta/plugins/adapter/<name>/plugin.toml`) read
+the broker-resolved secret from their own subprocess environment as
+`TA_CONNECTOR_SECRET` -- it is never part of the JSON payload/result
+exchanged with TA, so it cannot end up logged to `.ta/action-log.jsonl` or
+echoed into a plugin's own response by accident (a well-behaved plugin
+should not echo it either way).
 
 ### Context Memory
 


### PR DESCRIPTION
## Summary
- Builds the gateway's live pre-dispatch interception/authorization point in `ta_external_action`'s dispatch path (`resolve_connector_authorization` + `dispatch_auto_action`), backed by `ConnectorRegistry` (`.ta/connectors.toml`) and session tokens from the credential vault.
- On authorization success, the real secret is attached only to the gateway's own outbound subprocess call (`TA_CONNECTOR_SECRET` env var via `plugin_action.rs::execute_with_secret` / `transport.rs::call_with_env`) — never returned to the agent, and never logged.
- Scope deficits are captured for human review (`CapturedForReview`) rather than hard-denied, pending v0.17.6.6's escalation path.
- `bare_process.rs::apply_credentials_to_env` now withholds the raw secret entirely for `broker_mediated` credentials (injects a `TA_SESSION_TOKEN_<name>` instead); non-broker-mediated credentials keep the old direct-injection path, now explicitly flagged as a reduced-security fallback.
- Deduped `ApiMediator::classify_tool` and `ToolCallInterceptor`'s heuristics into one shared `ta_changeset::tool_classify::classify_tool_name`.
- Docs: new "Broker-Mediated Connectors" section in `docs/USAGE.md`.

## Review
Independently verified (not just the supervisor's PASS) that the raw secret never appears in any agent-visible path: traced every `ConnectorAuthorization` branch, `dispatch_auto_action`'s call into `execute_with_secret`, and confirmed no `tracing::*` call anywhere in the changed files logs the secret or the env map. `execute_with_secret_passes_secret_via_subprocess_env_not_payload` asserts the payload sent to the plugin never contains the secret string.

## Test plan
- `cargo build --workspace` — clean
- `cargo test --workspace` — all passing (5091+ tests)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean