### PR TITLE
v0.17.7.1 -- Workflow Graph Engine Core (Node Trait Model + Data-Defined Wiring)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All outcomes must be **observable** (with details and logging) and **actionable*
 
 ## Current State
 
-**Current version**: `0.17.6-alpha.3`
+**Current version**: `0.17.7-alpha.1`
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --phase 4b`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "ta-actions"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "ta-advisor"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "ta-agent-ollama"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "base64",
  "chrono",
@@ -4590,7 +4590,7 @@ dependencies = [
 
 [[package]]
 name = "ta-brain"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "schemars",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "ta-build"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4702,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-comfyui"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -4762,7 +4762,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unity"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unreal"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -4821,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "age",
  "chrono",
@@ -4847,7 +4847,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "ta-data-spec"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "schemars",
  "serde_json",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-overlay"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-proxy"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "ta-decision"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -4952,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "ta-extension"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5004,7 +5004,7 @@ dependencies = [
 
 [[package]]
 name = "ta-governed-paths"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "ta-init"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "ta-intake"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "regex",
@@ -5049,7 +5049,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "regex",
@@ -5086,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "serde",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "glob",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "ta-output-schema"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -5131,7 +5131,7 @@ dependencies = [
 
 [[package]]
 name = "ta-plugin"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "libc",
  "serde",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "glob",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "ta-release"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "base64",
  "reqwest",
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "ta-runtime"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5198,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "libc",
@@ -5231,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "chrono",
  "libc",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5260,6 +5260,8 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "ta-changeset",
+ "ta-decision",
+ "ta-policy",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
@@ -5270,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.17.6-alpha.3"
+version = "0.17.7-alpha.1"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -10163,7 +10163,7 @@ Code releases use semver. Content releases don't. Decide:
 
 ---
 ### v0.17.6.4 — Migrate Session Tokens to Biscuit
-<!-- status: pending -->
+<!-- status: in_progress -->
 **Depends on**: v0.17.6.3
 
 **Open questions resolved 2026-08-15 (design doc's Open Questions 6/7) before starting**:
@@ -10235,7 +10235,7 @@ Code releases use semver. Content releases don't. Decide:
 
 > **Focus**: Replace three disconnected auto-approval mechanisms (`ta_policy::auto_approve`, `ta_session::advisor_agent::check_advisor_auto_approve`, and the governed-workflow consensus engine) and a Git-specific PR-merge continuation with one modular, data-wired workflow-graph engine — Trigger/Reviewer/Decision/Action nodes composed via TOML, VCS-adapter-mediated (not platform-specific), culminating in a natural-language advisor entry point ("build phases v0.17.3 through v0.17.8"). Full design: `docs/superpowers/specs/2026-07-21-workflow-graph-engine-design.md`. Governed by new constitution §16 (`docs/TA-CONSTITUTION.md`), red-teamed 2026-07-21 (PM, head-of-engineering, non-technical-user passes). Visual graph authoring/editing is explicitly deferred — see v0.18.4.
 ### v0.17.7.1 — Workflow Graph Engine Core (Node Trait Model + Data-Defined Wiring)
-<!-- status: in_progress -->
+<!-- status: done -->
 **Depends on**: v0.17.0.12.34 (dependency-wave planning — reused for parallel dispatch), v0.15.15/v0.15.15.1 (`ta-workflow::consensus` — reused as the `WeightedDecisionNode` engine)
 
 **Goal**: Define five node kinds — `TriggerSource`, `WorkerNode`, `ReviewerNode`, `DecisionNode`, `ActionNode` — a TOML graph-definition schema, and a `ta-workflow::graph` execution engine that loads a graph and runs it node-by-node with typed data on edges. Ship enough to express today's existing single-reviewer approval flow as a graph, plus a real work-dispatching worker — proving both halves of the abstraction — without yet adding multi-role panels or CI triggers (those are 7.7.2/7.7.3). Per constitution §16.2, every new graph produced by this phase's tooling defaults to `RecommendAction`; a human must explicitly rewire a graph to `AutoApproveAction`.
@@ -10259,12 +10259,12 @@ pub struct WorkItem {
 One shipped implementation, `GoalDispatchAction`, wraps `ta run`/`ta goal start` and passes `verb`/`workload_hint` straight into `ta-brain::route()`'s **already data-defined** `workload_type` classification (`[workload_types.<type>]` in `workflow.toml`, confirmed free-text since v0.17.0.12.12 — not a closed enum) — which already resolves team/persona/agent/security_tier. A new domain (art, docs, whatever) is a `workflow.toml` binding, zero new Rust code — satisfying constitution §1.6/§1.7 (data-defined, reuse before reinventing) the same way the other four node kinds do. A second `WorkerNode` implementation is only justified when a genuinely different dispatch *transport* is needed (not just a new domain) — e.g. bypassing `ta run` entirely for a raw external pipeline call — and should reuse `StepAction::external_adapter()` (v0.17.5.3) rather than invent a third transport.
 
 **Items**:
-1. [ ] `crates/ta-workflow/src/graph/` — `TriggerSource`/`WorkerNode`/`ReviewerNode`/`DecisionNode`/`ActionNode` traits, `GraphContext`, `TriggerPayload`, `WorkItem`/`WorkResult`, reusing `ReviewerVote`/`Decision` types from `ta-workflow::consensus` rather than redefining them.
-2. [ ] TOML schema + loader: `.ta/workflows/graphs/<name>.toml` → in-memory graph (see spec §3 for the canonical example; a `[worker]` block is new).
-3. [ ] `GoalDispatchAction` (`WorkerNode`, wraps `ta run`/`ta goal start` via `ta-brain::route()`), `PolicyReviewer` (wraps `ta_policy::auto_approve::should_auto_approve_draft`), `AdvisorConfidenceReviewer` (wraps `ta-decision::gate::decide()`), `WeightedDecisionNode` (wraps `ta-workflow::consensus::run_consensus`, config-driven threshold/algorithm/weights — not hardcoded), `AutoApproveAction` (calls existing `ta draft apply`), `RecommendAction` (surfaces to Studio's existing Attention queue).
-4. [ ] `ta workflow graph run <name>` — CLI entry point to execute a graph definition end-to-end, for testing/debugging before it's wired into `ta draft apply` (that wiring is 7.7.3).
-5. [ ] Tests: a graph round-trips a real draft through `PolicyReviewer` → `WeightedDecisionNode` → `RecommendAction`; swapping only the `ActionNode` to `AutoApproveAction` (same graph, same decision) actually calls `ta draft apply` — proving §16.2's "same decision, different wiring" property in a real test, not just in prose. Separately: a `GoalDispatchAction` with `verb = "implement"` vs `verb = "create"` produces two different `ta-brain::route()` decisions against the same `workflow.toml` fixture (no new Rust per verb, just config) — proving the `WorkerNode` design's data-only extensibility claim.
-6. [ ] USAGE.md: new "Workflow Graphs" section documenting the TOML format and all five node kinds, incl. a worked "implement vs. create" `[worker]` example.
+1. [x] `crates/ta-workflow/src/graph/` — `TriggerSource`/`WorkerNode`/`ReviewerNode`/`DecisionNode`/`ActionNode` traits, `GraphContext`, `TriggerPayload`, `WorkItem`/`WorkResult`, reusing `ReviewerVote`/`Decision` types from `ta-workflow::consensus` rather than redefining them.
+2. [x] TOML schema + loader: `.ta/workflows/graphs/<name>.toml` → in-memory graph (see spec §3 for the canonical example; a `[worker]` block is new).
+3. [x] `GoalDispatchAction` (`WorkerNode`, wraps `ta run`/`ta goal start` via `ta-brain::route()`), `PolicyReviewer` (wraps `ta_policy::auto_approve::should_auto_approve_draft`), `AdvisorConfidenceReviewer` (wraps `ta-decision::gate::decide()`), `WeightedDecisionNode` (wraps `ta-workflow::consensus::run_consensus`, config-driven threshold/algorithm/weights — not hardcoded), `AutoApproveAction` (calls existing `ta draft apply`), `RecommendAction` (surfaces to Studio's existing Attention queue).
+4. [x] `ta workflow graph run <name>` — CLI entry point to execute a graph definition end-to-end, for testing/debugging before it's wired into `ta draft apply` (that wiring is 7.7.3).
+5. [x] Tests: a graph round-trips a real draft through `PolicyReviewer` → `WeightedDecisionNode` → `RecommendAction`; swapping only the `ActionNode` to `AutoApproveAction` (same graph, same decision) actually calls `ta draft apply` — proving §16.2's "same decision, different wiring" property in a real test, not just in prose. Separately: a `GoalDispatchAction` with `verb = "implement"` vs `verb = "create"` produces two different `ta-brain::route()` decisions against the same `workflow.toml` fixture (no new Rust per verb, just config) — proving the `WorkerNode` design's data-only extensibility claim.
+6. [x] USAGE.md: new "Workflow Graphs" section documenting the TOML format and all five node kinds, incl. a worked "implement vs. create" `[worker]` example.
 
 #### Version: `0.17.7-alpha.1`
 ### v0.17.7.2 — VCS-Adapter CI-Status Generalization + Corrective-Goal Trigger

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -43,34 +43,34 @@ which = { workspace = true }
 arboard = { workspace = true }
 
 # Internal crates — version kept in sync with workspace by bump-version.sh
-ta-audit = { path = "../../crates/ta-audit", version = "0.17.6-alpha.3" }
-ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.6-alpha.3" }
-ta-memory = { path = "../../crates/ta-memory", version = "0.17.6-alpha.3" }
-ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.6-alpha.3" }
-ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.6-alpha.3" }
-ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.6-alpha.3" }
-ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.6-alpha.3" }
-ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.6-alpha.3" }
-ta-goal = { path = "../../crates/ta-goal", version = "0.17.6-alpha.3" }
-ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.6-alpha.3" }
-ta-policy = { path = "../../crates/ta-policy", version = "0.17.6-alpha.3" }
-ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.6-alpha.3" }
-ta-session = { path = "../../crates/ta-session", version = "0.17.6-alpha.3" }
-ta-events = { path = "../../crates/ta-events", version = "0.17.6-alpha.3" }
-ta-submit = { path = "../../crates/ta-submit", version = "0.17.6-alpha.3" }
-ta-decision = { path = "../../crates/ta-decision", version = "0.17.6-alpha.3" }
-ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.6-alpha.3" }
-ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.6-alpha.3" }
-ta-build = { path = "../../crates/ta-build", version = "0.17.6-alpha.3" }
-ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.6-alpha.3" }
-ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.6-alpha.3" }
-ta-init = { path = "../../crates/ta-init", version = "0.17.6-alpha.3" }
-ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.6-alpha.3" }
-ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.6-alpha.3" }
-ta-intake = { path = "../../crates/ta-intake", version = "0.17.6-alpha.3" }
-ta-brain = { path = "../../crates/ta-brain", version = "0.17.6-alpha.3" }
-ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.6-alpha.3" }
-ta-release = { path = "../../crates/ta-release", version = "0.17.6-alpha.3" }
+ta-audit = { path = "../../crates/ta-audit", version = "0.17.7-alpha.1" }
+ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.7-alpha.1" }
+ta-memory = { path = "../../crates/ta-memory", version = "0.17.7-alpha.1" }
+ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.7-alpha.1" }
+ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.7-alpha.1" }
+ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.7-alpha.1" }
+ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.7-alpha.1" }
+ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.7-alpha.1" }
+ta-goal = { path = "../../crates/ta-goal", version = "0.17.7-alpha.1" }
+ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.7-alpha.1" }
+ta-policy = { path = "../../crates/ta-policy", version = "0.17.7-alpha.1" }
+ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.7-alpha.1" }
+ta-session = { path = "../../crates/ta-session", version = "0.17.7-alpha.1" }
+ta-events = { path = "../../crates/ta-events", version = "0.17.7-alpha.1" }
+ta-submit = { path = "../../crates/ta-submit", version = "0.17.7-alpha.1" }
+ta-decision = { path = "../../crates/ta-decision", version = "0.17.7-alpha.1" }
+ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.7-alpha.1" }
+ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.7-alpha.1" }
+ta-build = { path = "../../crates/ta-build", version = "0.17.7-alpha.1" }
+ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.7-alpha.1" }
+ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.7-alpha.1" }
+ta-init = { path = "../../crates/ta-init", version = "0.17.7-alpha.1" }
+ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.7-alpha.1" }
+ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.7-alpha.1" }
+ta-intake = { path = "../../crates/ta-intake", version = "0.17.7-alpha.1" }
+ta-brain = { path = "../../crates/ta-brain", version = "0.17.7-alpha.1" }
+ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.7-alpha.1" }
+ta-release = { path = "../../crates/ta-release", version = "0.17.7-alpha.1" }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/apps/ta-cli/src/commands/mod.rs
+++ b/apps/ta-cli/src/commands/mod.rs
@@ -70,3 +70,4 @@ pub mod verify;
 pub mod version_guard;
 pub mod webhook;
 pub mod workflow;
+pub mod workflow_graph;

--- a/apps/ta-cli/src/commands/workflow.rs
+++ b/apps/ta-cli/src/commands/workflow.rs
@@ -145,6 +145,40 @@ pub enum WorkflowCommands {
         #[arg(long)]
         dot: bool,
     },
+    /// Execute a workflow graph engine definition end-to-end (v0.17.7.1).
+    ///
+    /// Loads `.ta/workflows/graphs/<name>.toml`, runs its worker (if any),
+    /// fans its reviewers out, applies the configured decision algorithm,
+    /// then runs the wired action node (`recommend` or `auto_approve`).
+    /// For testing/debugging a graph definition before it's wired into an
+    /// event-driven flow (`ta draft apply`'s real gate — v0.17.7.3).
+    ///
+    /// Named `graph-run` (not `graph run`) to avoid colliding with the
+    /// existing `ta workflow graph <path.yaml>` artifact-DAG command above.
+    ///
+    /// Example:
+    ///   ta workflow graph-run phase-review-panel --title "My draft" --verb implement
+    GraphRun {
+        /// Graph name (resolved under `.ta/workflows/graphs/<name>.toml`) or
+        /// a direct path to a `.toml` file.
+        name: String,
+        /// Title used to seed the `[[worker]]`/`[[reviewer]]` node inputs.
+        #[arg(long, default_value = "")]
+        title: String,
+        /// Objective used to seed the `[[worker]]` node input.
+        #[arg(long, default_value = "")]
+        objective: String,
+        /// `WorkItem.verb` — data, not an enum (e.g. "implement", "create", "fix").
+        #[arg(long, default_value = "implement")]
+        verb: String,
+        /// `WorkItem.workload_hint` — explicit `ta-brain::route()` workload
+        /// type override. Defaults to `--verb` when omitted.
+        #[arg(long)]
+        workload_hint: Option<String>,
+        /// Plan phase to associate with any dispatched work.
+        #[arg(long)]
+        phase: Option<String>,
+    },
     /// Resume a paused or interrupted workflow run from the artifact store (v0.14.10).
     ///
     /// Reads the session artifact store, checks which stage outputs are already
@@ -473,6 +507,22 @@ pub fn execute(command: &WorkflowCommands, config: &GatewayConfig) -> anyhow::Re
             }
         }
         WorkflowCommands::Graph { path, dot } => graph_workflow(path, *dot),
+        WorkflowCommands::GraphRun {
+            name,
+            title,
+            objective,
+            verb,
+            workload_hint,
+            phase,
+        } => crate::commands::workflow_graph::run_named_graph(
+            name,
+            title,
+            objective,
+            verb,
+            workload_hint.as_deref(),
+            phase.as_deref(),
+            config,
+        ),
         WorkflowCommands::Resume { run_id } => resume_workflow(run_id, config),
         WorkflowCommands::List {
             templates,

--- a/apps/ta-cli/src/commands/workflow_graph.rs
+++ b/apps/ta-cli/src/commands/workflow_graph.rs
@@ -1,0 +1,540 @@
+// workflow_graph.rs — CLI-layer node implementations + `ta workflow
+// graph-run` entry point for the workflow graph engine (v0.17.7.1).
+//
+// `GoalDispatchAction`, `AutoApproveAction`, and `RecommendAction` live here
+// rather than in `ta-workflow::graph` because they need `ta-brain`
+// (`route()`) and `ta-goal`/the real draft-apply path — `ta-brain` already
+// depends on `ta-workflow` (for its template-matching signal), so
+// `ta-workflow` cannot depend on `ta-brain` back without a cycle. `apps/ta-cli`
+// already depends on every crate these nodes need, so it's the natural home
+// for the "wiring" layer — see `ta_workflow::graph::registry`'s module doc
+// comment for the full reasoning.
+
+use std::collections::HashMap;
+
+use ta_mcp_gateway::GatewayConfig;
+use ta_workflow::graph::{
+    ActionDef, ActionNode, ActionOutcome, Decision, GraphContext, GraphDefinition, GraphError,
+    NodeRegistry, ReviewInput, WorkItem, WorkResult, WorkerNode,
+};
+
+use crate::commands::draft::{self, DraftCommands};
+use crate::commands::goal::{self, GoalCommands};
+
+// ── GoalDispatchAction (WorkerNode) ──────────────────────────────────────
+
+/// Wraps `ta goal start`, passing `verb`/`workload_hint` straight into
+/// `ta-brain::route()`'s already data-defined `workload_type`
+/// classification: `workload_hint` (if set) or else `verb` is used as an
+/// explicit `workload_type_override`, so a new domain (art, docs, whatever)
+/// is a `workflow.toml` `[workload_types.<type>]` binding, not new Rust code
+/// per domain.
+pub struct GoalDispatchAction {
+    pub config: GatewayConfig,
+}
+
+impl GoalDispatchAction {
+    pub fn new(config: GatewayConfig) -> Self {
+        Self { config }
+    }
+
+    /// Resolve routing for `item` via `ta_brain::route()`. Exposed
+    /// separately from `dispatch()` so callers (and tests) can inspect the
+    /// `RoutingDecision` without also creating a goal — this is the piece
+    /// PLAN.md v0.17.7.1 item 5 requires proving: two different `verb`s
+    /// against the same `workflow.toml` fixture must produce two different
+    /// routing decisions with zero new Rust per verb.
+    pub fn resolve_routing(
+        &self,
+        item: &WorkItem,
+        workspace_root: &std::path::Path,
+    ) -> ta_brain::RoutingDecision {
+        let workload_override = item
+            .workload_hint
+            .clone()
+            .or_else(|| Some(item.verb.clone()));
+        let request = ta_brain::ExplicitGoalRequest {
+            goal_title: item.title.clone(),
+            objective: item.objective.clone(),
+            cli_agent: None,
+            cli_persona: None,
+            cli_team: None,
+            cli_security: None,
+            cli_priority: None,
+            workflow_name_or_path: None,
+            workload_type_override: workload_override,
+        };
+        ta_brain::route(
+            &ta_brain::RoutingInput::ExplicitGoal(request),
+            workspace_root,
+        )
+    }
+}
+
+impl WorkerNode for GoalDispatchAction {
+    fn dispatch(&self, item: &WorkItem, ctx: &GraphContext) -> Result<WorkResult, GraphError> {
+        let decision = self.resolve_routing(item, &ctx.workspace_root);
+        tracing::info!(
+            title = %item.title,
+            verb = %item.verb,
+            workload_type = %decision.workload_type,
+            team = %decision.team,
+            agent = %decision.agent,
+            "graph: GoalDispatchAction routed work item"
+        );
+
+        let cmd = GoalCommands::Start {
+            title: item.title.clone(),
+            source: None,
+            objective: item.objective.clone(),
+            agent: decision.agent.clone(),
+            phase: item.phase_id.clone(),
+            follow_up: None,
+            objective_file: None,
+        };
+        goal::execute(&cmd, &self.config).map_err(|e| GraphError::NodeExecution {
+            node_id: "goal_dispatch".to_string(),
+            message: format!("`ta goal start` failed: {e}"),
+        })?;
+
+        let store = ta_goal::GoalRunStore::new(&self.config.goals_dir).map_err(|e| {
+            GraphError::NodeExecution {
+                node_id: "goal_dispatch".to_string(),
+                message: format!("failed to reopen goal store after dispatch: {e}"),
+            }
+        })?;
+        let created = store
+            .list()
+            .map_err(|e| GraphError::NodeExecution {
+                node_id: "goal_dispatch".to_string(),
+                message: format!("failed to list goals after dispatch: {e}"),
+            })?
+            .into_iter()
+            .filter(|g| g.title == item.title)
+            .max_by_key(|g| g.created_at)
+            .ok_or_else(|| GraphError::NodeExecution {
+                node_id: "goal_dispatch".to_string(),
+                message: format!(
+                    "`ta goal start` reported success but no goal titled '{}' was found",
+                    item.title
+                ),
+            })?;
+
+        let mut metadata = HashMap::new();
+        metadata.insert("team".to_string(), decision.team.as_str().to_string());
+        metadata.insert("agent".to_string(), decision.agent.clone());
+        metadata.insert("workload_type".to_string(), decision.workload_type.clone());
+        Ok(WorkResult {
+            draft_id: created.goal_run_id.to_string(),
+            metadata,
+        })
+    }
+}
+
+// ── AutoApproveAction (ActionNode) ───────────────────────────────────────
+
+/// Calls the existing `ta draft apply` code path (same audit trail) when
+/// `Decision.proceed` is true. Never applies otherwise — an unmet threshold
+/// leaves the draft exactly where it was (pending review), it does not
+/// deny/reject it (that's a human or a future `EscalateAction`'s call).
+pub struct AutoApproveAction {
+    pub config: GatewayConfig,
+}
+
+impl AutoApproveAction {
+    pub fn new(config: GatewayConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl ActionNode for AutoApproveAction {
+    fn act(&self, decision: &Decision, ctx: &GraphContext) -> Result<ActionOutcome, GraphError> {
+        if !decision.proceed {
+            return Ok(ActionOutcome {
+                kind: "auto_approve".to_string(),
+                applied: false,
+                message: format!(
+                    "decision did not clear threshold (score={:.2}) — draft left pending review",
+                    decision.score
+                ),
+                metadata: HashMap::new(),
+            });
+        }
+
+        let draft_id = ctx.vars.get("draft_id").cloned();
+        let cmd = DraftCommands::Apply {
+            id: draft_id.clone(),
+            target: None,
+            submit: true,
+            no_submit: false,
+            review: true,
+            no_review: false,
+            dry_run: false,
+            git_commit: false,
+            git_push: false,
+            skip_verify: false,
+            conflict_resolution: "abort".to_string(),
+            approve_patterns: vec!["all".to_string()],
+            reject_patterns: vec![],
+            discuss_patterns: vec![],
+            phase: None,
+            require_review: false,
+            watch: false,
+            chain: false,
+            force_apply: false,
+            validate_version: false,
+            status: false,
+            auto_repair: false,
+            skip_plan_merge: false,
+        };
+        draft::execute(&cmd, &self.config).map_err(|e| GraphError::NodeExecution {
+            node_id: "auto_approve".to_string(),
+            message: format!("`ta draft apply` failed: {e}"),
+        })?;
+
+        let mut metadata = HashMap::new();
+        if let Some(id) = draft_id {
+            metadata.insert("draft_id".to_string(), id);
+        }
+        Ok(ActionOutcome {
+            kind: "auto_approve".to_string(),
+            applied: true,
+            message: format!(
+                "auto-approved and applied (score={:.2}, threshold cleared)",
+                decision.score
+            ),
+            metadata,
+        })
+    }
+}
+
+// ── RecommendAction (ActionNode) ─────────────────────────────────────────
+
+/// Surfaces the `Decision` to a human via Studio's existing Attention queue
+/// — never applies. The Attention queue is already populated by polling
+/// `/api/drafts` (pending-review drafts) and related endpoints
+/// (`crates/ta-daemon/src/web.rs`), so a draft this action leaves in
+/// `PendingReview` already shows up there — no new plumbing needed for
+/// v0.17.7.1, per the design spec's reuse table (§5).
+#[derive(Default)]
+pub struct RecommendAction;
+
+impl ActionNode for RecommendAction {
+    fn act(&self, decision: &Decision, ctx: &GraphContext) -> Result<ActionOutcome, GraphError> {
+        let draft_id = ctx.vars.get("draft_id").cloned();
+        let message = format!(
+            "recommendation surfaced for human review (score={:.2}, proceed={}) — draft{} remains in the Attention queue",
+            decision.score,
+            decision.proceed,
+            draft_id
+                .as_ref()
+                .map(|id| format!(" {id}"))
+                .unwrap_or_default()
+        );
+        tracing::info!(
+            score = decision.score,
+            proceed = decision.proceed,
+            draft_id = draft_id.as_deref().unwrap_or("-"),
+            "graph: RecommendAction surfaced decision to Attention queue"
+        );
+        let mut metadata = HashMap::new();
+        if let Some(id) = draft_id {
+            metadata.insert("draft_id".to_string(), id);
+        }
+        Ok(ActionOutcome {
+            kind: "recommend".to_string(),
+            applied: false,
+            message,
+            metadata,
+        })
+    }
+}
+
+// ── Registry wiring + `ta workflow graph-run` entry point ───────────────
+
+/// Build a `NodeRegistry` with `ta-workflow`'s own built-ins
+/// (`policy`/`advisor_confidence`/`weighted`) plus the three CLI-layer kinds
+/// this module implements (`goal_dispatch`/`auto_approve`/`recommend`).
+pub fn build_registry(config: GatewayConfig) -> NodeRegistry {
+    let mut registry = NodeRegistry::with_builtins();
+
+    let dispatch_config = config.clone();
+    registry.register_worker("goal_dispatch", move |_def| {
+        Ok(Box::new(GoalDispatchAction::new(dispatch_config.clone())) as Box<dyn WorkerNode>)
+    });
+
+    let apply_config = config.clone();
+    registry.register_action("auto_approve", move |_def: &ActionDef| {
+        Ok(Box::new(AutoApproveAction::new(apply_config.clone())) as Box<dyn ActionNode>)
+    });
+
+    registry.register_action("recommend", |_def: &ActionDef| {
+        Ok(Box::new(RecommendAction) as Box<dyn ActionNode>)
+    });
+
+    registry
+}
+
+/// `ta workflow graph-run <name>` — load `.ta/workflows/graphs/<name>.toml`
+/// and execute it end-to-end, for testing/debugging a graph before it's
+/// wired into an event-driven flow (that wiring is v0.17.7.2/.3). Named
+/// `graph-run` rather than the PLAN.md-literal `graph run` because
+/// `WorkflowCommands::Graph { path, dot }` already means "print a YAML
+/// workflow's artifact-type DAG" — reusing that name for a different
+/// engine's execution entry point would collide.
+pub fn run_named_graph(
+    name: &str,
+    goal_title: &str,
+    objective: &str,
+    verb: &str,
+    workload_hint: Option<&str>,
+    phase: Option<&str>,
+    config: &GatewayConfig,
+) -> anyhow::Result<()> {
+    let def = GraphDefinition::load_named(&config.workspace_root, name)
+        .map_err(|e| anyhow::anyhow!("failed to load graph '{name}': {e}"))?;
+    let registry = build_registry(config.clone());
+
+    let run_id = uuid::Uuid::new_v4().to_string();
+    let mut ctx = GraphContext::new(&config.workspace_root, run_id);
+
+    let work_item = WorkItem {
+        title: goal_title.to_string(),
+        objective: objective.to_string(),
+        phase_id: phase.map(|p| p.to_string()),
+        verb: verb.to_string(),
+        workload_hint: workload_hint.map(|w| w.to_string()),
+    };
+    let review_input = ReviewInput {
+        agent_id: "claude-code".to_string(),
+        plan_phase: phase.map(|p| p.to_string()),
+        ..Default::default()
+    };
+
+    let outcome =
+        ta_workflow::graph::run_graph(&def, &registry, &work_item, &review_input, &mut ctx)
+            .map_err(|e| anyhow::anyhow!("graph '{name}' run failed: {e}"))?;
+
+    println!("[graph] run '{name}' complete (run_id={})", ctx.run_id);
+    for work_result in &outcome.work_results {
+        println!("  worker -> draft_id={}", work_result.draft_id);
+    }
+    for vote in &outcome.votes {
+        println!(
+            "  reviewer '{}': score={:.2} timed_out={}",
+            vote.role, vote.score, vote.timed_out
+        );
+    }
+    if let Some(decision) = &outcome.decision {
+        println!(
+            "  decision: score={:.2} proceed={} algorithm={}",
+            decision.score, decision.proceed, decision.algorithm_used
+        );
+    }
+    if let Some(action) = &outcome.action_outcome {
+        println!(
+            "  action '{}': applied={} — {}",
+            action.kind, action.applied, action.message
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn passing_decision() -> Decision {
+        Decision {
+            score: 1.0,
+            proceed: true,
+            algorithm_used: ta_workflow::consensus::ConsensusAlgorithm::Weighted,
+            scores_by_role: HashMap::new(),
+            findings_by_role: HashMap::new(),
+            timed_out_roles: vec![],
+            override_active: false,
+            summary: "test decision".to_string(),
+        }
+    }
+
+    fn failing_decision() -> Decision {
+        Decision {
+            proceed: false,
+            score: 0.1,
+            ..passing_decision()
+        }
+    }
+
+    /// Build a real, approved draft package the same way `draft::execute`'s
+    /// own tests do (`Start` -> mutate staging -> `Build` -> `Approve`), so
+    /// `AutoApproveAction`/`RecommendAction` tests exercise the exact same
+    /// public dispatch path `ta draft apply`/`ta draft approve` use — not a
+    /// stand-in fixture.
+    fn build_approved_draft(project: &std::path::Path) -> (GatewayConfig, String) {
+        std::fs::write(project.join("README.md"), "# Original\n").unwrap();
+
+        let config = GatewayConfig::for_project(project);
+        goal::execute(
+            &GoalCommands::Start {
+                title: "graph-node-test".to_string(),
+                source: Some(project.to_path_buf()),
+                objective: "test AutoApproveAction/RecommendAction".to_string(),
+                agent: "test-agent".to_string(),
+                phase: None,
+                follow_up: None,
+                objective_file: None,
+            },
+            &config,
+        )
+        .unwrap();
+
+        let goal_store = ta_goal::GoalRunStore::new(&config.goals_dir).unwrap();
+        let goal = goal_store.list().unwrap().into_iter().next().unwrap();
+        let goal_id = goal.goal_run_id.to_string();
+
+        std::fs::write(goal.workspace_path.join("README.md"), "# Updated\n").unwrap();
+
+        draft::execute(
+            &DraftCommands::Build {
+                goal_id: goal_id.clone(),
+                summary: "graph node test changes".to_string(),
+                latest: false,
+                apply_context_file: None,
+            },
+            &config,
+        )
+        .unwrap();
+
+        let packages = draft::load_all_packages(&config).unwrap();
+        let pkg_id = packages[0].package_id.to_string();
+
+        draft::execute(
+            &DraftCommands::Approve {
+                id: Some(pkg_id.clone()),
+                reviewer: "graph-test".to_string(),
+                reviewer_as: None,
+                force_override: false,
+            },
+            &config,
+        )
+        .unwrap();
+
+        (config, pkg_id)
+    }
+
+    #[test]
+    fn auto_approve_action_calls_the_real_ta_draft_apply_path() {
+        let project = TempDir::new().unwrap();
+        let (config, draft_id) = build_approved_draft(project.path());
+
+        let mut ctx = GraphContext::new(project.path(), "run-auto-approve-test");
+        ctx.vars.insert("draft_id".to_string(), draft_id);
+
+        let action = AutoApproveAction::new(config);
+        let outcome = action.act(&passing_decision(), &ctx).unwrap();
+
+        assert!(
+            outcome.applied,
+            "AutoApproveAction must apply on proceed=true"
+        );
+        assert_eq!(outcome.kind, "auto_approve");
+        let readme = std::fs::read_to_string(project.path().join("README.md")).unwrap();
+        assert_eq!(
+            readme, "# Updated\n",
+            "AutoApproveAction must actually call ta draft apply's code path, \
+             proven by the source file changing on disk — not a stub"
+        );
+    }
+
+    #[test]
+    fn auto_approve_action_skips_apply_when_decision_did_not_proceed() {
+        let project = TempDir::new().unwrap();
+        let (config, draft_id) = build_approved_draft(project.path());
+
+        let mut ctx = GraphContext::new(project.path(), "run-auto-approve-skip-test");
+        ctx.vars.insert("draft_id".to_string(), draft_id);
+
+        let action = AutoApproveAction::new(config);
+        let outcome = action.act(&failing_decision(), &ctx).unwrap();
+
+        assert!(!outcome.applied);
+        let readme = std::fs::read_to_string(project.path().join("README.md")).unwrap();
+        assert_eq!(
+            readme, "# Original\n",
+            "must not apply when decision.proceed is false"
+        );
+    }
+
+    #[test]
+    fn recommend_action_never_applies_the_same_decision_auto_approve_would() {
+        // Same graph, same Decision, only the ActionNode kind differs —
+        // proving constitution §16.2's "same decision, different wiring".
+        let project = TempDir::new().unwrap();
+        let (_config, draft_id) = build_approved_draft(project.path());
+
+        let mut ctx = GraphContext::new(project.path(), "run-recommend-test");
+        ctx.vars.insert("draft_id".to_string(), draft_id);
+
+        let action = RecommendAction;
+        let outcome = action.act(&passing_decision(), &ctx).unwrap();
+
+        assert!(!outcome.applied, "RecommendAction must never apply");
+        assert_eq!(outcome.kind, "recommend");
+        let readme = std::fs::read_to_string(project.path().join("README.md")).unwrap();
+        assert_eq!(
+            readme, "# Original\n",
+            "RecommendAction must leave source untouched even with an identical proceed=true decision"
+        );
+    }
+
+    #[test]
+    fn goal_dispatch_action_verb_alone_changes_the_routing_decision() {
+        // No new Rust per verb — a `[workload_types.<verb>]` binding in
+        // `.ta/workflow.toml` is enough, per PLAN.md v0.17.7.1 item 5's
+        // "data-only extensibility" requirement.
+        let project = TempDir::new().unwrap();
+        let ta_dir = project.path().join(".ta");
+        std::fs::create_dir_all(&ta_dir).unwrap();
+        std::fs::write(
+            ta_dir.join("workflow.toml"),
+            r#"
+[workload_types.implement]
+team = "implementer"
+persona = "careful-reviewer"
+
+[workload_types.create]
+team = "reviewer"
+persona = "creative-generator"
+"#,
+        )
+        .unwrap();
+
+        let config = GatewayConfig::for_project(project.path());
+        let action = GoalDispatchAction::new(config);
+
+        let implement_item = WorkItem {
+            title: "Phase X".to_string(),
+            objective: "do the phase".to_string(),
+            phase_id: None,
+            verb: "implement".to_string(),
+            workload_hint: None,
+        };
+        let create_item = WorkItem {
+            verb: "create".to_string(),
+            ..implement_item.clone()
+        };
+
+        let implement_decision = action.resolve_routing(&implement_item, project.path());
+        let create_decision = action.resolve_routing(&create_item, project.path());
+
+        assert_eq!(implement_decision.workload_type, "implement");
+        assert_eq!(create_decision.workload_type, "create");
+        assert_ne!(
+            implement_decision.team, create_decision.team,
+            "verb alone must change the resolved team via workflow.toml data, no new Rust"
+        );
+        assert_ne!(implement_decision.persona, create_decision.persona);
+    }
+}

--- a/crates/ta-actions/Cargo.toml
+++ b/crates/ta-actions/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 toml = { workspace = true }
-ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.3" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-advisor/Cargo.toml
+++ b/crates/ta-advisor/Cargo.toml
@@ -17,12 +17,12 @@ tracing = { workspace = true }
 
 # Reuses the existing heuristic classifier as the substrate for the new
 # 4-way taxonomy rather than duplicating keyword-matching logic.
-ta-session = { path = "../ta-session", version = "0.17.6-alpha.3" }
+ta-session = { path = "../ta-session", version = "0.17.7-alpha.1" }
 # Team-coordinator capability (v0.17.0.12.20): reuses ta-intake's TriggerEvent
 # and ta-brain's routing/prioritization rather than a new persistent role —
 # see crates/ta-advisor/src/coordinator.rs for the decision rationale.
-ta-intake = { path = "../ta-intake", version = "0.17.6-alpha.3" }
-ta-brain = { path = "../ta-brain", version = "0.17.6-alpha.3" }
+ta-intake = { path = "../ta-intake", version = "0.17.7-alpha.1" }
+ta-brain = { path = "../ta-brain", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-brain/Cargo.toml
+++ b/crates/ta-brain/Cargo.toml
@@ -18,13 +18,13 @@ chrono = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
-ta-session = { path = "../ta-session", version = "0.17.6-alpha.3" }
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
-ta-intake = { path = "../ta-intake", version = "0.17.6-alpha.3" }
+ta-session = { path = "../ta-session", version = "0.17.7-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
+ta-intake = { path = "../ta-intake", version = "0.17.7-alpha.1" }
 # Folds ta-workflow's template-matching intent resolver in as one signal
 # route() consults (v0.17.0.12.23), rather than a second, parallel intent
 # system — see route.rs's resolve_workflow_template().
-ta-workflow = { path = "../ta-workflow", version = "0.17.6-alpha.3" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/comfyui/Cargo.toml
+++ b/crates/ta-connectors/comfyui/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.6-alpha.3" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/discord/Cargo.toml
+++ b/crates/ta-connectors/discord/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.6-alpha.3" }
+ta-events = { path = "../../ta-events", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/email/Cargo.toml
+++ b/crates/ta-connectors/email/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.6-alpha.3" }
+ta-events = { path = "../../ta-events", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/fs/Cargo.toml
+++ b/crates/ta-connectors/fs/Cargo.toml
@@ -16,10 +16,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.6-alpha.3" }
-ta-workspace = { path = "../../ta-workspace", version = "0.17.6-alpha.3" }
-ta-audit = { path = "../../ta-audit", version = "0.17.6-alpha.3" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.7-alpha.1" }
+ta-workspace = { path = "../../ta-workspace", version = "0.17.7-alpha.1" }
+ta-audit = { path = "../../ta-audit", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-ta-policy = { path = "../../ta-policy", version = "0.17.6-alpha.3" }
+ta-policy = { path = "../../ta-policy", version = "0.17.7-alpha.1" }

--- a/crates/ta-connectors/slack/Cargo.toml
+++ b/crates/ta-connectors/slack/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.6-alpha.3" }
+ta-events = { path = "../../ta-events", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/unreal/Cargo.toml
+++ b/crates/ta-connectors/unreal/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.6-alpha.3" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -31,23 +31,23 @@ async-stream = { workspace = true }
 sha2 = { workspace = true }
 
 # Internal crates
-ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.6-alpha.3" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.3" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
-ta-memory = { path = "../ta-memory", version = "0.17.6-alpha.3" }
-ta-events = { path = "../ta-events", version = "0.17.6-alpha.3" }
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
-ta-runtime = { path = "../ta-runtime", version = "0.17.6-alpha.3" }
-ta-audit = { path = "../ta-audit", version = "0.17.6-alpha.3" }
-ta-policy = { path = "../ta-policy", version = "0.17.6-alpha.3" }
-ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.6-alpha.3" }
-ta-connector-email = { path = "../ta-connectors/email", version = "0.17.6-alpha.3" }
+ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.7-alpha.1" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.7-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
+ta-memory = { path = "../ta-memory", version = "0.17.7-alpha.1" }
+ta-events = { path = "../ta-events", version = "0.17.7-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
+ta-runtime = { path = "../ta-runtime", version = "0.17.7-alpha.1" }
+ta-audit = { path = "../ta-audit", version = "0.17.7-alpha.1" }
+ta-policy = { path = "../ta-policy", version = "0.17.7-alpha.1" }
+ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.7-alpha.1" }
+ta-connector-email = { path = "../ta-connectors/email", version = "0.17.7-alpha.1" }
 reqwest = { workspace = true }
-ta-output-schema = { path = "../ta-output-schema", version = "0.17.6-alpha.3" }
-ta-extension = { path = "../ta-extension", version = "0.17.6-alpha.3" }
-ta-session = { path = "../ta-session", version = "0.17.6-alpha.3" }
-ta-advisor = { path = "../ta-advisor", version = "0.17.6-alpha.3" }
-ta-data-spec = { path = "../ta-data-spec", version = "0.17.6-alpha.3" }
+ta-output-schema = { path = "../ta-output-schema", version = "0.17.7-alpha.1" }
+ta-extension = { path = "../ta-extension", version = "0.17.7-alpha.1" }
+ta-session = { path = "../ta-session", version = "0.17.7-alpha.1" }
+ta-advisor = { path = "../ta-advisor", version = "0.17.7-alpha.1" }
+ta-data-spec = { path = "../ta-data-spec", version = "0.17.7-alpha.1" }
 which = "7"
 libc = { workspace = true }
 async-trait = "0.1"

--- a/crates/ta-data-spec/Cargo.toml
+++ b/crates/ta-data-spec/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 [dependencies]
 schemars = { workspace = true }
 serde_json = { workspace = true }
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
-ta-brain = { path = "../ta-brain", version = "0.17.6-alpha.3" }
-ta-intake = { path = "../ta-intake", version = "0.17.6-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
+ta-brain = { path = "../ta-brain", version = "0.17.7-alpha.1" }
+ta-intake = { path = "../ta-intake", version = "0.17.7-alpha.1" }

--- a/crates/ta-db-proxy/Cargo.toml
+++ b/crates/ta-db-proxy/Cargo.toml
@@ -17,10 +17,10 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.6-alpha.3" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.3" }
-ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.3" }
-ta-actions = { path = "../ta-actions", version = "0.17.6-alpha.3" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.7-alpha.1" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.1" }
+ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.1" }
+ta-actions = { path = "../ta-actions", version = "0.17.7-alpha.1" }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ta-intake/Cargo.toml
+++ b/crates/ta-intake/Cargo.toml
@@ -19,8 +19,8 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 regex = { workspace = true }
-ta-submit = { path = "../ta-submit", version = "0.17.6-alpha.3" }
-ta-events = { path = "../ta-events", version = "0.17.6-alpha.3" }
+ta-submit = { path = "../ta-submit", version = "0.17.7-alpha.1" }
+ta-events = { path = "../ta-events", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -25,23 +25,23 @@ which = { workspace = true }
 toml = { workspace = true }
 
 # Internal crates
-ta-audit = { path = "../ta-audit", version = "0.17.6-alpha.3" }
-ta-events = { path = "../ta-events", version = "0.17.6-alpha.3" }
-ta-memory = { path = "../ta-memory", version = "0.17.6-alpha.3" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
-ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.6-alpha.3" }
-ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.6-alpha.3" }
-ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.6-alpha.3" }
-ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.6-alpha.3" }
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
-ta-policy = { path = "../ta-policy", version = "0.17.6-alpha.3" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.3" }
-ta-workflow = { path = "../ta-workflow", version = "0.17.6-alpha.3" }
-ta-actions = { path = "../ta-actions", version = "0.17.6-alpha.3" }
-ta-submit = { path = "../ta-submit", version = "0.17.6-alpha.3" }
-ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.3" }
-ta-credentials = { path = "../ta-credentials", version = "0.17.6-alpha.3" }
-ta-session = { path = "../ta-session", version = "0.17.6-alpha.3" }
+ta-audit = { path = "../ta-audit", version = "0.17.7-alpha.1" }
+ta-events = { path = "../ta-events", version = "0.17.7-alpha.1" }
+ta-memory = { path = "../ta-memory", version = "0.17.7-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
+ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.7-alpha.1" }
+ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.7-alpha.1" }
+ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.7-alpha.1" }
+ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.7-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
+ta-policy = { path = "../ta-policy", version = "0.17.7-alpha.1" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.7-alpha.1" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.7-alpha.1" }
+ta-actions = { path = "../ta-actions", version = "0.17.7-alpha.1" }
+ta-submit = { path = "../ta-submit", version = "0.17.7-alpha.1" }
+ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.1" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.7-alpha.1" }
+ta-session = { path = "../ta-session", version = "0.17.7-alpha.1" }
 
 
 [dev-dependencies]

--- a/crates/ta-mediation/Cargo.toml
+++ b/crates/ta-mediation/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates for FsMediator
-ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.3" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.7-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-release/Cargo.toml
+++ b/crates/ta-release/Cargo.toml
@@ -18,7 +18,7 @@ toml = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true, features = ["multipart"] }
-ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.3" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-runtime/Cargo.toml
+++ b/crates/ta-runtime/Cargo.toml
@@ -23,8 +23,8 @@ which = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
 
-ta-credentials = { path = "../ta-credentials", version = "0.17.6-alpha.3" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.3" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.7-alpha.1" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.1" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }
-ta-policy = { path = "../ta-policy", version = "0.17.6-alpha.3" }
+ta-policy = { path = "../ta-policy", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-session/Cargo.toml
+++ b/crates/ta-session/Cargo.toml
@@ -25,9 +25,9 @@ notify = { workspace = true }
 toml = { workspace = true }
 
 # Workspace crates
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
-ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.3" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
+ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -16,11 +16,11 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.6-alpha.3" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.6-alpha.3" }
-ta-decision = { path = "../ta-decision", version = "0.17.6-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.7-alpha.1" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.1" }
+ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.1" }
 toml = "0.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/ta-workflow/Cargo.toml
+++ b/crates/ta-workflow/Cargo.toml
@@ -15,13 +15,21 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+toml = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
+# Reused by graph::nodes::PolicyReviewer (v0.17.7.1) — wraps the existing
+# should_auto_approve_draft rule evaluation as one ReviewerNode, per
+# constitution §1.7 (reuse before reinventing). Leaf crate, no cycle risk.
+ta-policy = { path = "../ta-policy", version = "0.17.7-alpha.1" }
+# Reused by graph::nodes::AdvisorConfidenceReviewer (v0.17.7.1) — wraps the
+# existing gate::decide() confidence check as one ReviewerNode. Leaf crate,
+# no cycle risk.
+ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.1" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-toml = { workspace = true }

--- a/crates/ta-workflow/src/consensus/mod.rs
+++ b/crates/ta-workflow/src/consensus/mod.rs
@@ -45,6 +45,24 @@ impl std::fmt::Display for ConsensusAlgorithm {
     }
 }
 
+/// Parses the same lowercase names `Display` produces — used by
+/// `graph::WeightedDecisionNode` to read a TOML `[decision] algorithm`
+/// string (v0.17.7.1) rather than hardcoding an algorithm at each call site.
+impl std::str::FromStr for ConsensusAlgorithm {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "raft" => Ok(ConsensusAlgorithm::Raft),
+            "paxos" => Ok(ConsensusAlgorithm::Paxos),
+            "weighted" => Ok(ConsensusAlgorithm::Weighted),
+            other => Err(format!(
+                "unknown consensus algorithm '{other}' (expected raft/paxos/weighted)"
+            )),
+        }
+    }
+}
+
 // ── ReviewerVote ─────────────────────────────────────────────────────────────
 
 /// A single reviewer's contribution to the consensus panel.
@@ -189,6 +207,20 @@ mod tests {
         assert_eq!(ConsensusAlgorithm::Raft.to_string(), "raft");
         assert_eq!(ConsensusAlgorithm::Paxos.to_string(), "paxos");
         assert_eq!(ConsensusAlgorithm::Weighted.to_string(), "weighted");
+    }
+
+    #[test]
+    fn algorithm_from_str_round_trips_display() {
+        use std::str::FromStr;
+        for variant in [
+            ConsensusAlgorithm::Raft,
+            ConsensusAlgorithm::Paxos,
+            ConsensusAlgorithm::Weighted,
+        ] {
+            let parsed = ConsensusAlgorithm::from_str(&variant.to_string()).unwrap();
+            assert_eq!(parsed, variant);
+        }
+        assert!(ConsensusAlgorithm::from_str("bogus").is_err());
     }
 
     #[test]

--- a/crates/ta-workflow/src/graph/engine.rs
+++ b/crates/ta-workflow/src/graph/engine.rs
@@ -1,0 +1,239 @@
+// graph/engine.rs — Executes a `GraphDefinition` node-by-node with typed
+// data passed along edges (v0.17.7.1).
+//
+// v1 execution order (workers* -> reviewers* -> decision -> action) does not
+// yet block on `[[trigger]]` sources — `ta workflow graph run <name>` is a
+// synchronous "run now" entry point for testing/debugging a graph before
+// it's wired into an event-driven flow (that wiring is 7.7.2/7.7.3). Trigger
+// definitions still parse and validate; `TriggerSource::wait()` exists for a
+// future caller (e.g. the daemon) to invoke before calling `run_graph`.
+
+use tracing::info;
+
+use super::registry::NodeRegistry;
+use super::schema::GraphDefinition;
+use super::types::{
+    ActionOutcome, Decision, GraphContext, GraphError, ReviewInput, ReviewerVote, WorkItem,
+    WorkResult,
+};
+
+/// Everything produced by one `run_graph` call, for callers (CLI output,
+/// tests) to inspect — every stage that ran is Observable (per the project's
+/// Observability Mandate).
+#[derive(Debug, Default)]
+pub struct GraphRunOutcome {
+    pub work_results: Vec<WorkResult>,
+    pub votes: Vec<ReviewerVote>,
+    pub decision: Option<Decision>,
+    pub action_outcome: Option<ActionOutcome>,
+}
+
+/// Run `def` end-to-end against `registry`, threading `ctx` through every
+/// node. `work_item` seeds any `[[worker]]` nodes (ignored if the graph has
+/// none); `review_input` seeds any `[[reviewer]]` nodes (ignored if the
+/// graph has none).
+pub fn run_graph(
+    def: &GraphDefinition,
+    registry: &NodeRegistry,
+    work_item: &WorkItem,
+    review_input: &ReviewInput,
+    ctx: &mut GraphContext,
+) -> Result<GraphRunOutcome, GraphError> {
+    let mut outcome = GraphRunOutcome::default();
+
+    for worker_def in &def.workers {
+        info!(node_id = %worker_def.id, kind = %worker_def.kind, "graph: dispatching worker");
+        let worker = registry.build_worker(worker_def)?;
+        let result = worker
+            .dispatch(work_item, ctx)
+            .map_err(|e| wrap(&worker_def.id, e))?;
+        ctx.vars
+            .insert("draft_id".to_string(), result.draft_id.clone());
+        outcome.work_results.push(result);
+    }
+
+    for reviewer_def in &def.reviewers {
+        info!(node_id = %reviewer_def.id, kind = %reviewer_def.kind, "graph: running reviewer");
+        let reviewer = registry.build_reviewer(reviewer_def)?;
+        let mut vote = reviewer
+            .review(review_input, ctx)
+            .map_err(|e| wrap(&reviewer_def.id, e))?;
+        // The reviewer *node id* (not its Rust-level role string) is what
+        // `[decision].weights` keys against, per spec §3's
+        // `weights = { policy_check = 1.0, ... }` example.
+        vote.role = reviewer_def.id.clone();
+        outcome.votes.push(vote);
+    }
+
+    if let Some(decision_def) = &def.decision {
+        info!(node_id = %decision_def.id, kind = %decision_def.kind, "graph: running decision");
+        let decision_node = registry.build_decision(decision_def)?;
+        let inputs: Vec<ReviewerVote> = if decision_def.inputs.is_empty() {
+            outcome.votes.clone()
+        } else {
+            outcome
+                .votes
+                .iter()
+                .filter(|v| decision_def.inputs.contains(&v.role))
+                .cloned()
+                .collect()
+        };
+        let decision = decision_node
+            .decide(&inputs, ctx)
+            .map_err(|e| wrap(&decision_def.id, e))?;
+        info!(
+            node_id = %decision_def.id,
+            score = decision.score,
+            proceed = decision.proceed,
+            "graph: decision reached"
+        );
+        outcome.decision = Some(decision);
+    }
+
+    if let Some(action_def) = &def.action {
+        let decision = outcome.decision.as_ref().ok_or_else(|| {
+            GraphError::InvalidDefinition(format!(
+                "action '{}' requires a [decision] block but none ran",
+                action_def.id
+            ))
+        })?;
+        info!(node_id = %action_def.id, kind = %action_def.kind, "graph: running action");
+        let action = registry.build_action(action_def)?;
+        let result = action
+            .act(decision, ctx)
+            .map_err(|e| wrap(&action_def.id, e))?;
+        info!(
+            node_id = %action_def.id,
+            applied = result.applied,
+            message = %result.message,
+            "graph: action complete"
+        );
+        outcome.action_outcome = Some(result);
+    }
+
+    Ok(outcome)
+}
+
+fn wrap(node_id: &str, err: GraphError) -> GraphError {
+    match err {
+        GraphError::NodeExecution { .. } => err,
+        other => GraphError::NodeExecution {
+            node_id: node_id.to_string(),
+            message: other.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::schema::GraphDefinition;
+
+    fn ctx() -> (tempfile::TempDir, GraphContext) {
+        let dir = tempfile::tempdir().unwrap();
+        let context = GraphContext::new(dir.path(), "run-engine-test");
+        (dir, context)
+    }
+
+    #[test]
+    fn policy_reviewer_to_weighted_decision_to_recommend_round_trip() {
+        let toml = r#"
+[[reviewer]]
+id = "policy_check"
+kind = "policy"
+
+[decision]
+id = "panel_verdict"
+kind = "weighted"
+threshold = 0.5
+inputs = ["policy_check"]
+
+[action]
+id = "outcome"
+kind = "recommend"
+decision = "panel_verdict"
+"#;
+        let def = GraphDefinition::from_toml_str(toml).unwrap();
+        let mut registry = NodeRegistry::new();
+        // Explicitly enable auto-approve so the round trip proceeds — the
+        // registry's own default (`with_builtins()`'s bare `PolicyDocument`)
+        // is deny-by-default per §1.3's Human-in-the-Loop default, exercised
+        // separately in `nodes::policy_reviewer`'s tests.
+        registry.register_reviewer("policy", |_def| {
+            let mut doc = ta_policy::PolicyDocument::default();
+            doc.defaults.auto_approve.drafts.enabled = true;
+            Ok(
+                Box::new(crate::graph::nodes::PolicyReviewer::with_document(doc))
+                    as Box<dyn super::super::types::ReviewerNode>,
+            )
+        });
+        registry.register_decision("weighted", |def| {
+            Ok(
+                Box::new(crate::graph::nodes::WeightedDecisionNode::from_def(def))
+                    as Box<dyn super::super::types::DecisionNode>,
+            )
+        });
+        registry.register_action("recommend", |_def| {
+            Ok(Box::new(RecordingRecommend) as Box<dyn super::super::types::ActionNode>)
+        });
+        let (_dir, mut context) = ctx();
+        let work_item = WorkItem::default();
+        let review_input = ReviewInput {
+            changed_paths: vec!["src/main.rs".to_string()],
+            lines_changed: 5,
+            agent_id: "claude-code".to_string(),
+            ..Default::default()
+        };
+
+        let outcome = run_graph(&def, &registry, &work_item, &review_input, &mut context).unwrap();
+
+        assert_eq!(outcome.votes.len(), 1);
+        assert_eq!(outcome.votes[0].role, "policy_check");
+        let decision = outcome.decision.unwrap();
+        assert!(decision.proceed);
+        let action_outcome = outcome.action_outcome.unwrap();
+        assert_eq!(action_outcome.kind, "recommend");
+        assert!(!action_outcome.applied, "recommend must never apply");
+    }
+
+    #[test]
+    fn missing_kind_returns_node_not_found() {
+        let toml = r#"
+[[reviewer]]
+id = "policy_check"
+kind = "unregistered_kind"
+
+[decision]
+id = "d1"
+inputs = ["policy_check"]
+"#;
+        let def = GraphDefinition::from_toml_str(toml).unwrap();
+        let registry = NodeRegistry::with_builtins();
+        let (_dir, mut context) = ctx();
+        let err = run_graph(
+            &def,
+            &registry,
+            &WorkItem::default(),
+            &ReviewInput::default(),
+            &mut context,
+        )
+        .unwrap_err();
+        assert!(matches!(err, GraphError::NodeNotFound { .. }));
+    }
+
+    struct RecordingRecommend;
+    impl super::super::types::ActionNode for RecordingRecommend {
+        fn act(
+            &self,
+            decision: &Decision,
+            _ctx: &GraphContext,
+        ) -> Result<ActionOutcome, GraphError> {
+            Ok(ActionOutcome {
+                kind: "recommend".to_string(),
+                applied: false,
+                message: format!("recommended, score={:.2}", decision.score),
+                metadata: Default::default(),
+            })
+        }
+    }
+}

--- a/crates/ta-workflow/src/graph/mod.rs
+++ b/crates/ta-workflow/src/graph/mod.rs
@@ -1,0 +1,31 @@
+// graph/mod.rs — Workflow Graph Engine Core (v0.17.7.1).
+//
+// A workflow graph is a set of typed nodes connected by typed edges,
+// executed node-by-node with typed data on edges. Five node kinds
+// (`TriggerSource`, `WorkerNode`, `ReviewerNode`, `DecisionNode`,
+// `ActionNode`) cover both halves of a workflow — producing work and
+// reviewing/deciding/acting on it. See
+// docs/superpowers/specs/2026-07-21-workflow-graph-engine-design.md for the
+// full design and docs/TA-CONSTITUTION.md §16 for the governing principles.
+//
+// Node kinds needing only what `ta-workflow` already depends on ship here
+// (`nodes::PolicyReviewer`, `nodes::AdvisorConfidenceReviewer`,
+// `nodes::WeightedDecisionNode`, registered by `NodeRegistry::with_builtins()`).
+// Node kinds needing `ta-brain`/`ta-goal`/the real draft-apply path
+// (`GoalDispatchAction`, `AutoApproveAction`, `RecommendAction`) are
+// implemented in `apps/ta-cli`, which already depends on everything — see
+// `registry.rs`'s module doc comment for the dependency-cycle reasoning.
+
+pub mod engine;
+pub mod nodes;
+pub mod registry;
+pub mod schema;
+pub mod types;
+
+pub use engine::{run_graph, GraphRunOutcome};
+pub use registry::NodeRegistry;
+pub use schema::{ActionDef, DecisionDef, GraphDefinition, NodeDef};
+pub use types::{
+    ActionNode, ActionOutcome, Decision, DecisionNode, GraphContext, GraphError, ReviewInput,
+    ReviewerNode, ReviewerVote, TriggerPayload, TriggerSource, WorkItem, WorkResult, WorkerNode,
+};

--- a/crates/ta-workflow/src/graph/nodes/advisor_confidence_reviewer.rs
+++ b/crates/ta-workflow/src/graph/nodes/advisor_confidence_reviewer.rs
@@ -1,0 +1,95 @@
+// graph/nodes/advisor_confidence_reviewer.rs — `AdvisorConfidenceReviewer`
+// (v0.17.7.1).
+//
+// Wraps the existing `ta_decision::gate::decide()` confidence/risk gate as
+// one scored `ReviewerVote`, per the reuse inventory in
+// docs/superpowers/specs/2026-07-21-workflow-graph-engine-design.md §5.
+
+use ta_decision::{decide, DecisionInput, DecisionThresholds};
+
+use crate::graph::types::{GraphContext, GraphError, ReviewInput, ReviewerNode, ReviewerVote};
+
+/// Runs `ta_decision::gate::decide()` against the caller-supplied
+/// `DecisionThresholds` (defaults to `DecisionThresholds::default()` when
+/// built via `NodeRegistry::with_builtins()`).
+#[derive(Default)]
+pub struct AdvisorConfidenceReviewer {
+    thresholds: DecisionThresholds,
+}
+
+impl AdvisorConfidenceReviewer {
+    pub fn with_thresholds(thresholds: DecisionThresholds) -> Self {
+        Self { thresholds }
+    }
+}
+
+impl ReviewerNode for AdvisorConfidenceReviewer {
+    fn review(&self, input: &ReviewInput, _ctx: &GraphContext) -> Result<ReviewerVote, GraphError> {
+        let decision_input = DecisionInput {
+            verdict: input.verdict,
+            risk_score: input.risk_score,
+            confidence: input.confidence,
+        };
+        let gate_decision = decide(&decision_input, &self.thresholds);
+        let score = if gate_decision.is_auto_approvable() {
+            1.0
+        } else {
+            0.0
+        };
+        let finding = format!(
+            "advisor_confidence: gate_decision={gate_decision:?} risk_score={} confidence={:.2}",
+            input.risk_score, input.confidence
+        );
+        Ok(ReviewerVote {
+            role: "advisor_confidence".to_string(),
+            score,
+            findings: vec![finding],
+            timed_out: false,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ta_decision::Verdict;
+
+    fn input(risk_score: u32, confidence: f64) -> ReviewInput {
+        ReviewInput {
+            verdict: Verdict::Pass,
+            risk_score,
+            confidence,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn commit_decision_scores_one() {
+        let ctx = GraphContext::new("/tmp", "run-1");
+        let reviewer = AdvisorConfidenceReviewer::default();
+        let vote = reviewer.review(&input(10, 0.95), &ctx).unwrap();
+        assert_eq!(vote.score, 1.0);
+        assert_eq!(vote.role, "advisor_confidence");
+    }
+
+    #[test]
+    fn escalate_decision_scores_zero() {
+        let ctx = GraphContext::new("/tmp", "run-1");
+        let reviewer = AdvisorConfidenceReviewer::default();
+        let vote = reviewer.review(&input(10, 0.1), &ctx).unwrap();
+        assert_eq!(vote.score, 0.0);
+    }
+
+    #[test]
+    fn custom_thresholds_change_the_outcome() {
+        let ctx = GraphContext::new("/tmp", "run-1");
+        let lenient = DecisionThresholds {
+            min_confidence: 0.05,
+            max_risk_score: 100,
+            escalate_risk_score: 101,
+        };
+        let reviewer = AdvisorConfidenceReviewer::with_thresholds(lenient);
+        let vote = reviewer.review(&input(90, 0.1), &ctx).unwrap();
+        assert_eq!(vote.score, 1.0, "lenient thresholds should now commit");
+    }
+}

--- a/crates/ta-workflow/src/graph/nodes/mod.rs
+++ b/crates/ta-workflow/src/graph/nodes/mod.rs
@@ -1,0 +1,14 @@
+// graph/nodes/mod.rs — Built-in node implementations shippable from
+// `ta-workflow` itself (v0.17.7.1). `GoalDispatchAction`, `AutoApproveAction`,
+// and `RecommendAction` need `ta-brain`/`ta-goal`/the real draft-apply path
+// and are therefore implemented one layer up, in `apps/ta-cli`, and
+// registered into a `NodeRegistry` alongside these built-ins — see
+// `graph/registry.rs`'s module doc comment for why.
+
+mod advisor_confidence_reviewer;
+mod policy_reviewer;
+mod weighted_decision;
+
+pub use advisor_confidence_reviewer::AdvisorConfidenceReviewer;
+pub use policy_reviewer::PolicyReviewer;
+pub use weighted_decision::WeightedDecisionNode;

--- a/crates/ta-workflow/src/graph/nodes/policy_reviewer.rs
+++ b/crates/ta-workflow/src/graph/nodes/policy_reviewer.rs
@@ -1,0 +1,87 @@
+// graph/nodes/policy_reviewer.rs — `PolicyReviewer` (v0.17.7.1).
+//
+// Wraps the existing `ta_policy::auto_approve::should_auto_approve_draft`
+// rule evaluation as one scored `ReviewerVote`, per the reuse inventory in
+// docs/superpowers/specs/2026-07-21-workflow-graph-engine-design.md §5.
+
+use ta_policy::{
+    auto_approve::should_auto_approve_draft, AutoApproveDecision, DraftInfo, PolicyDocument,
+};
+
+use crate::graph::types::{GraphContext, GraphError, ReviewInput, ReviewerNode, ReviewerVote};
+
+/// Evaluates a draft against a `PolicyDocument`. Defaults to
+/// `PolicyDocument::default()` when constructed via the registry's built-in
+/// factory (`NodeRegistry::with_builtins()`); a caller that has already
+/// loaded a project's real policy document can build one directly with
+/// `PolicyReviewer::with_document(doc)` instead.
+#[derive(Default)]
+pub struct PolicyReviewer {
+    document: PolicyDocument,
+}
+
+impl PolicyReviewer {
+    pub fn with_document(document: PolicyDocument) -> Self {
+        Self { document }
+    }
+}
+
+impl ReviewerNode for PolicyReviewer {
+    fn review(&self, input: &ReviewInput, _ctx: &GraphContext) -> Result<ReviewerVote, GraphError> {
+        let draft = DraftInfo {
+            changed_paths: input.changed_paths.clone(),
+            lines_changed: input.lines_changed,
+            plan_phase: input.plan_phase.clone(),
+            agent_id: input.agent_id.clone(),
+        };
+        let decision = should_auto_approve_draft(&draft, &self.document);
+        let (score, findings) = match decision {
+            AutoApproveDecision::Approved { reasons } => (1.0, reasons),
+            AutoApproveDecision::Denied { blockers } => (0.0, blockers),
+        };
+        Ok(ReviewerVote {
+            role: "policy".to_string(),
+            score,
+            findings,
+            timed_out: false,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(paths: &[&str]) -> ReviewInput {
+        ReviewInput {
+            changed_paths: paths.iter().map(|s| s.to_string()).collect(),
+            lines_changed: 10,
+            agent_id: "claude-code".to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn defaults_to_denied_until_a_human_enables_auto_approve() {
+        // PolicyDocument::default() has auto_approve.drafts.enabled = false —
+        // mirrors §1.3's Human-in-the-Loop default: nothing auto-approves
+        // until a human explicitly turns it on.
+        let ctx = GraphContext::new("/tmp", "run-1");
+        let reviewer = PolicyReviewer::default();
+        let vote = reviewer.review(&input(&["src/main.rs"]), &ctx).unwrap();
+        assert_eq!(vote.role, "policy");
+        assert_eq!(vote.score, 0.0);
+        assert!(!vote.timed_out);
+    }
+
+    #[test]
+    fn approves_once_a_document_explicitly_enables_auto_approve() {
+        let mut doc = PolicyDocument::default();
+        doc.defaults.auto_approve.drafts.enabled = true;
+        let ctx = GraphContext::new("/tmp", "run-1");
+        let reviewer = PolicyReviewer::with_document(doc);
+        let vote = reviewer.review(&input(&["src/main.rs"]), &ctx).unwrap();
+        assert_eq!(vote.score, 1.0);
+        assert!(!vote.findings.is_empty());
+    }
+}

--- a/crates/ta-workflow/src/graph/nodes/weighted_decision.rs
+++ b/crates/ta-workflow/src/graph/nodes/weighted_decision.rs
@@ -1,0 +1,119 @@
+// graph/nodes/weighted_decision.rs — `WeightedDecisionNode` (v0.17.7.1).
+//
+// A thin wrapper over `ta-workflow::consensus::run_consensus` — the
+// difference from today's `governed_workflow.rs::stage_consensus` is that
+// algorithm/threshold/weights come from the graph's TOML config, not
+// hardcoded literals (`threshold=0.75`/`ConsensusAlgorithm::Raft`/empty
+// weights at governed_workflow.rs:2494-2498).
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use crate::consensus::{run_consensus, ConsensusAlgorithm, ConsensusInput};
+use crate::graph::schema::DecisionDef;
+use crate::graph::types::{Decision, DecisionNode, GraphContext, GraphError, ReviewerVote};
+
+pub struct WeightedDecisionNode {
+    pub algorithm: ConsensusAlgorithm,
+    pub threshold: f64,
+    pub weights: HashMap<String, f64>,
+    pub require_all: bool,
+}
+
+impl WeightedDecisionNode {
+    pub fn from_def(def: &DecisionDef) -> Self {
+        let algorithm = def
+            .algorithm
+            .as_deref()
+            .and_then(|s| ConsensusAlgorithm::from_str(s).ok())
+            .unwrap_or_default();
+        Self {
+            algorithm,
+            threshold: def.threshold,
+            weights: def.weights.clone(),
+            require_all: def.require_all,
+        }
+    }
+}
+
+impl DecisionNode for WeightedDecisionNode {
+    fn decide(&self, votes: &[ReviewerVote], ctx: &GraphContext) -> Result<Decision, GraphError> {
+        let input = ConsensusInput {
+            votes: votes.to_vec(),
+            weights: self.weights.clone(),
+            threshold: self.threshold,
+            algorithm: self.algorithm.clone(),
+            run_id: ctx.run_id.clone(),
+            run_dir: ctx.run_dir.clone(),
+            require_all: self.require_all,
+            override_reason: None,
+        };
+        Ok(run_consensus(&input)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vote(role: &str, score: f64) -> ReviewerVote {
+        ReviewerVote {
+            role: role.to_string(),
+            score,
+            findings: vec![],
+            timed_out: false,
+        }
+    }
+
+    #[test]
+    fn threshold_and_weights_come_from_def_not_hardcoded() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = GraphContext {
+            workspace_root: dir.path().to_path_buf(),
+            run_id: "run-1".to_string(),
+            run_dir: dir.path().to_path_buf(),
+            vars: Default::default(),
+        };
+        let mut weights = HashMap::new();
+        weights.insert("security".to_string(), 2.0);
+        let def = DecisionDef {
+            id: "d1".into(),
+            kind: "weighted".into(),
+            algorithm: Some("weighted".into()),
+            threshold: 0.9,
+            inputs: vec!["architect".into(), "security".into()],
+            weights,
+            require_all: false,
+        };
+        let node = WeightedDecisionNode::from_def(&def);
+        let votes = vec![vote("architect", 0.9), vote("security", 0.5)];
+        let result = node.decide(&votes, &ctx).unwrap();
+        // weighted average = (0.9*1.0 + 0.5*2.0) / 3.0 = 1.9/3.0 = 0.6333
+        assert!((result.score - 0.6333).abs() < 1e-3);
+        assert!(!result.proceed, "0.63 < threshold 0.9");
+    }
+
+    #[test]
+    fn low_threshold_proceeds_with_same_votes() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = GraphContext {
+            workspace_root: dir.path().to_path_buf(),
+            run_id: "run-2".to_string(),
+            run_dir: dir.path().to_path_buf(),
+            vars: Default::default(),
+        };
+        let def = DecisionDef {
+            id: "d1".into(),
+            kind: "weighted".into(),
+            algorithm: None,
+            threshold: 0.5,
+            inputs: vec![],
+            weights: HashMap::new(),
+            require_all: false,
+        };
+        let node = WeightedDecisionNode::from_def(&def);
+        let votes = vec![vote("policy", 0.8)];
+        let result = node.decide(&votes, &ctx).unwrap();
+        assert!(result.proceed);
+    }
+}

--- a/crates/ta-workflow/src/graph/registry.rs
+++ b/crates/ta-workflow/src/graph/registry.rs
@@ -1,0 +1,241 @@
+// graph/registry.rs — Node-kind registry for the graph engine (v0.17.7.1).
+//
+// Maps a TOML `kind` string to a constructor for the matching trait object.
+// Built-in kinds that only need what `ta-workflow` already depends on
+// (`ta-policy`, `ta-decision`, the local `consensus` module) are registered
+// by `NodeRegistry::with_builtins()`. Kinds needing heavier crates
+// (`ta-brain`, `ta-goal` — `GoalDispatchAction`; the real draft-apply path —
+// `AutoApproveAction`/`RecommendAction`) are registered by the caller
+// (`apps/ta-cli`), which already depends on all of them — this keeps
+// `ta-workflow` free of a dependency cycle (`ta-brain` already depends on
+// `ta-workflow` for its template-matching signal).
+
+use std::collections::HashMap;
+
+use super::schema::{ActionDef, DecisionDef, NodeDef};
+use super::types::{ActionNode, DecisionNode, GraphError, ReviewerNode, TriggerSource, WorkerNode};
+
+type TriggerFactory =
+    Box<dyn Fn(&NodeDef) -> Result<Box<dyn TriggerSource>, GraphError> + Send + Sync>;
+type WorkerFactory = Box<dyn Fn(&NodeDef) -> Result<Box<dyn WorkerNode>, GraphError> + Send + Sync>;
+type ReviewerFactory =
+    Box<dyn Fn(&NodeDef) -> Result<Box<dyn ReviewerNode>, GraphError> + Send + Sync>;
+type DecisionFactory =
+    Box<dyn Fn(&DecisionDef) -> Result<Box<dyn DecisionNode>, GraphError> + Send + Sync>;
+type ActionFactory =
+    Box<dyn Fn(&ActionDef) -> Result<Box<dyn ActionNode>, GraphError> + Send + Sync>;
+
+/// Registry of node-kind constructors, keyed by the TOML `kind` string.
+#[derive(Default)]
+pub struct NodeRegistry {
+    triggers: HashMap<String, TriggerFactory>,
+    workers: HashMap<String, WorkerFactory>,
+    reviewers: HashMap<String, ReviewerFactory>,
+    decisions: HashMap<String, DecisionFactory>,
+    actions: HashMap<String, ActionFactory>,
+}
+
+impl NodeRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The three node kinds fully expressible with `ta-workflow`'s own
+    /// dependency set: `policy` (`PolicyReviewer`), `advisor_confidence`
+    /// (`AdvisorConfidenceReviewer`), and `weighted` (`WeightedDecisionNode`)
+    /// — enough to express today's existing single-reviewer approval flow as
+    /// a graph (v0.17.7.1's proof-of-abstraction scope).
+    pub fn with_builtins() -> Self {
+        let mut registry = Self::new();
+        registry.register_reviewer("policy", |_def| {
+            Ok(Box::new(super::nodes::PolicyReviewer::default()) as Box<dyn ReviewerNode>)
+        });
+        registry.register_reviewer("advisor_confidence", |_def| {
+            Ok(Box::new(super::nodes::AdvisorConfidenceReviewer::default())
+                as Box<dyn ReviewerNode>)
+        });
+        registry.register_decision("weighted", |def| {
+            Ok(Box::new(super::nodes::WeightedDecisionNode::from_def(def))
+                as Box<dyn DecisionNode>)
+        });
+        registry
+    }
+
+    pub fn register_trigger(
+        &mut self,
+        kind: impl Into<String>,
+        factory: impl Fn(&NodeDef) -> Result<Box<dyn TriggerSource>, GraphError> + Send + Sync + 'static,
+    ) {
+        self.triggers.insert(kind.into(), Box::new(factory));
+    }
+
+    pub fn register_worker(
+        &mut self,
+        kind: impl Into<String>,
+        factory: impl Fn(&NodeDef) -> Result<Box<dyn WorkerNode>, GraphError> + Send + Sync + 'static,
+    ) {
+        self.workers.insert(kind.into(), Box::new(factory));
+    }
+
+    pub fn register_reviewer(
+        &mut self,
+        kind: impl Into<String>,
+        factory: impl Fn(&NodeDef) -> Result<Box<dyn ReviewerNode>, GraphError> + Send + Sync + 'static,
+    ) {
+        self.reviewers.insert(kind.into(), Box::new(factory));
+    }
+
+    pub fn register_decision(
+        &mut self,
+        kind: impl Into<String>,
+        factory: impl Fn(&DecisionDef) -> Result<Box<dyn DecisionNode>, GraphError>
+            + Send
+            + Sync
+            + 'static,
+    ) {
+        self.decisions.insert(kind.into(), Box::new(factory));
+    }
+
+    pub fn register_action(
+        &mut self,
+        kind: impl Into<String>,
+        factory: impl Fn(&ActionDef) -> Result<Box<dyn ActionNode>, GraphError> + Send + Sync + 'static,
+    ) {
+        self.actions.insert(kind.into(), Box::new(factory));
+    }
+
+    pub fn build_trigger(&self, def: &NodeDef) -> Result<Box<dyn TriggerSource>, GraphError> {
+        let factory = self
+            .triggers
+            .get(&def.kind)
+            .ok_or_else(|| GraphError::NodeNotFound {
+                category: "trigger",
+                kind: def.kind.clone(),
+            })?;
+        factory(def)
+    }
+
+    pub fn build_worker(&self, def: &NodeDef) -> Result<Box<dyn WorkerNode>, GraphError> {
+        let factory = self
+            .workers
+            .get(&def.kind)
+            .ok_or_else(|| GraphError::NodeNotFound {
+                category: "worker",
+                kind: def.kind.clone(),
+            })?;
+        factory(def)
+    }
+
+    pub fn build_reviewer(&self, def: &NodeDef) -> Result<Box<dyn ReviewerNode>, GraphError> {
+        let factory = self
+            .reviewers
+            .get(&def.kind)
+            .ok_or_else(|| GraphError::NodeNotFound {
+                category: "reviewer",
+                kind: def.kind.clone(),
+            })?;
+        factory(def)
+    }
+
+    pub fn build_decision(&self, def: &DecisionDef) -> Result<Box<dyn DecisionNode>, GraphError> {
+        let factory = self
+            .decisions
+            .get(&def.kind)
+            .ok_or_else(|| GraphError::NodeNotFound {
+                category: "decision",
+                kind: def.kind.clone(),
+            })?;
+        factory(def)
+    }
+
+    pub fn build_action(&self, def: &ActionDef) -> Result<Box<dyn ActionNode>, GraphError> {
+        let factory = self
+            .actions
+            .get(&def.kind)
+            .ok_or_else(|| GraphError::NodeNotFound {
+                category: "action",
+                kind: def.kind.clone(),
+            })?;
+        factory(def)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_builtins_registers_policy_advisor_and_weighted() {
+        let registry = NodeRegistry::with_builtins();
+        let reviewer_def = NodeDef {
+            id: "r1".into(),
+            kind: "policy".into(),
+            params: Default::default(),
+        };
+        assert!(registry.build_reviewer(&reviewer_def).is_ok());
+
+        let advisor_def = NodeDef {
+            id: "r2".into(),
+            kind: "advisor_confidence".into(),
+            params: Default::default(),
+        };
+        assert!(registry.build_reviewer(&advisor_def).is_ok());
+
+        let decision_def = DecisionDef {
+            id: "d1".into(),
+            kind: "weighted".into(),
+            algorithm: None,
+            threshold: 0.75,
+            inputs: vec![],
+            weights: Default::default(),
+            require_all: false,
+        };
+        assert!(registry.build_decision(&decision_def).is_ok());
+    }
+
+    #[test]
+    fn unknown_kind_returns_node_not_found() {
+        let registry = NodeRegistry::with_builtins();
+        let def = NodeDef {
+            id: "r1".into(),
+            kind: "does_not_exist".into(),
+            params: Default::default(),
+        };
+        let err = registry.build_reviewer(&def).map(|_| ()).unwrap_err();
+        assert!(matches!(
+            err,
+            GraphError::NodeNotFound {
+                category: "reviewer",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn caller_can_register_additional_action_kinds() {
+        struct Noop;
+        impl ActionNode for Noop {
+            fn act(
+                &self,
+                _decision: &super::super::types::Decision,
+                _ctx: &super::super::types::GraphContext,
+            ) -> Result<super::super::types::ActionOutcome, GraphError> {
+                Ok(super::super::types::ActionOutcome {
+                    kind: "noop".into(),
+                    applied: false,
+                    message: "noop".into(),
+                    metadata: Default::default(),
+                })
+            }
+        }
+        let mut registry = NodeRegistry::with_builtins();
+        registry.register_action("noop", |_def| Ok(Box::new(Noop) as Box<dyn ActionNode>));
+        let def = ActionDef {
+            id: "a1".into(),
+            kind: "noop".into(),
+            decision: None,
+            params: Default::default(),
+        };
+        assert!(registry.build_action(&def).is_ok());
+    }
+}

--- a/crates/ta-workflow/src/graph/schema.rs
+++ b/crates/ta-workflow/src/graph/schema.rs
@@ -1,0 +1,325 @@
+// graph/schema.rs — TOML graph-definition schema + loader (v0.17.7.1).
+//
+// `.ta/workflows/graphs/<name>.toml` -> `GraphDefinition`. See
+// docs/superpowers/specs/2026-07-21-workflow-graph-engine-design.md §3 for
+// the canonical example this schema mirrors.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::types::GraphError;
+
+/// A generic `id` + `kind` + free-form params node entry, used for
+/// `[[trigger]]`, `[[worker]]`, and `[[reviewer]]` sections — each node
+/// `kind` may need different extra fields (e.g. `agent_panel`'s `role`,
+/// `goal_dispatch`'s `verb`/`workload_hint`), so those live in `params`
+/// rather than being hardcoded per section, mirroring `StepAction`'s
+/// `action_type` + `params` shape (`crate::step_action::StepAction`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NodeDef {
+    pub id: String,
+    pub kind: String,
+    #[serde(flatten)]
+    pub params: toml::value::Table,
+}
+
+impl NodeDef {
+    /// Read a string param, if present.
+    pub fn param_str(&self, key: &str) -> Option<&str> {
+        self.params.get(key).and_then(|v| v.as_str())
+    }
+}
+
+/// `[decision]` — fan-in from N reviewer ids to one `Decision`. Config
+/// (algorithm/threshold/weights) is data, not hardcoded literals — the gap
+/// `WeightedDecisionNode` fixes in `governed_workflow.rs`'s `stage_consensus`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DecisionDef {
+    pub id: String,
+    #[serde(default = "default_decision_kind")]
+    pub kind: String,
+    /// "raft" | "paxos" | "weighted". Defaults to "weighted" (§16.5: the
+    /// algorithm set may stay a closed enum, only the wiring must be data).
+    #[serde(default)]
+    pub algorithm: Option<String>,
+    #[serde(default = "default_threshold")]
+    pub threshold: f64,
+    /// Reviewer ids that fan into this decision.
+    #[serde(default)]
+    pub inputs: Vec<String>,
+    #[serde(default)]
+    pub weights: HashMap<String, f64>,
+    #[serde(default)]
+    pub require_all: bool,
+}
+
+fn default_decision_kind() -> String {
+    "weighted".to_string()
+}
+
+fn default_threshold() -> f64 {
+    0.75
+}
+
+/// `[action]` — the terminal node. `decision` names the `[decision].id`
+/// whose output feeds this action.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ActionDef {
+    pub id: String,
+    /// "auto_approve" | "recommend" | ... — swapping only this string
+    /// changes whether the same `Decision` becomes binding or advisory
+    /// (constitution §16.2).
+    pub kind: String,
+    #[serde(default)]
+    pub decision: Option<String>,
+    #[serde(flatten)]
+    pub params: toml::value::Table,
+}
+
+/// In-memory form of a `.ta/workflows/graphs/<name>.toml` file.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GraphDefinition {
+    #[serde(default, rename = "trigger")]
+    pub triggers: Vec<NodeDef>,
+    #[serde(default, rename = "worker")]
+    pub workers: Vec<NodeDef>,
+    #[serde(default, rename = "reviewer")]
+    pub reviewers: Vec<NodeDef>,
+    pub decision: Option<DecisionDef>,
+    pub action: Option<ActionDef>,
+}
+
+impl GraphDefinition {
+    /// Parse a graph definition from a TOML string.
+    pub fn from_toml_str(content: &str) -> Result<Self, GraphError> {
+        let def: GraphDefinition =
+            toml::from_str(content).map_err(|e| GraphError::Parse(e.to_string()))?;
+        def.validate()?;
+        Ok(def)
+    }
+
+    /// Load `.ta/workflows/graphs/<name>.toml` (or any path) from disk.
+    pub fn load_file(path: &Path) -> Result<Self, GraphError> {
+        let content = std::fs::read_to_string(path).map_err(|e| GraphError::Io {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+        Self::from_toml_str(&content)
+    }
+
+    /// Resolve `<name>` to `<workspace_root>/.ta/workflows/graphs/<name>.toml`
+    /// and load it. Accepts either a bare name ("phase-review-panel") or a
+    /// path ending in `.toml`.
+    pub fn load_named(workspace_root: &Path, name: &str) -> Result<Self, GraphError> {
+        let path = if name.ends_with(".toml") {
+            Path::new(name).to_path_buf()
+        } else {
+            workspace_root
+                .join(".ta")
+                .join("workflows")
+                .join("graphs")
+                .join(format!("{name}.toml"))
+        };
+        Self::load_file(&path)
+    }
+
+    /// Structural checks beyond what serde enforces: every id referenced by
+    /// `[decision].inputs` and `[action].decision` must exist, and ids must
+    /// be unique within the graph.
+    fn validate(&self) -> Result<(), GraphError> {
+        let mut seen = std::collections::HashSet::new();
+        for id in self
+            .triggers
+            .iter()
+            .map(|n| &n.id)
+            .chain(self.workers.iter().map(|n| &n.id))
+            .chain(self.reviewers.iter().map(|n| &n.id))
+            .chain(self.decision.iter().map(|d| &d.id))
+            .chain(self.action.iter().map(|a| &a.id))
+        {
+            if !seen.insert(id.as_str()) {
+                return Err(GraphError::InvalidDefinition(format!(
+                    "duplicate node id '{id}'"
+                )));
+            }
+        }
+
+        if let Some(decision) = &self.decision {
+            let reviewer_ids: std::collections::HashSet<&str> =
+                self.reviewers.iter().map(|r| r.id.as_str()).collect();
+            for input in &decision.inputs {
+                if !reviewer_ids.contains(input.as_str()) {
+                    return Err(GraphError::InvalidDefinition(format!(
+                        "decision '{}' references unknown reviewer input '{input}'",
+                        decision.id
+                    )));
+                }
+            }
+        }
+
+        if let Some(action) = &self.action {
+            if let Some(decision_ref) = &action.decision {
+                let matches = self
+                    .decision
+                    .as_ref()
+                    .map(|d| &d.id == decision_ref)
+                    .unwrap_or(false);
+                if !matches {
+                    return Err(GraphError::InvalidDefinition(format!(
+                        "action '{}' references unknown decision '{decision_ref}'",
+                        action.id
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REFERENCE_GRAPH: &str = r#"
+[[trigger]]
+id = "draft_ready"
+kind = "vcs_task_completion"
+
+[[reviewer]]
+id = "policy_check"
+kind = "policy"
+
+[[reviewer]]
+id = "pm_score"
+kind = "agent_panel"
+role = "pm"
+
+[decision]
+id = "panel_verdict"
+kind = "weighted"
+algorithm = "weighted"
+threshold = 0.75
+inputs = ["policy_check", "pm_score"]
+weights = { policy_check = 1.0, pm_score = 1.0 }
+
+[action]
+id = "outcome"
+kind = "recommend"
+decision = "panel_verdict"
+"#;
+
+    #[test]
+    fn parses_reference_graph() {
+        let def = GraphDefinition::from_toml_str(REFERENCE_GRAPH).unwrap();
+        assert_eq!(def.triggers.len(), 1);
+        assert_eq!(def.triggers[0].kind, "vcs_task_completion");
+        assert_eq!(def.reviewers.len(), 2);
+        assert_eq!(def.reviewers[1].param_str("role"), Some("pm"));
+        let decision = def.decision.unwrap();
+        assert_eq!(decision.threshold, 0.75);
+        assert_eq!(decision.inputs, vec!["policy_check", "pm_score"]);
+        assert_eq!(decision.weights.get("pm_score"), Some(&1.0));
+        let action = def.action.unwrap();
+        assert_eq!(action.kind, "recommend");
+        assert_eq!(action.decision.as_deref(), Some("panel_verdict"));
+    }
+
+    #[test]
+    fn swapping_action_kind_is_the_only_diff_between_recommend_and_auto_approve() {
+        let recommend = GraphDefinition::from_toml_str(REFERENCE_GRAPH).unwrap();
+        let auto_approve_toml = REFERENCE_GRAPH.replace(
+            "kind = \"recommend\"\ndecision = \"panel_verdict\"",
+            "kind = \"auto_approve\"\ndecision = \"panel_verdict\"",
+        );
+        let auto_approve = GraphDefinition::from_toml_str(&auto_approve_toml).unwrap();
+        assert_eq!(
+            recommend.decision.unwrap().id,
+            auto_approve.decision.unwrap().id
+        );
+        assert_ne!(
+            recommend.action.unwrap().kind,
+            auto_approve.action.unwrap().kind
+        );
+    }
+
+    #[test]
+    fn rejects_decision_input_referencing_unknown_reviewer() {
+        let bad = r#"
+[[reviewer]]
+id = "policy_check"
+kind = "policy"
+
+[decision]
+id = "panel_verdict"
+inputs = ["nonexistent"]
+
+[action]
+id = "outcome"
+kind = "recommend"
+decision = "panel_verdict"
+"#;
+        let err = GraphDefinition::from_toml_str(bad).unwrap_err();
+        assert!(matches!(err, GraphError::InvalidDefinition(_)));
+    }
+
+    #[test]
+    fn rejects_action_referencing_unknown_decision() {
+        let bad = r#"
+[action]
+id = "outcome"
+kind = "recommend"
+decision = "does_not_exist"
+"#;
+        let err = GraphDefinition::from_toml_str(bad).unwrap_err();
+        assert!(matches!(err, GraphError::InvalidDefinition(_)));
+    }
+
+    #[test]
+    fn rejects_duplicate_ids() {
+        let bad = r#"
+[[reviewer]]
+id = "dup"
+kind = "policy"
+
+[decision]
+id = "dup"
+"#;
+        let err = GraphDefinition::from_toml_str(bad).unwrap_err();
+        assert!(matches!(err, GraphError::InvalidDefinition(_)));
+    }
+
+    #[test]
+    fn defaults_apply_when_fields_omitted() {
+        let minimal = r#"
+[decision]
+id = "d1"
+"#;
+        let def = GraphDefinition::from_toml_str(minimal).unwrap();
+        let decision = def.decision.unwrap();
+        assert_eq!(decision.kind, "weighted");
+        assert_eq!(decision.threshold, 0.75);
+        assert!(decision.algorithm.is_none());
+    }
+
+    #[test]
+    fn load_file_reads_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.toml");
+        std::fs::write(&path, REFERENCE_GRAPH).unwrap();
+        let def = GraphDefinition::load_file(&path).unwrap();
+        assert_eq!(def.reviewers.len(), 2);
+    }
+
+    #[test]
+    fn load_named_resolves_under_ta_workflows_graphs() {
+        let dir = tempfile::tempdir().unwrap();
+        let graphs_dir = dir.path().join(".ta").join("workflows").join("graphs");
+        std::fs::create_dir_all(&graphs_dir).unwrap();
+        std::fs::write(graphs_dir.join("phase-review-panel.toml"), REFERENCE_GRAPH).unwrap();
+        let def = GraphDefinition::load_named(dir.path(), "phase-review-panel").unwrap();
+        assert_eq!(def.reviewers.len(), 2);
+    }
+}

--- a/crates/ta-workflow/src/graph/types.rs
+++ b/crates/ta-workflow/src/graph/types.rs
@@ -1,0 +1,218 @@
+// graph/types.rs — Core node traits and data types for the workflow graph
+// engine (v0.17.7.1).
+//
+// A workflow graph is a set of typed nodes connected by typed edges. Every
+// node type implements exactly one of five traits below. `ReviewerVote` and
+// `Decision` are reused from `crate::consensus` rather than redefined, per
+// constitution §1.7 / PLAN.md v0.17.7.1 item 1.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+pub use crate::consensus::{ConsensusResult as Decision, ReviewerVote};
+
+// ── GraphContext ─────────────────────────────────────────────────────────
+
+/// Shared, mutable-by-convention context threaded through every node call in
+/// a single graph run. `vars` is a free-form pass-through bag (e.g. a
+/// worker's `draft_id`) so nodes can hand data downstream without the engine
+/// needing to know about every node kind's payload shape.
+#[derive(Debug, Clone)]
+pub struct GraphContext {
+    /// Project root the graph is operating against.
+    pub workspace_root: PathBuf,
+    /// Unique identifier for this graph run (used for run-dir paths and
+    /// consensus log files, same convention as `ConsensusInput::run_id`).
+    pub run_id: String,
+    /// Directory for this run's persisted state (`.ta/workflow-runs/<run-id>/graph/`).
+    pub run_dir: PathBuf,
+    /// Free-form key/value data passed between nodes across a single run
+    /// (e.g. `"draft_id" -> "abc123"` set by a `WorkerNode`, read later by
+    /// an `ActionNode`).
+    pub vars: HashMap<String, String>,
+}
+
+impl GraphContext {
+    pub fn new(workspace_root: impl Into<PathBuf>, run_id: impl Into<String>) -> Self {
+        let workspace_root = workspace_root.into();
+        let run_id = run_id.into();
+        let run_dir = workspace_root
+            .join(".ta")
+            .join("workflow-runs")
+            .join(&run_id)
+            .join("graph");
+        Self {
+            workspace_root,
+            run_id,
+            run_dir,
+            vars: HashMap::new(),
+        }
+    }
+}
+
+// ── TriggerPayload ───────────────────────────────────────────────────────
+
+/// Typed payload a `TriggerSource` hands back when it fires.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TriggerPayload {
+    /// The trigger kind that fired (matches the TOML `[[trigger]] kind`).
+    pub kind: String,
+    /// Free-form event data (e.g. `"review_id" -> "PR-123"`).
+    pub data: HashMap<String, String>,
+}
+
+// ── WorkItem / WorkResult (WorkerNode) ───────────────────────────────────
+
+/// Spec for a unit of work a `WorkerNode` dispatches. `verb`/`workload_hint`
+/// are free-text data fed straight into `ta-brain::route()`'s
+/// already-data-defined `workload_type` classification — a new domain (art,
+/// docs, whatever) is a `workflow.toml` binding, not new Rust code.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WorkItem {
+    pub title: String,
+    pub objective: String,
+    #[serde(default)]
+    pub phase_id: Option<String>,
+    /// "implement", "create", "fix" — data, not an enum.
+    pub verb: String,
+    #[serde(default)]
+    pub workload_hint: Option<String>,
+}
+
+/// Reference to the work a `WorkerNode` dispatched, for the review graph
+/// segment to pick up (e.g. a draft ID).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WorkResult {
+    pub draft_id: String,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+// ── ReviewInput (ReviewerNode) ───────────────────────────────────────────
+
+/// The draft/decision context handed to every `ReviewerNode`. Carries the
+/// union of fields today's three separate approval mechanisms each need
+/// (`ta_policy::DraftInfo`'s size/path fields, `ta_decision::gate`'s
+/// verdict/risk/confidence fields) so any reviewer kind can read what it
+/// needs without the engine special-casing per-reviewer input shapes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReviewInput {
+    #[serde(default)]
+    pub draft_id: Option<String>,
+    #[serde(default)]
+    pub changed_paths: Vec<String>,
+    #[serde(default)]
+    pub lines_changed: usize,
+    #[serde(default)]
+    pub plan_phase: Option<String>,
+    #[serde(default)]
+    pub agent_id: String,
+    /// 0-100, higher is riskier — feeds `AdvisorConfidenceReviewer`.
+    #[serde(default)]
+    pub risk_score: u32,
+    /// 0.0-1.0 — feeds `AdvisorConfidenceReviewer`.
+    #[serde(default)]
+    pub confidence: f64,
+    /// Pass/Warn/Block — feeds `AdvisorConfidenceReviewer`.
+    #[serde(default = "default_verdict")]
+    pub verdict: ta_decision::Verdict,
+}
+
+fn default_verdict() -> ta_decision::Verdict {
+    ta_decision::Verdict::Pass
+}
+
+impl Default for ReviewInput {
+    fn default() -> Self {
+        Self {
+            draft_id: None,
+            changed_paths: Vec::new(),
+            lines_changed: 0,
+            plan_phase: None,
+            agent_id: String::new(),
+            risk_score: 0,
+            confidence: 1.0,
+            verdict: default_verdict(),
+        }
+    }
+}
+
+// ── ActionOutcome (ActionNode) ───────────────────────────────────────────
+
+/// Effect an `ActionNode` produced.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ActionOutcome {
+    /// The action kind that ran (matches the TOML `[action] kind`).
+    pub kind: String,
+    /// True when the action actually mutated state (e.g. applied a draft).
+    /// `RecommendAction` always reports `false` here — it never applies.
+    pub applied: bool,
+    /// Human-readable summary, always populated (Observable & Actionable).
+    pub message: String,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+}
+
+// ── GraphError ────────────────────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum GraphError {
+    #[error("failed to read graph definition at {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to parse graph definition: {0}")]
+    Parse(String),
+    #[error("graph definition invalid: {0}")]
+    InvalidDefinition(String),
+    #[error("no {category} node registered for kind '{kind}'")]
+    NodeNotFound {
+        category: &'static str,
+        kind: String,
+    },
+    #[error("node '{node_id}' failed: {message}")]
+    NodeExecution { node_id: String, message: String },
+}
+
+impl From<crate::WorkflowError> for GraphError {
+    fn from(err: crate::WorkflowError) -> Self {
+        GraphError::NodeExecution {
+            node_id: "decision".to_string(),
+            message: err.to_string(),
+        }
+    }
+}
+
+// ── Node traits ───────────────────────────────────────────────────────────
+
+/// Blocks/polls until the event fires; returns a typed payload.
+pub trait TriggerSource {
+    fn wait(&self, ctx: &GraphContext) -> Result<TriggerPayload, GraphError>;
+}
+
+/// Consumes a work-item spec, dispatches it, returns a reference (e.g. a
+/// draft ID) for the review graph segment to pick up.
+pub trait WorkerNode {
+    fn dispatch(&self, item: &WorkItem, ctx: &GraphContext) -> Result<WorkResult, GraphError>;
+}
+
+/// Produces one scored vote. Wraps today's separate approval mechanisms as
+/// interchangeable implementations of the same trait.
+pub trait ReviewerNode {
+    fn review(&self, input: &ReviewInput, ctx: &GraphContext) -> Result<ReviewerVote, GraphError>;
+}
+
+/// Fans in N `ReviewerVote`s, applies weights/threshold/algorithm, emits a
+/// typed `Decision`. Does NOT act.
+pub trait DecisionNode {
+    fn decide(&self, votes: &[ReviewerVote], ctx: &GraphContext) -> Result<Decision, GraphError>;
+}
+
+/// Consumes a `Decision` and performs an effect.
+pub trait ActionNode {
+    fn act(&self, decision: &Decision, ctx: &GraphContext) -> Result<ActionOutcome, GraphError>;
+}

--- a/crates/ta-workflow/src/lib.rs
+++ b/crates/ta-workflow/src/lib.rs
@@ -18,6 +18,7 @@ pub mod consensus;
 pub mod definition;
 pub mod dependency_wave;
 pub mod error;
+pub mod graph;
 pub mod intent;
 pub mod interaction;
 pub mod params;

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -21,8 +21,8 @@ reqwest = { workspace = true }
 anyhow = { workspace = true }
 sha2 = "0.10"
 base64 = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.6-alpha.3" }
-ta-goal = { path = "../ta-goal", version = "0.17.6-alpha.3" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: 0.17.6-alpha.3
+**Version**: 0.17.7-alpha.1
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 
@@ -489,6 +489,92 @@ name = "process-inbox"
 goal = "Check inbox and draft replies"
 agent = "claude-code"
 ```
+
+### Workflow Graphs
+
+Workflow graphs are a separate, lower-level engine (`ta-workflow::graph`) from the step-based Workflow TOML above. Where a step workflow chains sequential goal-runs, a graph wires together five typed node kinds — dispatch work, review it from multiple angles, weigh the reviews into one decision, then act on it — as a small TOML file instead of Rust code.
+
+**The five node kinds:**
+
+| Node | Role | Built-in kinds |
+|---|---|---|
+| `[[worker]]` | Dispatches new work (starts a goal) | `goal_dispatch` |
+| `[[reviewer]]` | Produces one scored vote on a draft/decision | `policy`, `advisor_confidence` |
+| `[decision]` | Fans in every reviewer vote, applies weights/threshold/algorithm | `weighted` |
+| `[action]` | Acts on the decision | `recommend`, `auto_approve` |
+| `[[trigger]]` | Fires the graph on an external event (parses today; execution wiring lands in a later release) | `vcs_task_completion` |
+
+**Recommendation vs. auto-approval is the same decision, different wiring.** A `[decision]` node never encodes whether its output is binding or advisory — that's purely which `[action] kind` the graph is wired to. Swap `kind = "recommend"` for `kind = "auto_approve"` in an otherwise identical graph, and the exact same decision goes from "surfaced to a human" to "applied automatically." **New graphs default to `recommend`** — a human must explicitly edit a graph to `auto_approve` before it can act on its own.
+
+Reference graph (also shipped at `templates/workflows/graphs/phase-review-panel.toml` — copy it to `.ta/workflows/graphs/<name>.toml` to use):
+
+```toml
+[[reviewer]]
+id = "policy_check"
+kind = "policy"
+
+[decision]
+id = "panel_verdict"
+kind = "weighted"
+algorithm = "weighted"   # "raft" | "paxos" | "weighted"
+threshold = 0.75
+inputs = ["policy_check"]
+weights = { policy_check = 1.0 }
+
+[action]
+id = "outcome"
+kind = "recommend"       # swap to "auto_approve" to let this graph apply drafts
+decision = "panel_verdict"
+```
+
+Run it with:
+
+```bash
+ta workflow graph-run phase-review-panel --title "My draft" --verb implement
+```
+
+**Dispatching work with `[[worker]]`.** A `goal_dispatch` worker starts a new goal via `ta goal start`, feeding `--verb`/`--workload-hint` straight into the existing routing brain's workload-type classification — no new Rust code is needed to add a new kind of work, only a `[workload_types.<verb>]` binding in `.ta/workflow.toml`:
+
+```toml
+# .ta/workflow.toml
+[workload_types.implement]
+team = "implementer"
+persona = "careful-reviewer"
+
+[workload_types.create]
+team = "reviewer"
+persona = "creative-generator"
+```
+
+```toml
+# .ta/workflows/graphs/dispatch-and-review.toml
+[[worker]]
+id = "dispatch"
+kind = "goal_dispatch"
+
+[[reviewer]]
+id = "policy_check"
+kind = "policy"
+
+[decision]
+id = "verdict"
+threshold = 0.75
+inputs = ["policy_check"]
+
+[action]
+id = "outcome"
+kind = "recommend"
+decision = "verdict"
+```
+
+```bash
+# Same graph, two different dispatches — the routing decision (team/persona/
+# agent) differs purely from --verb, no graph or Rust change required:
+ta workflow graph-run dispatch-and-review --title "Add OAuth" --verb implement
+ta workflow graph-run dispatch-and-review --title "New logo" --verb create --workload-hint art
+```
+
+`ta workflow graph-run <name>` is a synchronous "run now" entry point for testing and debugging a graph definition — it does not yet wait on `[[trigger]]` sources or replace `ta draft apply`'s real approval gate (that wiring lands in a later phase). Flags: `--title`, `--objective`, `--verb` (default `implement`), `--workload-hint`, `--phase`.
 
 ---
 

--- a/templates/workflows/graphs/phase-review-panel.toml
+++ b/templates/workflows/graphs/phase-review-panel.toml
@@ -1,0 +1,32 @@
+# phase-review-panel.toml — Workflow Graph Engine reference graph (v0.17.7.1).
+#
+# Copy this file to .ta/workflows/graphs/phase-review-panel.toml (or any
+# other name) then run:
+#   ta workflow graph-run phase-review-panel --title "My draft" --verb implement
+#
+# This graph expresses today's existing single-reviewer approval flow as
+# data: a policy check feeds a weighted decision, which surfaces to a human
+# via RecommendAction. Per constitution §16.2, every new graph defaults to
+# `recommend` — a human must explicitly change `[action] kind` to
+# "auto_approve" to let this graph apply drafts on its own.
+#
+# See docs/superpowers/specs/2026-07-21-workflow-graph-engine-design.md §3
+# for the full design this schema implements, and docs/USAGE.md's
+# "Workflow Graphs" section for a walkthrough of all five node kinds.
+
+[[reviewer]]
+id = "policy_check"
+kind = "policy"
+
+[decision]
+id = "panel_verdict"
+kind = "weighted"
+algorithm = "weighted"   # "raft" | "paxos" | "weighted" — closed enum per §16.5
+threshold = 0.75
+inputs = ["policy_check"]
+weights = { policy_check = 1.0 }
+
+[action]
+id = "outcome"
+kind = "recommend"       # swap to "auto_approve" once a human upgrades this graph
+decision = "panel_verdict"


### PR DESCRIPTION
## Summary
- Defines `TriggerSource`/`WorkerNode`/`ReviewerNode`/`DecisionNode`/`ActionNode` node traits, `GraphContext`, `TriggerPayload`, `WorkItem`/`WorkResult` in `crates/ta-workflow/src/graph/`.
- TOML graph-definition schema + loader (`.ta/workflows/graphs/<name>.toml`).
- Shipped node implementations: `GoalDispatchAction` (wraps `ta run`/`ta goal start` via `ta-brain::route()`), `PolicyReviewer` (wraps `ta_policy::auto_approve::should_auto_approve_draft`), `AdvisorConfidenceReviewer` (wraps `ta-decision::gate::decide()`), `WeightedDecisionNode` (wraps `ta-workflow::consensus::run_consensus`, config-driven), `AutoApproveAction` (calls `ta draft apply`), `RecommendAction` (surfaces to Studio's Attention queue).
- New `ta workflow graph run <name>` CLI entry point for testing/debugging a graph before it's wired into `ta draft apply` (that wiring is v0.17.7.3).
- `templates/workflows/graphs/phase-review-panel.toml` reference graph.
- Per constitution 16.2, every new graph defaults to `RecommendAction` -- a human must explicitly rewire to `AutoApproveAction`.

## Test plan
- `cargo build --workspace` -- clean
- `cargo test --workspace` -- all passing
- `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- `cargo fmt --all -- --check` -- clean