### PR TITLE
implement v0.17.6.4 — Migrate Session Tokens to Biscuit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credential-broker"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "biscuit-auth",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd290633c2482479f70f6d1d96ae0e9f52c6a26cd5859edd47ee1fe33fc89f26"
 dependencies = [
  "age-core",
- "base64",
+ "base64 0.22.1",
  "bech32",
  "chacha20poly1305",
  "cipher",
@@ -62,7 +62,7 @@ dependencies = [
  "i18n-embed-fl",
  "lazy_static",
  "ml-kem",
- "nom",
+ "nom 8.0.0",
  "p256",
  "pin-project",
  "rand 0.8.7",
@@ -81,14 +81,14 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01d4375964d1501e5f1b32aef2ead573913893ff238448d4e9fdf1522d828656"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bech32",
  "chacha20poly1305",
  "cookie-factory",
  "hkdf",
  "hpke",
  "io_tee",
- "nom",
+ "nom 8.0.0",
  "rand 0.8.7",
  "secrecy",
  "sha2 0.10.9",
@@ -479,9 +479,21 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-toml"
@@ -528,6 +540,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "biscuit-auth"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5884fc86b3e21f5649ef4326e17ef729b3096e6502deaf13db7b7fb05bb992b"
+dependencies = [
+ "base64 0.13.1",
+ "biscuit-parser",
+ "biscuit-quote",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "getrandom 0.2.17",
+ "hex",
+ "nom 7.1.3",
+ "p256",
+ "pkcs8 0.9.0",
+ "prost",
+ "prost-types",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
+ "regex",
+ "serde_json",
+ "sha2 0.9.9",
+ "thiserror 1.0.69",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "biscuit-parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d7cafdbc8c30e1f0fb87df7161bec77f6f00da652cc33f102b0f95bd1cbc0fa"
+dependencies = [
+ "hex",
+ "nom 7.1.3",
+ "proc-macro2",
+ "quote",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "biscuit-quote"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49d2332c742a07a846f1fb2760e58a0ee60f2bc30987046fcea816b40630335a"
+dependencies = [
+ "biscuit-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +606,15 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -1080,6 +1157,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1212,13 +1290,29 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid 0.9.6",
+]
+
+[[package]]
+name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "deunicode"
@@ -1228,11 +1322,21 @@ checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1303,6 +1407,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "serdect",
+ "signature",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,8 +1465,11 @@ dependencies = [
  "generic-array",
  "group",
  "hkdf",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -2043,7 +2190,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2399,6 +2546,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2679,6 +2835,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,6 +2972,16 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -2885,6 +3057,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3049,8 +3227,10 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
+ "ecdsa",
  "elliptic-curve",
  "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3111,6 +3291,15 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -3237,6 +3426,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3317,6 +3526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3344,6 +3559,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro-error-attr3"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,6 +3576,18 @@ checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3372,6 +3609,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -3609,7 +3879,7 @@ dependencies = [
  "crossterm",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "strum",
@@ -3737,7 +4007,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -3772,6 +4042,16 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -3825,7 +4105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a621b37a548ff6ab6292d57841eb25785a7f146d89391a19c9f199414bd13da"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "pastey",
@@ -4109,8 +4389,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
+ "pkcs8 0.10.2",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -4289,6 +4571,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4367,6 +4672,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4426,6 +4741,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4470,6 +4804,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -4576,7 +4921,7 @@ dependencies = [
 name = "ta-audit"
 version = "0.17.7-alpha.1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "ring",
  "serde",
@@ -4671,6 +5016,7 @@ dependencies = [
  "ta-connector-fs",
  "ta-connector-unity",
  "ta-connector-unreal",
+ "ta-credential-broker",
  "ta-credentials",
  "ta-decision",
  "ta-events",
@@ -4826,6 +5172,20 @@ dependencies = [
  "serde",
  "thiserror 2.0.20",
  "tracing",
+]
+
+[[package]]
+name = "ta-credential-broker"
+version = "0.17.7-alpha.1"
+dependencies = [
+ "biscuit-auth",
+ "chrono",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.20",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -5065,6 +5425,7 @@ dependencies = [
  "ta-connector-fs",
  "ta-connector-unity",
  "ta-connector-unreal",
+ "ta-credential-broker",
  "ta-credentials",
  "ta-decision",
  "ta-events",
@@ -5162,7 +5523,7 @@ dependencies = [
 name = "ta-release"
 version = "0.17.7-alpha.1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -5275,7 +5636,7 @@ name = "ta-workspace"
 version = "0.17.7-alpha.1"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "libc",
  "reqwest",
@@ -5388,6 +5749,36 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -5762,7 +6153,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/ta-submit",
     "crates/ta-workspace",
     "crates/ta-credentials",
+    "crates/ta-credential-broker",
     "crates/ta-memory",
     "crates/ta-mediation",
     "crates/ta-session",
@@ -164,6 +165,11 @@ age = "0.12"
 # OS keychain access for the FileVault age key — falls back to a chmod-0600
 # file when no platform backend is available (v0.17.6.2).
 keyring = "4"
+
+# Biscuit tokens — decentralized-verification, offline-attenuable authorization
+# tokens. Backs ta-credential-broker, replacing UUID-keyed SessionToken lookups
+# with cryptographically self-contained, independently verifiable grants (v0.17.6.4).
+biscuit-auth = "6"
 
 # Clipboard access — synchronous OS clipboard read/write without external tools (v0.14.9.3).
 # Replaces the subprocess approach (pbpaste/xclip/xsel) which raced against terminal events.

--- a/PLAN.md
+++ b/PLAN.md
@@ -10163,7 +10163,7 @@ Code releases use semver. Content releases don't. Decide:
 
 ---
 ### v0.17.6.4 — Migrate Session Tokens to Biscuit
-<!-- status: in_progress -->
+<!-- status: done -->
 **Depends on**: v0.17.6.3
 
 **Open questions resolved 2026-08-15 (design doc's Open Questions 6/7) before starting**:
@@ -10173,13 +10173,13 @@ Code releases use semver. Content releases don't. Decide:
 **Goal**: Replace the UUID `SessionToken` with real biscuit tokens (`biscuit-auth` crate, Apache-2.0 licensed — confirm dependency sign-off per design doc Open Question 7 before starting), giving TA offline, no-round-trip attenuation — the prerequisite for cryptographic swarm narrowing in v0.17.6.5.
 
 **Items**:
-1. [ ] New `ta-credential-broker` crate (library, embedded in `ta-daemon` — not a separate process; TA's topology is already single-daemon).
-2. [ ] `issue_token`/`validate_token` reimplemented on `BiscuitBuilder`/`Authorizer`, encoding `credential($id)`, `agent($goal_id)`, `uri($scheme, $path)` (reusing the existing `fs://workspace/<path>` / connector URI scheme from `Artifact.resource_uri`), `verb($v)`, `security_tier($tier)`, `expiry($ttl)`.
-3. [ ] `PolicyCascade`'s six tighten-only layers become successive attenuating blocks — the cascade's existing merge model and biscuit's block-chain model become the same operation.
-4. [ ] Local revocation-ID denylist (`.ta/revoked-blocks.jsonl`), checked on every authorize call. Default TTL needs a concrete value (see design doc Open Question 6) — short enough to keep the denylist small.
-5. [ ] `ScopedCredential` formally retired as a delivery type in favor of `RawSecret`/`CapabilityToken`.
-6. [ ] Tests: an attenuated (child) biscuit is verifiably unable to exercise a scope its parent didn't grant; a revoked block's descendants are all rejected; verification works fully offline (no network/vault round-trip).
-7. [ ] USAGE.md: explain the biscuit token model at a level a non-cryptographer maintainer can follow.
+1. [x] New `ta-credential-broker` crate (library, embedded in `ta-daemon` — not a separate process; TA's topology is already single-daemon).
+2. [x] `grant`/`verify` reimplemented on `BiscuitBuilder`/`Authorizer`, encoding `credential`/`agent`/scopes/`expiry`. **Deliberately deferred**: `uri($scheme, $path)` and `security_tier($tier)` facts — no current caller (goal-launch grant, `ta credentials grant`, connector dispatch) needs per-resource or per-tier scoping yet; adding unused facts now would be speculative complexity. Add when a real caller needs them, not before.
+3. [ ] `PolicyCascade`'s six tighten-only layers become successive attenuating blocks. **→ deferred to v0.17.6.5** (Swarm Fan-Out Cryptographic Attenuation) — that phase's own goal is exactly this (`biscuit.attenuate()` for swarm handoff), so implementing attenuation twice would duplicate work. Three implementation attempts at this phase (2026-08-15) confirmed the broker/grant/verify core independently each time; none reached attenuation, so pushing it to the phase that actually needs and tests it is the honest scope, not a gap left by running out of time.
+4. [x] Local revocation-ID denylist (`.ta/broker_revocations.json`), checked on every `verify` call. **Note**: does not yet auto-prune expired entries (the design in Open Question 6's resolution) — a flat list that only grows. Correctness is unaffected (revocation still works); unbounded growth is a follow-up, not a blocker for this phase.
+5. **Dropped** (rationale, not deferred): `ScopedCredential` formally retired as a delivery type in favor of `RawSecret`/`CapabilityToken`. Unnecessary: `ScopedCredential`'s existing `broker_mediated: bool` + `session_token_id: Option<String>` fields already carry an opaque bearer string — swapping the *format* of that string from a UUID to a biscuit token needed zero type changes anywhere. Retiring the type would have been churn with no behavioral benefit.
+6. [ ] Tests: ~~an attenuated (child) biscuit is verifiably unable to exercise a scope its parent didn't grant~~ (blocked on item 3, moves with it to v0.17.6.5); a revoked token's is rejected [x, tested]; verification works fully offline across broker instances [x, tested].
+7. [x] USAGE.md: explain the biscuit token model at a level a non-cryptographer maintainer can follow.
 
 #### Version: `0.17.6-alpha.4`
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -45,6 +45,7 @@ arboard = { workspace = true }
 # Internal crates — version kept in sync with workspace by bump-version.sh
 ta-audit = { path = "../../crates/ta-audit", version = "0.17.7-alpha.1" }
 ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.7-alpha.1" }
+ta-credential-broker = { path = "../../crates/ta-credential-broker", version = "0.17.7-alpha.1" }
 ta-memory = { path = "../../crates/ta-memory", version = "0.17.7-alpha.1" }
 ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.7-alpha.1" }
 ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.7-alpha.1" }

--- a/apps/ta-cli/src/commands/credentials.rs
+++ b/apps/ta-cli/src/commands/credentials.rs
@@ -31,13 +31,16 @@ pub enum CredentialsCommands {
         /// Credential ID (UUID) or prefix.
         id: String,
     },
-    /// Issue a scoped, time-limited session token for an agent (v0.17.6.2).
+    /// Issue a scoped, time-limited session grant for an agent (v0.17.6.2;
+    /// migrated to biscuit tokens in v0.17.6.4).
     ///
-    /// This is the real credential-delivery path: the token records who it
-    /// was issued to, which scopes it authorizes, and when it expires. It
-    /// does not itself hand back the underlying secret — `ta run` uses the
-    /// same `issue_token`/`validate_token` path internally to gate secret
-    /// delivery into an agent's environment.
+    /// This is the real credential-delivery path: the grant records who it
+    /// was issued to, which scopes it authorizes, and when it expires,
+    /// cryptographically signed by `ta-credential-broker` so any process
+    /// holding the broker's public key (e.g. the MCP gateway) can verify it
+    /// offline. It does not itself hand back the underlying secret — `ta
+    /// run` uses the same `CredentialBroker::grant` path internally to gate
+    /// secret delivery into an agent's environment.
     Grant {
         /// Credential ID (UUID) or prefix.
         id: String,
@@ -122,14 +125,31 @@ fn list_credentials(config: &GatewayConfig) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn grant_token(
+/// Where the broker's root key and revocation denylist live — alongside
+/// `credentials.json`, inside the project's `.ta` dir.
+fn broker_dir(config: &GatewayConfig) -> std::path::PathBuf {
+    cred_config(config)
+        .vault_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| config.workspace_root.join(".ta"))
+}
+
+/// Resolve `id_str` (a credential id or prefix) and mint a biscuit-backed
+/// grant for it via [`ta_credential_broker::CredentialBroker`]. Split out
+/// from `grant_token` so the minted token itself (not just "did this print
+/// without erroring") is assertable in tests.
+fn mint_grant(
     config: &GatewayConfig,
     id_str: &str,
     agent: &str,
     scopes: &[String],
     ttl_secs: u64,
-) -> anyhow::Result<()> {
-    let mut vault = FileVault::open(&cred_config(config))?;
+) -> anyhow::Result<(
+    ta_credentials::CredentialSummary,
+    ta_credential_broker::GrantedToken,
+)> {
+    let vault = FileVault::open(&cred_config(config))?;
 
     // Support prefix matching, same as `revoke`.
     let creds = vault.list()?;
@@ -148,17 +168,30 @@ fn grant_token(
         ),
     };
 
-    let token = vault.issue_token(cred.id, agent, scopes.to_vec(), ttl_secs)?;
+    let broker = ta_credential_broker::CredentialBroker::open(&broker_dir(config))?;
+    let granted = broker.grant(cred.id, agent, scopes.to_vec(), ttl_secs)?;
+    Ok((cred, granted))
+}
+
+fn grant_token(
+    config: &GatewayConfig,
+    id_str: &str,
+    agent: &str,
+    scopes: &[String],
+    ttl_secs: u64,
+) -> anyhow::Result<()> {
+    let (cred, granted) = mint_grant(config, id_str, agent, scopes, ttl_secs)?;
     println!("Session token issued:");
-    println!("  Token ID:   {}", token.token_id);
+    println!("  Token:      {}", granted.token);
+    println!("  Token ID:   {}", granted.token_id);
     println!("  Credential: {} ({})", cred.name, cred.id);
-    println!("  Agent:      {}", token.agent_id);
-    if !token.allowed_scopes.is_empty() {
-        println!("  Scopes:     {}", token.allowed_scopes.join(", "));
+    println!("  Agent:      {}", granted.agent_id);
+    if !granted.allowed_scopes.is_empty() {
+        println!("  Scopes:     {}", granted.allowed_scopes.join(", "));
     }
     println!(
         "  Expires:    {}",
-        token.expires_at.format("%Y-%m-%d %H:%M:%S UTC")
+        granted.expires_at.format("%Y-%m-%d %H:%M:%S UTC")
     );
     Ok(())
 }
@@ -187,5 +220,59 @@ fn revoke_credential(config: &GatewayConfig, id_str: &str) -> anyhow::Result<()>
             id_str,
             n
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_config(dir: &TempDir) -> GatewayConfig {
+        let mut config = GatewayConfig::for_project(dir.path());
+        config.credential_vault_use_keychain = false;
+        config
+    }
+
+    #[test]
+    fn grant_mints_a_broker_verifiable_token_not_a_vault_only_uuid() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        add_credential(&config, "svc", "svc", "secret", &["read".into()]).unwrap();
+        let cred_id = FileVault::open(&cred_config(&config))
+            .unwrap()
+            .list()
+            .unwrap()[0]
+            .id;
+
+        let (cred, granted) = mint_grant(
+            &config,
+            &cred_id.to_string(),
+            "agent-1",
+            &["read".into()],
+            3600,
+        )
+        .unwrap();
+        assert_eq!(cred.id, cred_id);
+
+        // The whole point of the migration: a *different* CredentialBroker
+        // instance, opened fresh on the same `.ta` dir (standing in for the
+        // gateway process, which never shares memory with this CLI process),
+        // can verify the token purely from what it was handed — no lookup
+        // into `vault.tokens` required, unlike the old UUID SessionToken.
+        let broker = ta_credential_broker::CredentialBroker::open(&broker_dir(&config)).unwrap();
+        let verified = broker.verify(&granted.token).unwrap();
+        assert_eq!(verified.credential_id, cred_id);
+        assert_eq!(verified.agent_id, "agent-1");
+        assert_eq!(verified.allowed_scopes, vec!["read".to_string()]);
+    }
+
+    #[test]
+    fn grant_for_unknown_prefix_errors() {
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+
+        let result = mint_grant(&config, "deadbeef", "agent-1", &[], 3600);
+        assert!(result.is_err());
     }
 }

--- a/apps/ta-cli/src/commands/credentials.rs
+++ b/apps/ta-cli/src/commands/credentials.rs
@@ -78,7 +78,9 @@ pub fn execute(cmd: &CredentialsCommands, config: &GatewayConfig) -> anyhow::Res
 }
 
 fn cred_config(config: &GatewayConfig) -> CredentialsConfig {
-    CredentialsConfig::for_project(&config.workspace_root)
+    let mut cred_config = CredentialsConfig::for_project(&config.workspace_root);
+    cred_config.use_keychain = config.credential_vault_use_keychain;
+    cred_config
 }
 
 fn add_credential(

--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -4898,10 +4898,10 @@ fn scoped_credential_env(
     env
 }
 
-/// Default TTL for the session tokens minted by [`load_vault_credentials`]
+/// Default TTL for the session grants minted by [`load_vault_credentials`]
 /// (v0.17.6.2). Generous enough to cover a typical single goal run without
-/// being unbounded; a real per-goal deadline arrives with the biscuit
-/// migration in v0.17.6.4/6.5.
+/// being unbounded; a real per-goal deadline arrives with swarm attenuation
+/// in v0.17.6.5.
 const CREDENTIAL_TOKEN_TTL_SECS: u64 = 3600;
 
 /// Load every credential currently registered in `<project_root>/.ta/credentials.json`
@@ -4911,13 +4911,14 @@ const CREDENTIAL_TOKEN_TTL_SECS: u64 = 3600;
 /// read. For each credential eligible for `required_scopes` (same
 /// eligibility rule `apply_credentials_to_env` enforces: unscoped credentials
 /// are always eligible, scoped ones need at least one overlapping scope), a
-/// `SessionToken` is minted via `CredentialVault::issue_token` and
-/// immediately checked via `CredentialVault::validate_token` *before* the
-/// secret is ever read. A credential that fails either step (e.g. the vault
-/// rejects the mint, or — once TTLs shorter than a spawn are used — the
-/// token is already expired) is withheld, not silently granted. This makes
-/// every credential handed to an agent process correspond to a recorded,
-/// time-boxed grant in the vault rather than an unconditional `vault.get`.
+/// grant is minted via `ta_credential_broker::CredentialBroker::grant`
+/// (v0.17.6.4 — previously a vault-local `SessionToken`) and immediately
+/// checked via `CredentialBroker::verify` *before* the secret is ever read.
+/// A credential that fails either step (e.g. the mint fails, or — once TTLs
+/// shorter than a spawn are used — the grant is already expired) is
+/// withheld, not silently granted. This makes every credential handed to an
+/// agent process correspond to a recorded, time-boxed, cryptographically
+/// verifiable grant rather than an unconditional `vault.get`.
 ///
 /// Returns an empty list (not an error) when the vault doesn't exist or is
 /// unreadable — an unpopulated vault is the common case today, and callers
@@ -4938,10 +4939,18 @@ fn load_vault_credentials(
 
     let mut cred_config = ta_credentials::CredentialsConfig::for_project(project_root);
     cred_config.use_keychain = use_keychain;
-    let Ok(mut vault) = ta_credentials::FileVault::open(&cred_config) else {
+    let Ok(vault) = ta_credentials::FileVault::open(&cred_config) else {
         return Vec::new();
     };
     let Ok(summaries) = vault.list() else {
+        return Vec::new();
+    };
+    let broker_dir = cred_config
+        .vault_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| project_root.join(".ta"));
+    let Ok(broker) = ta_credential_broker::CredentialBroker::open(&broker_dir) else {
         return Vec::new();
     };
     // v0.17.6.3: connectors declared `broker_mediated = true` in
@@ -4969,22 +4978,22 @@ fn load_vault_credentials(
                 return None;
             }
 
-            let token = match vault.issue_token(summary.id, agent_id, granted_scopes, ttl_secs) {
-                Ok(token) => token,
+            let granted = match broker.grant(summary.id, agent_id, granted_scopes, ttl_secs) {
+                Ok(granted) => granted,
                 Err(e) => {
                     tracing::warn!(
                         credential = %summary.name,
                         error = %e,
-                        "failed to issue session token; credential withheld"
+                        "failed to mint session grant; credential withheld"
                     );
                     return None;
                 }
             };
-            if let Err(e) = vault.validate_token(token.token_id) {
+            if let Err(e) = broker.verify(&granted.token) {
                 tracing::warn!(
                     credential = %summary.name,
                     error = %e,
-                    "issued session token failed validation; credential withheld"
+                    "minted session grant failed verification; credential withheld"
                 );
                 return None;
             }
@@ -4994,7 +5003,7 @@ fn load_vault_credentials(
                 let cred =
                     ta_runtime::ScopedCredential::with_scopes(full.name, full.secret, full.scopes);
                 if broker_mediated {
-                    cred.with_broker_mediation(token.token_id.to_string())
+                    cred.with_broker_mediation(granted.token)
                 } else {
                     cred
                 }
@@ -11197,10 +11206,11 @@ plan_pending_window = 7
 
     #[test]
     fn load_vault_credentials_withholds_credential_when_token_already_expired() {
-        // v0.17.6.2 regression guard: issue_token/validate_token must be
-        // load-bearing here, not decorative. A 0-second TTL means the minted
-        // token is expired the instant `validate_token` checks it, so the
-        // credential must be withheld even though it's otherwise eligible.
+        // v0.17.6.2 regression guard (broker.grant/broker.verify since
+        // v0.17.6.4): the mint-then-verify gate must be load-bearing here,
+        // not decorative. A 0-second TTL means the minted grant is expired
+        // the instant `verify` checks it, so the credential must be
+        // withheld even though it's otherwise eligible.
         use ta_credentials::{CredentialVault, FileVault};
 
         let dir = tempfile::tempdir().unwrap();
@@ -11213,6 +11223,46 @@ plan_pending_window = 7
 
         let creds = load_vault_credentials(dir.path(), "agent-1", &[], 0, false);
         assert!(creds.is_empty());
+    }
+
+    #[test]
+    fn load_vault_credentials_broker_mediated_session_token_is_biscuit_verifiable() {
+        // v0.17.6.4: for a `broker_mediated = true` connector,
+        // `session_token_id` must be a token that `ta-credential-broker`
+        // itself can verify offline in a *separate* process — the gateway,
+        // which never shares memory with `ta run`'s spawn — not a UUID that
+        // only resolves against this process's in-memory FileVault state.
+        use ta_credentials::{CredentialVault, FileVault};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ta_dir = dir.path().join(".ta");
+        std::fs::create_dir_all(&ta_dir).unwrap();
+        std::fs::write(
+            ta_dir.join("connectors.toml"),
+            "[connectors.github]\ncredential_name = \"GITHUB_TOKEN\"\nbroker_mediated = true\n",
+        )
+        .unwrap();
+
+        let cred_id = {
+            let mut vault = FileVault::open(&test_cred_config(dir.path())).unwrap();
+            vault
+                .add("GITHUB_TOKEN", "github", "ghp_secret", vec![])
+                .unwrap()
+                .id
+        };
+
+        let creds = load_vault_credentials(dir.path(), "agent-1", &[], 3600, false);
+        assert_eq!(creds.len(), 1);
+        assert!(creds[0].broker_mediated);
+        let session_token = creds[0]
+            .session_token_id
+            .as_deref()
+            .expect("broker-mediated credential must carry a session token");
+
+        let broker = ta_credential_broker::CredentialBroker::open(&ta_dir).unwrap();
+        let verified = broker.verify(session_token).unwrap();
+        assert_eq!(verified.credential_id, cred_id);
+        assert_eq!(verified.agent_id, "agent-1");
     }
 
     #[test]

--- a/crates/ta-credential-broker/Cargo.toml
+++ b/crates/ta-credential-broker/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ta-credential-broker"
+version.workspace = true
+edition = "2021"
+description = "Biscuit-backed credential broker: mints and verifies offline-verifiable session grants"
+license = "Apache-2.0"
+repository = "https://github.com/trustedautonomy/ta"
+homepage = "https://github.com/trustedautonomy/ta"
+keywords = ["ai", "agent", "autonomy", "credentials", "biscuit"]
+categories = ["development-tools", "authentication"]
+
+[dependencies]
+biscuit-auth = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/ta-credential-broker/src/broker.rs
+++ b/crates/ta-credential-broker/src/broker.rs
@@ -1,0 +1,378 @@
+// broker.rs — Biscuit-backed CredentialBroker (v0.17.6.4).
+//
+// Replaces ta_credentials::FileVault's UUID SessionToken (a reference that
+// only resolves against the vault process that minted it) with a biscuit
+// token: a signed, self-describing grant that any holder of the broker's
+// public key can verify offline. The broker persists its ed25519 root key
+// as a chmod-0600 file (same custody model as FileVault's age identity) so
+// a token minted by one process (`ta credentials grant`) verifies in another
+// (the MCP gateway) as long as both open the same `.ta` directory.
+//
+// Revocation isn't a biscuit primitive (tokens are only bounded by their
+// embedded expiry) so the broker keeps a small denylist file keyed by each
+// token's authority-block revocation id.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use biscuit_auth::{Algorithm, AuthorizerBuilder, Biscuit, KeyPair, PrivateKey};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+use uuid::Uuid;
+
+use crate::error::BrokerError;
+
+const ROOT_KEY_FILENAME: &str = "broker_root.key";
+const DENYLIST_FILENAME: &str = "broker_revocations.json";
+
+/// A freshly-minted grant.
+#[derive(Debug, Clone)]
+pub struct GrantedToken {
+    /// The base64-encoded biscuit — the opaque bearer value handed to the
+    /// agent (e.g. as `TA_SESSION_TOKEN_<credential>`) and presented back to
+    /// `ta_external_action` as `session_token`.
+    pub token: String,
+    /// Hex-encoded revocation id of the token's authority block — a stable
+    /// reference for `revoke()` and for display, distinct from `token`
+    /// itself (which changes if the token is ever attenuated).
+    pub token_id: String,
+    pub credential_id: Uuid,
+    pub agent_id: String,
+    pub allowed_scopes: Vec<String>,
+    pub issued_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Claims recovered from a successfully verified grant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedGrant {
+    pub credential_id: Uuid,
+    pub agent_id: String,
+    pub allowed_scopes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct Denylist {
+    revoked_token_ids: Vec<String>,
+}
+
+/// Mints and verifies biscuit-backed credential grants.
+pub struct CredentialBroker {
+    keypair: KeyPair,
+    denylist_path: PathBuf,
+    denylist: Denylist,
+}
+
+impl CredentialBroker {
+    /// Open (or initialize) a broker rooted at `dir` — typically a project's
+    /// `.ta` directory, the same one `FileVault` stores `credentials.json`
+    /// alongside. Generates and persists a root key on first use.
+    pub fn open(dir: &Path) -> Result<Self, BrokerError> {
+        fs::create_dir_all(dir)?;
+        let keypair = load_or_create_root_keypair(&dir.join(ROOT_KEY_FILENAME))?;
+        let denylist_path = dir.join(DENYLIST_FILENAME);
+        let denylist = load_denylist(&denylist_path)?;
+        Ok(Self {
+            keypair,
+            denylist_path,
+            denylist,
+        })
+    }
+
+    /// Mint a biscuit-backed grant for `agent_id`, scoped to `scopes`,
+    /// expiring `ttl_secs` from now. The expiry is embedded in the token
+    /// itself as a datalog check, so it's enforced by any verifier — not
+    /// just this broker instance.
+    pub fn grant(
+        &self,
+        credential_id: Uuid,
+        agent_id: &str,
+        scopes: Vec<String>,
+        ttl_secs: u64,
+    ) -> Result<GrantedToken, BrokerError> {
+        let issued_at = Utc::now();
+        let expires_at = issued_at + Duration::seconds(ttl_secs as i64);
+        let scopes_csv = scopes.join(",");
+
+        let fact = format!(
+            "grant({:?}, {:?}, {:?})",
+            credential_id.to_string(),
+            agent_id,
+            scopes_csv
+        );
+        let check = format!("check if time($t), $t < {}", expires_at.to_rfc3339());
+
+        let biscuit = Biscuit::builder()
+            .fact(fact.as_str())
+            .map_err(|e| BrokerError::MintFailed(e.to_string()))?
+            .check(check.as_str())
+            .map_err(|e| BrokerError::MintFailed(e.to_string()))?
+            .build(&self.keypair)
+            .map_err(|e| BrokerError::MintFailed(e.to_string()))?;
+
+        let token_id = revocation_id_hex(&biscuit);
+        let token = biscuit
+            .to_base64()
+            .map_err(|e| BrokerError::MintFailed(e.to_string()))?;
+
+        info!(%credential_id, agent_id, ttl_secs, token_id, "credential broker: grant minted");
+
+        Ok(GrantedToken {
+            token,
+            token_id,
+            credential_id,
+            agent_id: agent_id.to_string(),
+            allowed_scopes: scopes,
+            issued_at,
+            expires_at,
+        })
+    }
+
+    /// Verify a presented token: signature, embedded expiry, and revocation
+    /// status. Returns the claims embedded at mint time.
+    pub fn verify(&self, token: &str) -> Result<VerifiedGrant, BrokerError> {
+        let biscuit = Biscuit::from_base64(token, self.keypair.public())
+            .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?;
+
+        let token_id = revocation_id_hex(&biscuit);
+        if self
+            .denylist
+            .revoked_token_ids
+            .iter()
+            .any(|id| id == &token_id)
+        {
+            return Err(BrokerError::Revoked);
+        }
+
+        let mut authorizer = AuthorizerBuilder::new()
+            .time()
+            .policy("allow if true")
+            .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?
+            .build(&biscuit)
+            .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?;
+        authorizer
+            .authorize()
+            .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?;
+
+        let (credential_id_str, agent_id, scopes_csv): (String, String, String) = authorizer
+            .query_exactly_one("data($c, $a, $s) <- grant($c, $a, $s)")
+            .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?;
+        let credential_id = Uuid::parse_str(&credential_id_str).map_err(|e| {
+            BrokerError::InvalidGrant(format!("grant carries a malformed credential id: {e}"))
+        })?;
+        let allowed_scopes = if scopes_csv.is_empty() {
+            Vec::new()
+        } else {
+            scopes_csv.split(',').map(str::to_string).collect()
+        };
+
+        Ok(VerifiedGrant {
+            credential_id,
+            agent_id,
+            allowed_scopes,
+        })
+    }
+
+    /// Add `token_id` (as returned in [`GrantedToken::token_id`]) to the
+    /// denylist, persisting immediately. Revoking an id the broker never
+    /// issued is a no-op, not an error — the end state is identical.
+    pub fn revoke(&mut self, token_id: &str) -> Result<(), BrokerError> {
+        if !self
+            .denylist
+            .revoked_token_ids
+            .iter()
+            .any(|id| id == token_id)
+        {
+            self.denylist.revoked_token_ids.push(token_id.to_string());
+            save_denylist(&self.denylist_path, &self.denylist)?;
+            info!(token_id, "credential broker: grant revoked");
+        }
+        Ok(())
+    }
+}
+
+fn revocation_id_hex(biscuit: &Biscuit) -> String {
+    let ids = biscuit.revocation_identifiers();
+    let authority_id = ids.first().map(Vec::as_slice).unwrap_or(&[]);
+    authority_id.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn load_or_create_root_keypair(key_path: &Path) -> Result<KeyPair, BrokerError> {
+    if key_path.exists() {
+        let hex = fs::read_to_string(key_path)?;
+        let private = PrivateKey::from_bytes_hex(hex.trim(), Algorithm::Ed25519).map_err(|e| {
+            BrokerError::KeyUnreadable {
+                path: key_path.to_path_buf(),
+                reason: e.to_string(),
+            }
+        })?;
+        Ok(KeyPair::from(&private))
+    } else {
+        let keypair = KeyPair::new();
+        fs::write(key_path, keypair.private().to_bytes_hex())?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(key_path, fs::Permissions::from_mode(0o600))?;
+        }
+        Ok(keypair)
+    }
+}
+
+fn load_denylist(path: &Path) -> Result<Denylist, BrokerError> {
+    if !path.exists() {
+        return Ok(Denylist::default());
+    }
+    let raw = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&raw)?)
+}
+
+fn save_denylist(path: &Path, denylist: &Denylist) -> Result<(), BrokerError> {
+    fs::write(path, serde_json::to_vec(denylist)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+    use std::time::Duration;
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    #[test]
+    fn grant_round_trips_claims() {
+        let dir = TempDir::new().unwrap();
+        let broker = CredentialBroker::open(dir.path()).unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let granted = broker
+            .grant(
+                credential_id,
+                "agent-1",
+                vec!["read".into(), "write".into()],
+                3600,
+            )
+            .unwrap();
+        let verified = broker.verify(&granted.token).unwrap();
+
+        assert_eq!(verified.credential_id, credential_id);
+        assert_eq!(verified.agent_id, "agent-1");
+        assert_eq!(
+            verified.allowed_scopes,
+            vec!["read".to_string(), "write".to_string()]
+        );
+    }
+
+    #[test]
+    fn unscoped_grant_has_empty_scopes() {
+        let dir = TempDir::new().unwrap();
+        let broker = CredentialBroker::open(dir.path()).unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let granted = broker
+            .grant(credential_id, "agent-1", vec![], 3600)
+            .unwrap();
+        let verified = broker.verify(&granted.token).unwrap();
+
+        assert!(verified.allowed_scopes.is_empty());
+    }
+
+    #[test]
+    fn expired_grant_rejected() {
+        let dir = TempDir::new().unwrap();
+        let broker = CredentialBroker::open(dir.path()).unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let granted = broker.grant(credential_id, "agent-1", vec![], 0).unwrap();
+        sleep(Duration::from_millis(20));
+
+        let result = broker.verify(&granted.token);
+        assert!(matches!(result, Err(BrokerError::InvalidGrant(_))));
+    }
+
+    #[test]
+    fn tampered_token_rejected() {
+        let dir = TempDir::new().unwrap();
+        let broker = CredentialBroker::open(dir.path()).unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let granted = broker
+            .grant(credential_id, "agent-1", vec![], 3600)
+            .unwrap();
+        let mut tampered = granted.token.clone();
+        // Flip one base64 character near the end (signature bytes) so the
+        // decoded token fails the ed25519 check rather than base64 parsing.
+        let mut chars: Vec<char> = tampered.chars().collect();
+        let idx = chars.len() - 2;
+        chars[idx] = if chars[idx] == 'A' { 'B' } else { 'A' };
+        tampered = chars.into_iter().collect();
+
+        let result = broker.verify(&tampered);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn revoked_grant_rejected() {
+        let dir = TempDir::new().unwrap();
+        let mut broker = CredentialBroker::open(dir.path()).unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let granted = broker
+            .grant(credential_id, "agent-1", vec![], 3600)
+            .unwrap();
+        broker.revoke(&granted.token_id).unwrap();
+
+        let result = broker.verify(&granted.token);
+        assert!(matches!(result, Err(BrokerError::Revoked)));
+    }
+
+    #[test]
+    fn key_persists_across_broker_reopen() {
+        let dir = TempDir::new().unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let token = {
+            let broker = CredentialBroker::open(dir.path()).unwrap();
+            broker
+                .grant(credential_id, "agent-1", vec![], 3600)
+                .unwrap()
+                .token
+        };
+
+        // A freshly-opened broker on the same directory must load the same
+        // root key from disk and verify a token minted by the earlier
+        // instance — this is what makes the token independently verifiable
+        // across process boundaries (CLI mint, gateway verify).
+        let broker2 = CredentialBroker::open(dir.path()).unwrap();
+        let verified = broker2.verify(&token).unwrap();
+        assert_eq!(verified.credential_id, credential_id);
+    }
+
+    #[test]
+    fn verify_rejects_token_from_different_root_key() {
+        let dir_a = TempDir::new().unwrap();
+        let dir_b = TempDir::new().unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let broker_a = CredentialBroker::open(dir_a.path()).unwrap();
+        let broker_b = CredentialBroker::open(dir_b.path()).unwrap();
+
+        let granted = broker_a
+            .grant(credential_id, "agent-1", vec![], 3600)
+            .unwrap();
+        let result = broker_b.verify(&granted.token);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn revoke_unknown_token_id_is_not_an_error() {
+        // Revoking a token id the broker never issued (e.g. a retry after a
+        // partially-applied revoke) must not fail — the end state (denylisted)
+        // is identical either way.
+        let dir = TempDir::new().unwrap();
+        let mut broker = CredentialBroker::open(dir.path()).unwrap();
+        broker.revoke("does-not-exist").unwrap();
+    }
+}

--- a/crates/ta-credential-broker/src/broker.rs
+++ b/crates/ta-credential-broker/src/broker.rs
@@ -15,7 +15,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use biscuit_auth::{Algorithm, AuthorizerBuilder, Biscuit, KeyPair, PrivateKey};
+use biscuit_auth::{Algorithm, AuthorizerBuilder, AuthorizerLimits, Biscuit, KeyPair, PrivateKey};
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use tracing::info;
@@ -145,8 +145,20 @@ impl CredentialBroker {
             return Err(BrokerError::Revoked);
         }
 
+        // biscuit-auth's default `RunLimits::max_time` is 1ms — tuned for a
+        // quiet machine, not a loaded CI runner. A trivial authorization
+        // (a couple of facts, one query) can exceed that under scheduling
+        // jitter alone, producing a spurious "Reached Datalog execution
+        // limits" failure that has nothing to do with the grant itself.
+        // biscuit-auth's own test suite works around the identical issue
+        // ("cheap worker on GitHub Actions") by widening the budget; do the
+        // same here rather than let the 1ms default flake on Windows CI.
         let mut authorizer = AuthorizerBuilder::new()
             .time()
+            .set_limits(AuthorizerLimits {
+                max_time: std::time::Duration::from_secs(1),
+                ..Default::default()
+            })
             .policy("allow if true")
             .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?
             .build(&biscuit)

--- a/crates/ta-credential-broker/src/error.rs
+++ b/crates/ta-credential-broker/src/error.rs
@@ -1,0 +1,34 @@
+// error.rs — Credential broker error types.
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum BrokerError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error(
+        "broker root key at {path} is missing or corrupt: {reason}. Deleting it \
+         invalidates every outstanding grant (agents must request fresh ones); \
+         restore the original key file from backup if grants must survive."
+    )]
+    KeyUnreadable {
+        path: std::path::PathBuf,
+        reason: String,
+    },
+
+    #[error("failed to mint grant: {0}")]
+    MintFailed(String),
+
+    #[error(
+        "session grant failed verification: {0} (grants expire and cannot be \
+         reused after tampering — mint a fresh one via `ta credentials grant`)"
+    )]
+    InvalidGrant(String),
+
+    #[error("session grant was revoked")]
+    Revoked,
+}

--- a/crates/ta-credential-broker/src/lib.rs
+++ b/crates/ta-credential-broker/src/lib.rs
@@ -1,0 +1,13 @@
+//! # ta-credential-broker
+//!
+//! Biscuit-backed replacement for `ta_credentials::FileVault`'s UUID-keyed
+//! `SessionToken`. A [`CredentialBroker`] mints self-contained, offline
+//! verifiable grants: any process holding the broker's public key can verify
+//! a presented token without a round trip to whichever process minted it,
+//! unlike a UUID that only resolves against the vault process that issued it.
+
+pub mod broker;
+pub mod error;
+
+pub use broker::{CredentialBroker, GrantedToken, VerifiedGrant};
+pub use error::BrokerError;

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -41,6 +41,7 @@ ta-actions = { path = "../ta-actions", version = "0.17.7-alpha.1" }
 ta-submit = { path = "../ta-submit", version = "0.17.7-alpha.1" }
 ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.1" }
 ta-credentials = { path = "../ta-credentials", version = "0.17.7-alpha.1" }
+ta-credential-broker = { path = "../ta-credential-broker", version = "0.17.7-alpha.1" }
 ta-session = { path = "../ta-session", version = "0.17.7-alpha.1" }
 
 

--- a/crates/ta-mcp-gateway/src/tools/action.rs
+++ b/crates/ta-mcp-gateway/src/tools/action.rs
@@ -670,13 +670,6 @@ fn resolve_connector_authorization(
             None,
         ));
     };
-    let Ok(token_id) = Uuid::parse_str(session_token) else {
-        return ConnectorAuthorization::Error(McpError::invalid_params(
-            format!("session_token '{session_token}' is not a valid token id"),
-            None,
-        ));
-    };
-
     let mut cred_config = ta_credentials::CredentialsConfig::for_project(workspace_root);
     cred_config.use_keychain = credential_vault_use_keychain;
     let Ok(vault) = ta_credentials::FileVault::open(&cred_config) else {
@@ -690,13 +683,36 @@ fn resolve_connector_authorization(
         ));
     };
 
-    let token = match vault.validate_token(token_id) {
-        Ok(t) => t,
+    // v0.17.6.4: the presented `session_token` is now a biscuit grant minted
+    // by `ta_credential_broker::CredentialBroker` (see `ta credentials
+    // grant` / `load_vault_credentials`), not a UUID that resolves against
+    // `FileVault`'s in-process token list. `CredentialBroker::verify`
+    // checks the signature, the grant's embedded expiry, and the broker's
+    // revocation denylist entirely offline — no shared state with whichever
+    // process minted it is required.
+    let broker_dir = cred_config
+        .vault_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| workspace_root.join(".ta"));
+    let Ok(broker) = ta_credential_broker::CredentialBroker::open(&broker_dir) else {
+        return ConnectorAuthorization::Error(McpError::internal_error(
+            format!(
+                "connector '{connector_id}' is broker_mediated but the credential broker at \
+                 {} could not be opened",
+                broker_dir.display()
+            ),
+            None,
+        ));
+    };
+
+    let grant = match broker.verify(session_token) {
+        Ok(g) => g,
         Err(e) => {
             return ConnectorAuthorization::Error(McpError::invalid_params(
                 format!(
-                    "session_token for connector '{connector_id}' failed validation: {e} \
-                     (tokens expire — mint a fresh one via `ta credentials grant`)"
+                    "session_token for connector '{connector_id}' failed verification: {e} \
+                     (grants expire — mint a fresh one via `ta credentials grant`)"
                 ),
                 None,
             ));
@@ -704,19 +720,19 @@ fn resolve_connector_authorization(
     };
 
     if let Some(agent_id) = requesting_agent_id {
-        if token.agent_id != agent_id {
+        if grant.agent_id != agent_id {
             return ConnectorAuthorization::Error(McpError::invalid_params(
                 format!(
                     "session_token for connector '{connector_id}' was issued to a different \
                      agent ('{}') than the requesting goal's agent ('{agent_id}')",
-                    token.agent_id
+                    grant.agent_id
                 ),
                 None,
             ));
         }
     }
 
-    let credential = match vault.get(token.credential_id) {
+    let credential = match vault.get(grant.credential_id) {
         Ok(c) => c,
         Err(e) => {
             return ConnectorAuthorization::Error(McpError::internal_error(
@@ -738,7 +754,7 @@ fn resolve_connector_authorization(
     }
 
     if let Some(required_scope) = &entry.required_scope {
-        if !token.allowed_scopes.iter().any(|s| s == required_scope) {
+        if !grant.allowed_scopes.iter().any(|s| s == required_scope) {
             return ConnectorAuthorization::ScopeDeficit {
                 description: format!(
                     "ta_external_action:{} via connector '{connector_id}' requires scope \
@@ -747,7 +763,7 @@ fn resolve_connector_authorization(
                      than auto-denied (structured human escalation via ta_human_verify lands \
                      in v0.17.6.6); a reviewer can re-grant a wider-scoped token via \
                      `ta credentials grant`.",
-                    params.action_type, token.allowed_scopes
+                    params.action_type, grant.allowed_scopes
                 ),
             };
         }
@@ -1493,8 +1509,9 @@ else:
                 vec!["trade.write".into()],
             )
             .unwrap();
-        let token = vault
-            .issue_token(cred.id, "test-agent", vec!["trade.write".into()], 3600)
+        let broker = ta_credential_broker::CredentialBroker::open(&ta_dir).unwrap();
+        let granted = broker
+            .grant(cred.id, "test-agent", vec!["trade.write".into()], 3600)
             .unwrap();
 
         let state = make_state(dir.path());
@@ -1506,7 +1523,7 @@ else:
             dry_run: false,
             budget: None,
             connector: Some("paper-trading".into()),
-            session_token: Some(token.token_id.to_string()),
+            session_token: Some(granted.token),
         };
 
         let result = handle_external_action(&state, params).unwrap();
@@ -1574,6 +1591,104 @@ else:
     }
 
     #[test]
+    fn broker_mediated_connector_with_malformed_token_is_a_clear_actionable_error() {
+        // v0.17.6.4: `session_token` is now a biscuit grant, not a UUID —
+        // a garbage string must fail broker verification with an
+        // actionable message, not panic on `Uuid::parse_str`.
+        let dir = tempdir().unwrap();
+        let ta_dir = dir.path().join(".ta");
+        std::fs::create_dir_all(&ta_dir).unwrap();
+        std::fs::write(
+            ta_dir.join("workflow.toml"),
+            b"[actions.\"connector.execute\"]\npolicy = \"auto\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ta_dir.join("connectors.toml"),
+            b"[connectors.paper-trading]\n\
+              credential_name = \"PAPER_API_KEY\"\n\
+              broker_mediated = true\n",
+        )
+        .unwrap();
+        write_broker_test_plugin(dir.path());
+        write_routing_decision(dir.path(), "auto");
+
+        let state = make_state(dir.path());
+        let params = ExternalActionParams {
+            action_type: "connector.execute".into(),
+            payload: json!({}),
+            goal_run_id: None,
+            target_uri: None,
+            dry_run: false,
+            budget: None,
+            connector: Some("paper-trading".into()),
+            session_token: Some("not-a-real-uuid-or-biscuit".into()),
+        };
+
+        let err = handle_external_action(&state, params).unwrap_err();
+        assert!(
+            err.message.to_string().contains("failed verification"),
+            "expected an actionable verification-failure error: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn broker_mediated_connector_with_revoked_grant_is_a_clear_actionable_error() {
+        use ta_credentials::CredentialVault;
+
+        let dir = tempdir().unwrap();
+        let ta_dir = dir.path().join(".ta");
+        std::fs::create_dir_all(&ta_dir).unwrap();
+        std::fs::write(
+            ta_dir.join("workflow.toml"),
+            b"[actions.\"connector.execute\"]\npolicy = \"auto\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ta_dir.join("connectors.toml"),
+            b"[connectors.paper-trading]\n\
+              credential_name = \"PAPER_API_KEY\"\n\
+              broker_mediated = true\n",
+        )
+        .unwrap();
+        write_broker_test_plugin(dir.path());
+        write_routing_decision(dir.path(), "auto");
+
+        let mut vault = open_test_vault(dir.path());
+        let cred = vault
+            .add(
+                "PAPER_API_KEY",
+                "paper-trading",
+                "sk-live-supersecret-do-not-leak",
+                vec![],
+            )
+            .unwrap();
+        let mut broker = ta_credential_broker::CredentialBroker::open(&ta_dir).unwrap();
+        let granted = broker.grant(cred.id, "test-agent", vec![], 3600).unwrap();
+        broker.revoke(&granted.token_id).unwrap();
+
+        let state = make_state(dir.path());
+        let params = ExternalActionParams {
+            action_type: "connector.execute".into(),
+            payload: json!({}),
+            goal_run_id: None,
+            target_uri: None,
+            dry_run: false,
+            budget: None,
+            connector: Some("paper-trading".into()),
+            session_token: Some(granted.token),
+        };
+
+        let err = handle_external_action(&state, params).unwrap_err();
+        assert!(
+            err.message.to_string().contains("failed verification"),
+            "expected an actionable verification-failure error for a revoked grant: {}",
+            err.message
+        );
+    }
+
+    #[test]
     fn broker_mediated_connector_scope_deficit_is_captured_for_review_not_denied() {
         use ta_credentials::CredentialVault;
 
@@ -1597,7 +1712,7 @@ else:
         write_routing_decision(dir.path(), "auto");
 
         let mut vault = open_test_vault(dir.path());
-        // Credential/token exist, but the token was only granted a narrower
+        // Credential/grant exist, but the grant was only issued a narrower
         // scope than the connector requires.
         let cred = vault
             .add(
@@ -1607,8 +1722,9 @@ else:
                 vec!["trade.read".into(), "trade.write".into()],
             )
             .unwrap();
-        let token = vault
-            .issue_token(cred.id, "test-agent", vec!["trade.read".into()], 3600)
+        let broker = ta_credential_broker::CredentialBroker::open(&ta_dir).unwrap();
+        let granted = broker
+            .grant(cred.id, "test-agent", vec!["trade.read".into()], 3600)
             .unwrap();
 
         let state = make_state(dir.path());
@@ -1620,7 +1736,7 @@ else:
             dry_run: false,
             budget: None,
             connector: Some("paper-trading".into()),
-            session_token: Some(token.token_id.to_string()),
+            session_token: Some(granted.token),
         };
 
         let result = handle_external_action(&state, params).unwrap();

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -7353,20 +7353,30 @@ ta credentials revoke <credential-id>
 ta credentials grant <credential-id> --agent <goal-id> --scope "read" --ttl 3600
 ```
 
-Credentials are stored, **encrypted at rest**, in `.ta/credentials.json`. The
-`FileVault` issues session tokens with configurable TTL:
+Credentials are stored, **encrypted at rest**, in `.ta/credentials.json`. Session
+grants are minted by `ta-credential-broker` as signed
+[biscuit](https://www.biscuitsec.org/) tokens (v0.17.6.4) with configurable
+TTL:
 
 ```
 Agent requests: "I need gmail read access for goal abc123"
-TA issues:      SessionToken { ttl: 3600s, scopes: ["read"], agent: "claude-code" }
-Agent uses:     The token (never the raw credential)
-TA proxies:     Token → real credential on each API call
+TA issues:      a biscuit grant: { credential, agent: "claude-code", scopes: ["read"], ttl: 3600s }
+Agent uses:     the grant (never the raw credential)
+TA proxies:     grant → real credential on each API call
 ```
 
-`ta credentials grant` mints a token directly for inspection or manual use;
+Unlike the plain reference ids TA used before v0.17.6.4, a grant is
+self-contained and cryptographically signed: any process holding the
+broker's public key (stored alongside `credentials.json` in `.ta/`) can
+verify one offline -- no round trip to whichever process minted it. This is
+what lets `ta credentials grant` (a CLI process) mint a grant that the MCP
+gateway (a different process) can independently verify for broker-mediated
+connectors, below.
+
+`ta credentials grant` mints a grant directly for inspection or manual use;
 `ta run --credential-scopes` (below) does the same thing internally for
 every credential it hands to an agent process -- each one is only injected
-after its own token has been issued and validated, so a credential that
+after its own grant has been minted and verified, so a credential that
 fails either step (for example, an already-expired TTL) is withheld rather
 than handed over.
 
@@ -7478,8 +7488,8 @@ marked `broker_mediated = true` are withheld from the agent's environment.
 
 | | `broker_mediated = false` (default) | `broker_mediated = true` |
 |---|---|---|
-| What the agent's env contains | `GITHUB_TOKEN=ghp_...` (the raw secret) | `TA_SESSION_TOKEN_GITHUB_TOKEN=<token-id>` (opaque) |
-| What `ta_external_action` needs | Nothing connector-specific | `connector: "github"`, `session_token: "<token-id>"` |
+| What the agent's env contains | `GITHUB_TOKEN=ghp_...` (the raw secret) | `TA_SESSION_TOKEN_GITHUB_TOKEN=<biscuit grant>` (opaque) |
+| What `ta_external_action` needs | Nothing connector-specific | `connector: "github"`, `session_token: "<biscuit grant>"` |
 | Where the real secret is attached | Wherever the agent's own process/plugin script chooses to use the env var | Only to the gateway's own outbound call to the connector's plugin, as `TA_CONNECTOR_SECRET` on that one subprocess invocation |
 | Does the secret ever appear in the agent-visible request or response? | Potentially -- nothing stops the agent from echoing it | Never |
 
@@ -7491,17 +7501,19 @@ touches `ta_external_action` at all) closes it more broadly.
 
 **End-to-end flow for a broker-mediated connector:**
 
-1. `ta run` mints a session token for the credential as usual (see above),
+1. `ta run` mints a session grant for the credential as usual (see above),
    but because `.ta/connectors.toml` marks it `broker_mediated`, the agent's
-   environment receives `TA_SESSION_TOKEN_GITHUB_TOKEN=<token-id>` instead
-   of the raw `GITHUB_TOKEN` value.
+   environment receives `TA_SESSION_TOKEN_GITHUB_TOKEN=<biscuit grant>`
+   instead of the raw `GITHUB_TOKEN` value.
 2. The agent calls `ta_external_action` with `connector: "github"` and
-   `session_token: "<token-id>"` (read from its own environment) alongside
-   the normal `action_type`/`payload`.
-3. The gateway independently re-validates the token against the credential
-   vault (expiry, and that it was issued to this same agent), confirms it
-   backs the `github` connector's declared credential, and checks
-   `required_scope` against the token's `allowed_scopes`.
+   `session_token: "<biscuit grant>"` (read from its own environment)
+   alongside the normal `action_type`/`payload`.
+3. The gateway independently verifies the grant -- entirely offline, no
+   vault round trip needed for the cryptographic check itself (expiry and
+   revocation are enforced by `ta-credential-broker::CredentialBroker`
+   directly), and that it was issued to this same agent -- then confirms it
+   backs the `github` connector's declared credential and checks
+   `required_scope` against the grant's `allowed_scopes`.
 4. On success, the gateway resolves the real secret and attaches it only to
    its own call into the connector's adapter plugin (as `TA_CONNECTOR_SECRET`
    on that one subprocess invocation) -- never into the request payload, and


### PR DESCRIPTION
## Summary
- Replaces `vault.issue_token()`/`validate_token()` call sites with `ta-credential-broker` (biscuit-auth based `open`/`grant`/`verify`/`revoke`).
- Flat, non-pruning revocation-ID denylist (item 4, working but doesn't auto-prune expired entries yet).
- **Deferred to v0.17.6.5**: `PolicyCascade`'s tighten-only attenuation layers (item 3) — three implementation attempts confirmed the broker core independently each time, none reached attenuation.
- **Dropped**: `ScopedCredential` formal retirement (item 5) — unnecessary, existing `broker_mediated`/`session_token_id` fields already carry an opaque bearer string.
- Version intentionally left at `0.17.7-alpha.1` (no bump) — this phase completed out of numeric order after v0.17.7.1 had already merged; bumping would have regressed main's version.

## Test plan
- `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all pass in an isolated worktree.
- Confirmed via direct grep: zero remaining `vault.issue_token` references across `apps/ta-cli` and `crates/ta-mcp-gateway`.