### PR TITLE
implement v0.17.7.2 — VCS-Adapter CI-Status Generalization + Corrective-Goal Trigger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All outcomes must be **observable** (with details and logging) and **actionable*
 
 ## Current State
 
-**Current version**: `0.17.7-alpha.1`
+**Current version**: `0.17.7-alpha.2`
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --phase 4b`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "ta-actions"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "ta-advisor"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "ta-agent-ollama"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "base64",
  "chrono",
@@ -4590,7 +4590,7 @@ dependencies = [
 
 [[package]]
 name = "ta-brain"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "schemars",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "ta-build"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4702,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-comfyui"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -4762,7 +4762,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unity"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unreal"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -4821,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "age",
  "chrono",
@@ -4847,7 +4847,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "ta-data-spec"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "schemars",
  "serde_json",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-overlay"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-proxy"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "ta-decision"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -4952,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4970,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "ta-extension"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5004,7 +5004,7 @@ dependencies = [
 
 [[package]]
 name = "ta-governed-paths"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "ta-init"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "ta-intake"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "regex",
@@ -5049,7 +5049,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "regex",
@@ -5086,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "serde",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "glob",
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "ta-output-schema"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -5131,7 +5131,7 @@ dependencies = [
 
 [[package]]
 name = "ta-plugin"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "libc",
  "serde",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "glob",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "ta-release"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "base64",
  "reqwest",
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "ta-runtime"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5198,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "libc",
@@ -5231,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "chrono",
  "libc",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.17.7-alpha.1"
+version = "0.17.7-alpha.2"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -10268,19 +10268,19 @@ One shipped implementation, `GoalDispatchAction`, wraps `ta run`/`ta goal start`
 
 #### Version: `0.17.7-alpha.1`
 ### v0.17.7.2 — VCS-Adapter CI-Status Generalization + Corrective-Goal Trigger
-<!-- status: pending -->
+<!-- status: done -->
 **Depends on**: v0.17.7.1
 
 **Goal**: Generalize CI/review-completion triggering off Git specifically, per constitution §16.4 — add a defaulted `SourceAdapter::check_failures()` method (empty-vec default, following the exact pattern `check_review()`/`merge_review()` already use), implement it for the Git adapter, and add the two trigger/action nodes that replace this session's manual "watch CI, read failing log, diagnose, fix, push, repeat" loop.
 
 **Items**:
-1. [ ] `SourceAdapter::check_failures(&self, review_id: &str) -> Result<Vec<CheckFailure>>` (default `Ok(vec![])`) in `crates/ta-submit/src/adapter.rs`; `CheckFailure { check_name, log_excerpt }`.
-2. [ ] Git adapter implementation: shells `gh run view --log-failed` for the PR's failing checks, parses into `CheckFailure` entries.
-3. [ ] `VcsTaskCompletionTrigger` (fires on `SourceAdapter::check_review()` reaching a terminal state) and `CiFailureTrigger` (fires specifically when `checks_passing` transitions to `Some(false)`) — both go through `SourceAdapter` only, per §16.4; no direct `gh`/platform calls in trigger code.
-4. [ ] `CorrectiveGoalAction` — on a `CiFailureTrigger` payload, launches `ta run --follow-up` with the `CheckFailure` detail injected as the goal objective. Reuses v0.17.0.12.31's existing auto-fix-retry cap/escalate logic (`decide_gate_failure_action`/`GateFailureMode::AutoFix`) — not a second retry mechanism.
-5. [ ] Non-Git adapter behavior: Perforce/SVN/"none" adapters return the `check_failures()` default; `CiFailureTrigger` degrades to "CI failure detail unavailable for this VCS adapter, investigate manually" per §16.4/§1.4 — verified with a test against the SVN or Perforce adapter stub, not just Git.
-6. [ ] Tests: a mock adapter with a scripted failing check drives `CiFailureTrigger` → `CorrectiveGoalAction` end-to-end; the retry cap escalates to human after N consecutive corrective-goal failures (reusing 12.31's existing cap, not a new counter).
-7. [ ] USAGE.md: document `check_failures()`'s adapter-optional contract and the corrective-goal flow.
+1. [x] `SourceAdapter::check_failures(&self, review_id: &str) -> Result<Vec<CheckFailure>>` (default `Ok(vec![])`) in `crates/ta-submit/src/adapter.rs`; `CheckFailure { check_name, log_excerpt }`.
+2. [x] Git adapter implementation: shells `gh run view --log-failed` for the PR's failing checks, parses into `CheckFailure` entries.
+3. [x] `VcsTaskCompletionTrigger` (fires on `SourceAdapter::check_review()` reaching a terminal state) and `CiFailureTrigger` (fires specifically when `checks_passing` transitions to `Some(false)`) — both go through `SourceAdapter` only, per §16.4; no direct `gh`/platform calls in trigger code.
+4. [x] `CorrectiveGoalAction` — on a `CiFailureTrigger` payload, launches a follow-up goal with the `CheckFailure` detail injected as the goal objective. **Deviation from literal spec, documented**: the plan text said `ta run --follow-up`, but no existing auto-fix code path uses that flag — matched the actual precedent instead (in-process dispatch via the existing `GoalDispatchAction`, extended to follow up on `ctx.vars["draft_id"]`). Reuses v0.17.0.12.31's existing auto-fix-retry cap/escalate logic (`decide_gate_failure_action`/`GateFailureMode::AutoFix`) — not a second retry mechanism.
+5. [x] Non-Git adapter behavior: Perforce/SVN/"none" adapters return the `check_failures()` default; `CiFailureTrigger` degrades to "CI failure detail unavailable for this VCS adapter, investigate manually" per §16.4/§1.4 — verified with a test against the SVN or Perforce adapter stub, not just Git.
+6. [x] Tests: a mock adapter with a scripted failing check drives `CiFailureTrigger` → `CorrectiveGoalAction` end-to-end; the retry cap escalates to human after N consecutive corrective-goal failures (reusing 12.31's existing cap, not a new counter).
+7. [x] USAGE.md: document `check_failures()`'s adapter-optional contract and the corrective-goal flow.
 
 #### Version: `0.17.7-alpha.2`
 ### v0.17.7.3 — Multi-Role Review Panels + Single Approval-Gate Unification

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -43,34 +43,34 @@ which = { workspace = true }
 arboard = { workspace = true }
 
 # Internal crates — version kept in sync with workspace by bump-version.sh
-ta-audit = { path = "../../crates/ta-audit", version = "0.17.7-alpha.1" }
-ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.7-alpha.1" }
-ta-memory = { path = "../../crates/ta-memory", version = "0.17.7-alpha.1" }
-ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.7-alpha.1" }
-ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.7-alpha.1" }
-ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.7-alpha.1" }
-ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.7-alpha.1" }
-ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.7-alpha.1" }
-ta-goal = { path = "../../crates/ta-goal", version = "0.17.7-alpha.1" }
-ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.7-alpha.1" }
-ta-policy = { path = "../../crates/ta-policy", version = "0.17.7-alpha.1" }
-ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.7-alpha.1" }
-ta-session = { path = "../../crates/ta-session", version = "0.17.7-alpha.1" }
-ta-events = { path = "../../crates/ta-events", version = "0.17.7-alpha.1" }
-ta-submit = { path = "../../crates/ta-submit", version = "0.17.7-alpha.1" }
-ta-decision = { path = "../../crates/ta-decision", version = "0.17.7-alpha.1" }
-ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.7-alpha.1" }
-ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.7-alpha.1" }
-ta-build = { path = "../../crates/ta-build", version = "0.17.7-alpha.1" }
-ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.7-alpha.1" }
-ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.7-alpha.1" }
-ta-init = { path = "../../crates/ta-init", version = "0.17.7-alpha.1" }
-ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.7-alpha.1" }
-ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.7-alpha.1" }
-ta-intake = { path = "../../crates/ta-intake", version = "0.17.7-alpha.1" }
-ta-brain = { path = "../../crates/ta-brain", version = "0.17.7-alpha.1" }
-ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.7-alpha.1" }
-ta-release = { path = "../../crates/ta-release", version = "0.17.7-alpha.1" }
+ta-audit = { path = "../../crates/ta-audit", version = "0.17.7-alpha.2" }
+ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.7-alpha.2" }
+ta-memory = { path = "../../crates/ta-memory", version = "0.17.7-alpha.2" }
+ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.7-alpha.2" }
+ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.7-alpha.2" }
+ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.7-alpha.2" }
+ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.7-alpha.2" }
+ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.7-alpha.2" }
+ta-goal = { path = "../../crates/ta-goal", version = "0.17.7-alpha.2" }
+ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.7-alpha.2" }
+ta-policy = { path = "../../crates/ta-policy", version = "0.17.7-alpha.2" }
+ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.7-alpha.2" }
+ta-session = { path = "../../crates/ta-session", version = "0.17.7-alpha.2" }
+ta-events = { path = "../../crates/ta-events", version = "0.17.7-alpha.2" }
+ta-submit = { path = "../../crates/ta-submit", version = "0.17.7-alpha.2" }
+ta-decision = { path = "../../crates/ta-decision", version = "0.17.7-alpha.2" }
+ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.7-alpha.2" }
+ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.7-alpha.2" }
+ta-build = { path = "../../crates/ta-build", version = "0.17.7-alpha.2" }
+ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.7-alpha.2" }
+ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.7-alpha.2" }
+ta-init = { path = "../../crates/ta-init", version = "0.17.7-alpha.2" }
+ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.7-alpha.2" }
+ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.7-alpha.2" }
+ta-intake = { path = "../../crates/ta-intake", version = "0.17.7-alpha.2" }
+ta-brain = { path = "../../crates/ta-brain", version = "0.17.7-alpha.2" }
+ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.7-alpha.2" }
+ta-release = { path = "../../crates/ta-release", version = "0.17.7-alpha.2" }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/apps/ta-cli/src/commands/workflow.rs
+++ b/apps/ta-cli/src/commands/workflow.rs
@@ -179,6 +179,37 @@ pub enum WorkflowCommands {
         #[arg(long)]
         phase: Option<String>,
     },
+    /// Watch a review's CI status and auto-launch corrective fix goals on
+    /// failure (v0.17.7.2).
+    ///
+    /// Generalizes this project's own "watch CI, read failing job log,
+    /// diagnose, fix, push, repeat" loop into `CiFailureTrigger` +
+    /// `CorrectiveGoalAction`: polls the configured `SourceAdapter` (Git,
+    /// Perforce, SVN, ...) for the review's CI status, and on each new
+    /// failure launches a follow-up fix goal on the *same* branch/PR with
+    /// the failing check's log excerpt as the objective. Reuses
+    /// v0.17.0.12.31's auto-fix-retry cap — a failure past `--retry-cap`
+    /// escalates to a human instead of retrying forever.
+    ///
+    /// Non-Git adapters (or Git without the `gh` CLI) degrade to "CI
+    /// failure detail unavailable for this VCS adapter, investigate
+    /// manually" per constitution §16.4 rather than erroring.
+    ///
+    /// Example:
+    ///   ta workflow watch-ci 123 --retry-cap 2
+    WatchCi {
+        /// Review ID to watch (e.g. a GitHub PR number).
+        review_id: String,
+        /// Max consecutive auto-fix attempts before escalating to a human.
+        #[arg(long, default_value = "1")]
+        retry_cap: u32,
+        /// Seconds between CI status polls.
+        #[arg(long, default_value = "30")]
+        poll_interval_secs: u64,
+        /// Max polls per wait cycle before giving up on this review.
+        #[arg(long, default_value = "120")]
+        max_polls: u32,
+    },
     /// Resume a paused or interrupted workflow run from the artifact store (v0.14.10).
     ///
     /// Reads the session artifact store, checks which stage outputs are already
@@ -523,6 +554,37 @@ pub fn execute(command: &WorkflowCommands, config: &GatewayConfig) -> anyhow::Re
             phase.as_deref(),
             config,
         ),
+        WorkflowCommands::WatchCi {
+            review_id,
+            retry_cap,
+            poll_interval_secs,
+            max_polls,
+        } => {
+            let adapter = crate::commands::workflow_graph::source_adapter_for_project(config);
+            let outcomes = crate::commands::workflow_graph::run_ci_failure_watch(
+                adapter,
+                review_id,
+                None,
+                *retry_cap,
+                std::time::Duration::from_secs(*poll_interval_secs),
+                *max_polls,
+                config,
+            )?;
+            if outcomes.is_empty() {
+                println!(
+                    "[watch-ci] review {} reached a terminal state (or the poll budget was \
+                     exhausted) with no CI failure detected — nothing to fix.",
+                    review_id
+                );
+            }
+            for outcome in &outcomes {
+                println!(
+                    "[watch-ci] {}: applied={} — {}",
+                    outcome.kind, outcome.applied, outcome.message
+                );
+            }
+            Ok(())
+        }
         WorkflowCommands::Resume { run_id } => resume_workflow(run_id, config),
         WorkflowCommands::List {
             templates,

--- a/apps/ta-cli/src/commands/workflow_graph.rs
+++ b/apps/ta-cli/src/commands/workflow_graph.rs
@@ -15,7 +15,8 @@ use std::collections::HashMap;
 use ta_mcp_gateway::GatewayConfig;
 use ta_workflow::graph::{
     ActionDef, ActionNode, ActionOutcome, Decision, GraphContext, GraphDefinition, GraphError,
-    NodeRegistry, ReviewInput, WorkItem, WorkResult, WorkerNode,
+    NodeDef, NodeRegistry, ReviewInput, TriggerPayload, TriggerSource, WorkItem, WorkResult,
+    WorkerNode,
 };
 
 use crate::commands::draft::{self, DraftCommands};
@@ -74,12 +75,22 @@ impl GoalDispatchAction {
 impl WorkerNode for GoalDispatchAction {
     fn dispatch(&self, item: &WorkItem, ctx: &GraphContext) -> Result<WorkResult, GraphError> {
         let decision = self.resolve_routing(item, &ctx.workspace_root);
+        // `ctx.vars["draft_id"]` — if already set (e.g. by an earlier
+        // worker in this same graph run, or by a driver seeding the
+        // originating goal per v0.17.7.2's `CorrectiveGoalAction`) — is
+        // treated as "follow up on this goal" rather than starting fresh.
+        // This keeps a corrective fix on the *same* PR/branch instead of
+        // opening a new one, reusing `ta goal start --follow-up`'s existing
+        // parent-staging-reuse behavior (`goal.rs::start_goal_extending_parent`)
+        // rather than a second dispatch path.
+        let follow_up_goal_id = ctx.vars.get("draft_id").cloned();
         tracing::info!(
             title = %item.title,
             verb = %item.verb,
             workload_type = %decision.workload_type,
             team = %decision.team,
             agent = %decision.agent,
+            follow_up_goal_id = follow_up_goal_id.as_deref().unwrap_or("-"),
             "graph: GoalDispatchAction routed work item"
         );
 
@@ -89,7 +100,7 @@ impl WorkerNode for GoalDispatchAction {
             objective: item.objective.clone(),
             agent: decision.agent.clone(),
             phase: item.phase_id.clone(),
-            follow_up: None,
+            follow_up: follow_up_goal_id.map(Some),
             objective_file: None,
         };
         goal::execute(&cmd, &self.config).map_err(|e| GraphError::NodeExecution {
@@ -250,6 +261,345 @@ impl ActionNode for RecommendAction {
     }
 }
 
+// ── VcsTaskCompletionTrigger / CiFailureTrigger (TriggerSource, v0.17.7.2) ──
+//
+// Both triggers go through `SourceAdapter` only (constitution §16.4) — no
+// `gh`/platform-specific code lives here. They poll `check_review()`
+// (already used by `AutoApproveAction`'s siblings via `ta draft watch`) on a
+// fixed interval up to `max_polls` times; `max_polls`/`poll_interval` are
+// constructor params (not hardcoded) so tests can run with a zero interval
+// and a small poll budget instead of a real sleep loop.
+
+/// Fires once `SourceAdapter::check_review()` reports the review has reached
+/// a terminal state (`merged`/`closed`) — VCS-agnostic per spec §2.1 ("via
+/// `SourceAdapter::check_review()` polling ... not a `gh`-specific call").
+pub struct VcsTaskCompletionTrigger {
+    pub adapter: std::sync::Arc<dyn ta_submit::SourceAdapter>,
+    pub review_id: String,
+    pub poll_interval: std::time::Duration,
+    pub max_polls: u32,
+}
+
+fn terminal_review_state(state: &str) -> bool {
+    matches!(state, "merged" | "closed")
+}
+
+impl TriggerSource for VcsTaskCompletionTrigger {
+    fn wait(&self, _ctx: &GraphContext) -> Result<TriggerPayload, GraphError> {
+        for attempt in 0..self.max_polls {
+            let status = self.adapter.check_review(&self.review_id).map_err(|e| {
+                GraphError::NodeExecution {
+                    node_id: "vcs_task_completion".to_string(),
+                    message: format!("check_review failed for review {}: {e}", self.review_id),
+                }
+            })?;
+            if let Some(status) = status {
+                if terminal_review_state(&status.state) {
+                    let mut data = std::collections::HashMap::new();
+                    data.insert("review_id".to_string(), self.review_id.clone());
+                    data.insert("state".to_string(), status.state.clone());
+                    data.insert(
+                        "checks_passing".to_string(),
+                        status
+                            .checks_passing
+                            .map(|b| b.to_string())
+                            .unwrap_or_default(),
+                    );
+                    return Ok(TriggerPayload {
+                        kind: "vcs_task_completion".to_string(),
+                        data,
+                    });
+                }
+            }
+            if attempt + 1 < self.max_polls && !self.poll_interval.is_zero() {
+                std::thread::sleep(self.poll_interval);
+            }
+        }
+        Err(GraphError::NodeExecution {
+            node_id: "vcs_task_completion".to_string(),
+            message: format!(
+                "review {} did not reach a terminal state within {} poll(s) \
+                 (interval {:?}) — it may still be open, or CI is still running",
+                self.review_id, self.max_polls, self.poll_interval
+            ),
+        })
+    }
+}
+
+/// Fires specifically when `check_review()`'s `checks_passing` transitions
+/// to `Some(false)` (not merely "is false" — avoids re-firing every poll
+/// while CI stays red). On firing, also calls `check_failures()` for detail;
+/// per spec §4, an adapter with no failure-log support (Perforce/SVN/"none",
+/// or Git with no `gh` CLI) degrades to an explicit "investigate manually"
+/// hint rather than an empty/confusing payload.
+pub struct CiFailureTrigger {
+    pub adapter: std::sync::Arc<dyn ta_submit::SourceAdapter>,
+    pub review_id: String,
+    pub poll_interval: std::time::Duration,
+    pub max_polls: u32,
+}
+
+const CI_DETAIL_UNAVAILABLE_MESSAGE: &str =
+    "CI failure detail unavailable for this VCS adapter, investigate manually.";
+
+impl TriggerSource for CiFailureTrigger {
+    fn wait(&self, _ctx: &GraphContext) -> Result<TriggerPayload, GraphError> {
+        let mut previously_passing: Option<bool> = None;
+        for attempt in 0..self.max_polls {
+            let status = self.adapter.check_review(&self.review_id).map_err(|e| {
+                GraphError::NodeExecution {
+                    node_id: "ci_failure".to_string(),
+                    message: format!("check_review failed for review {}: {e}", self.review_id),
+                }
+            })?;
+            if let Some(status) = status {
+                let checks_passing = status.checks_passing;
+                if checks_passing == Some(false) && previously_passing != Some(false) {
+                    let failures = self
+                        .adapter
+                        .check_failures(&self.review_id)
+                        .unwrap_or_default();
+
+                    let mut data = std::collections::HashMap::new();
+                    data.insert("review_id".to_string(), self.review_id.clone());
+                    data.insert("state".to_string(), status.state.clone());
+                    if let Some(first) = failures.first() {
+                        data.insert("check_name".to_string(), first.check_name.clone());
+                        data.insert("log_excerpt".to_string(), first.log_excerpt.clone());
+                    } else {
+                        data.insert("check_name".to_string(), "unknown".to_string());
+                        data.insert(
+                            "log_excerpt".to_string(),
+                            CI_DETAIL_UNAVAILABLE_MESSAGE.to_string(),
+                        );
+                    }
+                    if failures.len() > 1 {
+                        data.insert("check_count".to_string(), failures.len().to_string());
+                    }
+                    return Ok(TriggerPayload {
+                        kind: "ci_failure".to_string(),
+                        data,
+                    });
+                }
+                if terminal_review_state(&status.state) {
+                    return Err(GraphError::NodeExecution {
+                        node_id: "ci_failure".to_string(),
+                        message: format!(
+                            "review {} reached terminal state '{}' without a new CI \
+                             failure — nothing to correct",
+                            self.review_id, status.state
+                        ),
+                    });
+                }
+                previously_passing = checks_passing;
+            }
+            if attempt + 1 < self.max_polls && !self.poll_interval.is_zero() {
+                std::thread::sleep(self.poll_interval);
+            }
+        }
+        Err(GraphError::NodeExecution {
+            node_id: "ci_failure".to_string(),
+            message: format!(
+                "no CI failure detected for review {} within {} poll(s) (interval {:?})",
+                self.review_id, self.max_polls, self.poll_interval
+            ),
+        })
+    }
+}
+
+// ── CorrectiveGoalAction (ActionNode, v0.17.7.2) ─────────────────────────
+
+/// On a `CiFailureTrigger`'s payload, dispatches a follow-up fix goal via
+/// the same `GoalDispatchAction` machinery `WorkerNode`s use — "one dispatch
+/// path, not two" per the design spec. Reuses v0.17.0.12.31's
+/// `decide_gate_failure_action`/`GateFailureMode::AutoFix` retry-cap/escalate
+/// logic rather than a second auto-fix mechanism.
+///
+/// `decision` is accepted only for `ActionNode` trait conformance — this
+/// action's real gate is the retry cap (`ctx.vars["ci_fix_attempt"]` vs.
+/// `retry_cap`), not `Decision.proceed`: a CI failure needing a fix isn't a
+/// panel vote, per spec §3's `ci-failure-response.toml` ("no reviewers
+/// needed"). The caller (`run_ci_failure_watch`) is responsible for
+/// populating `ctx.vars` from the trigger payload before calling `act()`.
+pub struct CorrectiveGoalAction {
+    pub dispatcher: GoalDispatchAction,
+    pub retry_cap: u32,
+}
+
+impl CorrectiveGoalAction {
+    pub fn new(config: GatewayConfig, retry_cap: u32) -> Self {
+        Self {
+            dispatcher: GoalDispatchAction::new(config),
+            retry_cap,
+        }
+    }
+}
+
+impl ActionNode for CorrectiveGoalAction {
+    fn act(&self, _decision: &Decision, ctx: &GraphContext) -> Result<ActionOutcome, GraphError> {
+        let check_name = ctx
+            .vars
+            .get("check_name")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        let log_excerpt = ctx
+            .vars
+            .get("log_excerpt")
+            .cloned()
+            .unwrap_or_else(|| CI_DETAIL_UNAVAILABLE_MESSAGE.to_string());
+        let review_id = ctx.vars.get("review_id").cloned().unwrap_or_default();
+        let attempt: u32 = ctx
+            .vars
+            .get("ci_fix_attempt")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1);
+
+        match ta_workflow::decide_gate_failure_action(
+            ta_workflow::GateFailureMode::AutoFix,
+            attempt,
+            self.retry_cap,
+        ) {
+            ta_workflow::GateFailureAction::EscalateToHuman => {
+                let message = format!(
+                    "check '{check_name}' failed on review {review_id} (attempt {attempt}/{}) \
+                     — auto-fix retry cap exhausted, escalating to human.\n{log_excerpt}",
+                    self.retry_cap
+                );
+                tracing::warn!(
+                    review_id = %review_id,
+                    check_name = %check_name,
+                    attempt,
+                    retry_cap = self.retry_cap,
+                    "graph: CorrectiveGoalAction escalating to human"
+                );
+                let mut metadata = HashMap::new();
+                metadata.insert("review_id".to_string(), review_id);
+                metadata.insert("escalated".to_string(), "true".to_string());
+                Ok(ActionOutcome {
+                    kind: "corrective_goal".to_string(),
+                    applied: false,
+                    message,
+                    metadata,
+                })
+            }
+            ta_workflow::GateFailureAction::LaunchFollowUpFix => {
+                let objective = format!(
+                    "# Fix CI failure\n\n\
+                     Check `{check_name}` failed on review {review_id} (auto-fix attempt \
+                     {attempt}/{}).\n\nLog excerpt:\n```\n{log_excerpt}\n```\n\n\
+                     Fix the issue so this check passes.",
+                    self.retry_cap
+                );
+                let item = WorkItem {
+                    title: format!("Fix CI failure: {check_name}"),
+                    objective,
+                    phase_id: None,
+                    verb: "fix".to_string(),
+                    workload_hint: None,
+                };
+                let result = self.dispatcher.dispatch(&item, ctx)?;
+                tracing::info!(
+                    review_id = %review_id,
+                    check_name = %check_name,
+                    attempt,
+                    retry_cap = self.retry_cap,
+                    goal_id = %result.draft_id,
+                    "graph: CorrectiveGoalAction launched follow-up fix goal"
+                );
+                let mut metadata = result.metadata;
+                metadata.insert("review_id".to_string(), review_id.clone());
+                metadata.insert("goal_id".to_string(), result.draft_id.clone());
+                Ok(ActionOutcome {
+                    kind: "corrective_goal".to_string(),
+                    applied: true,
+                    message: format!(
+                        "launched follow-up fix goal {} for check '{check_name}' on review \
+                         {review_id} (attempt {attempt}/{})",
+                        result.draft_id, self.retry_cap
+                    ),
+                    metadata,
+                })
+            }
+        }
+    }
+}
+
+/// Drives `CiFailureTrigger` → `CorrectiveGoalAction` end-to-end for one
+/// review: waits for a CI failure, dispatches (or escalates) a fix, then
+/// loops back to watch for the *next* failure (e.g. after the fix goal's own
+/// push re-triggers CI) until either the review reaches a terminal state or
+/// the retry cap escalates. This is the "future caller" `graph::engine`'s
+/// module doc anticipates for wiring `TriggerSource::wait()` into an
+/// event-driven flow — scoped here to the single CI-failure-response use
+/// case rather than the full daemon-level graph scheduler (later phases).
+///
+/// Attempt count is tracked in `ctx.vars["ci_fix_attempt"]` for the lifetime
+/// of this call only (in-process, not persisted across restarts) — adequate
+/// for a single `ta workflow watch-ci` invocation; daemon-level persistence
+/// is out of scope for this phase.
+///
+/// `origin_goal_id`, when known, seeds `ctx.vars["draft_id"]` so
+/// `GoalDispatchAction::dispatch`'s follow-up support keeps the fix on the
+/// *same* branch/PR (see `GoalDispatchAction::dispatch`'s doc comment).
+/// Standalone callers like `ta workflow watch-ci <review-id>` don't have a
+/// goal ID for a bare review ID (no reverse PR->goal lookup exists yet), so
+/// they pass `None` and get a fresh (non-follow-up) fix goal per failure —
+/// still correct, just not landing on the original branch. A future caller
+/// that already knows the originating goal (e.g. a chained
+/// `phase-review-panel` -> `ci-failure-response` graph run, v0.17.7.4) can
+/// supply it here.
+pub fn run_ci_failure_watch(
+    adapter: std::sync::Arc<dyn ta_submit::SourceAdapter>,
+    review_id: &str,
+    origin_goal_id: Option<&str>,
+    retry_cap: u32,
+    poll_interval: std::time::Duration,
+    max_polls_per_wait: u32,
+    config: &GatewayConfig,
+) -> anyhow::Result<Vec<ActionOutcome>> {
+    let trigger = CiFailureTrigger {
+        adapter,
+        review_id: review_id.to_string(),
+        poll_interval,
+        max_polls: max_polls_per_wait,
+    };
+    let action = CorrectiveGoalAction::new(config.clone(), retry_cap);
+    let mut ctx = GraphContext::new(&config.workspace_root, uuid::Uuid::new_v4().to_string());
+    if let Some(goal_id) = origin_goal_id {
+        ctx.vars.insert("draft_id".to_string(), goal_id.to_string());
+    }
+
+    let mut outcomes = Vec::new();
+    let mut attempt: u32 = 0;
+    // terminal state or poll budget exhausted — stop watching.
+    while let Ok(payload) = trigger.wait(&ctx) {
+        attempt += 1;
+        for (k, v) in payload.data {
+            ctx.vars.insert(k, v);
+        }
+        ctx.vars
+            .insert("ci_fix_attempt".to_string(), attempt.to_string());
+
+        let decision = Decision {
+            score: 1.0,
+            proceed: true,
+            algorithm_used: ta_workflow::consensus::ConsensusAlgorithm::Weighted,
+            scores_by_role: HashMap::new(),
+            findings_by_role: HashMap::new(),
+            timed_out_roles: vec![],
+            override_active: false,
+            summary: "CI failure — no panel vote needed".to_string(),
+        };
+        let outcome = action.act(&decision, &ctx)?;
+        let escalated = outcome.metadata.get("escalated").map(String::as_str) == Some("true");
+        outcomes.push(outcome);
+        if escalated {
+            break;
+        }
+    }
+    Ok(outcomes)
+}
+
 // ── Registry wiring + `ta workflow graph-run` entry point ───────────────
 
 /// Build a `NodeRegistry` with `ta-workflow`'s own built-ins
@@ -272,7 +622,77 @@ pub fn build_registry(config: GatewayConfig) -> NodeRegistry {
         Ok(Box::new(RecommendAction) as Box<dyn ActionNode>)
     });
 
+    let corrective_config = config.clone();
+    registry.register_action("corrective_goal", move |def: &ActionDef| {
+        let retry_cap = def
+            .params
+            .get("retry_cap")
+            .and_then(|v| v.as_integer())
+            .unwrap_or(1) as u32;
+        Ok(Box::new(CorrectiveGoalAction::new(
+            corrective_config.clone(),
+            retry_cap,
+        )) as Box<dyn ActionNode>)
+    });
+
+    let vcs_trigger_config = config.clone();
+    registry.register_trigger("vcs_task_completion", move |def| {
+        Ok(Box::new(VcsTaskCompletionTrigger {
+            adapter: source_adapter_for_project(&vcs_trigger_config),
+            review_id: def.param_str("review_id").unwrap_or_default().to_string(),
+            poll_interval: poll_interval_param(def),
+            max_polls: max_polls_param(def),
+        }) as Box<dyn TriggerSource>)
+    });
+
+    let ci_trigger_config = config.clone();
+    registry.register_trigger("ci_failure", move |def| {
+        Ok(Box::new(CiFailureTrigger {
+            adapter: source_adapter_for_project(&ci_trigger_config),
+            review_id: def.param_str("review_id").unwrap_or_default().to_string(),
+            poll_interval: poll_interval_param(def),
+            max_polls: max_polls_param(def),
+        }) as Box<dyn TriggerSource>)
+    });
+
     registry
+}
+
+/// Resolve this project's configured `SourceAdapter` the same way
+/// `load_excludes_with_adapter`/`draft.rs`'s apply path do (`.ta/workflow.toml`
+/// -> `select_adapter`), shared to `Arc` so multiple trigger instances (and
+/// the daemon-style watch loop) can hold it concurrently without re-reading
+/// config per poll.
+pub fn source_adapter_for_project(
+    config: &GatewayConfig,
+) -> std::sync::Arc<dyn ta_submit::SourceAdapter> {
+    let wf_path = config.workspace_root.join(".ta").join("workflow.toml");
+    let wf_config = ta_submit::WorkflowConfig::load_or_default(&wf_path);
+    std::sync::Arc::from(ta_submit::select_adapter(
+        &config.workspace_root,
+        &wf_config.submit,
+    ))
+}
+
+const DEFAULT_TRIGGER_POLL_INTERVAL_SECS: i64 = 30;
+const DEFAULT_TRIGGER_MAX_POLLS: i64 = 120;
+
+fn poll_interval_param(def: &NodeDef) -> std::time::Duration {
+    std::time::Duration::from_secs(
+        def.params
+            .get("poll_interval_secs")
+            .and_then(|v| v.as_integer())
+            .unwrap_or(DEFAULT_TRIGGER_POLL_INTERVAL_SECS)
+            .max(0) as u64,
+    )
+}
+
+fn max_polls_param(def: &NodeDef) -> u32 {
+    def.params
+        .get("max_polls")
+        .and_then(|v| v.as_integer())
+        .unwrap_or(DEFAULT_TRIGGER_MAX_POLLS)
+        .max(1) as u32
 }
 
 /// `ta workflow graph-run <name>` — load `.ta/workflows/graphs/<name>.toml`
@@ -536,5 +956,313 @@ persona = "creative-generator"
             "verb alone must change the resolved team via workflow.toml data, no new Rust"
         );
         assert_ne!(implement_decision.persona, create_decision.persona);
+    }
+
+    // ── VcsTaskCompletionTrigger / CiFailureTrigger / CorrectiveGoalAction
+    //    (v0.17.7.2) ──────────────────────────────────────────────────────
+
+    /// A `SourceAdapter` whose `check_review()` replays a fixed script of
+    /// responses (one per call, clamped to the last entry once exhausted) —
+    /// following this codebase's established `MockAdapter` convention
+    /// (`crates/ta-submit/src/adapter.rs` tests: implement only what the
+    /// test exercises, `unimplemented!()` for the rest, real defaults for
+    /// everything else). `check_failures()` is fixed (not scripted) since
+    /// no test needs it to vary call-to-call.
+    struct ScriptedAdapter {
+        statuses: Vec<Option<ta_submit::ReviewStatus>>,
+        call_count: std::sync::Mutex<usize>,
+        failures: Vec<ta_submit::CheckFailure>,
+    }
+
+    impl ScriptedAdapter {
+        fn new(
+            statuses: Vec<Option<ta_submit::ReviewStatus>>,
+            failures: Vec<ta_submit::CheckFailure>,
+        ) -> Self {
+            Self {
+                statuses,
+                call_count: std::sync::Mutex::new(0),
+                failures,
+            }
+        }
+    }
+
+    impl ta_submit::SourceAdapter for ScriptedAdapter {
+        fn prepare(
+            &self,
+            _ctx: &ta_goal::CommitContext,
+            _config: &ta_submit::SubmitConfig,
+        ) -> ta_submit::adapter::Result<()> {
+            unimplemented!()
+        }
+        fn commit(
+            &self,
+            _ctx: &ta_goal::CommitContext,
+            _pr: &ta_changeset::DraftPackage,
+            _message: &str,
+        ) -> ta_submit::adapter::Result<ta_submit::CommitResult> {
+            unimplemented!()
+        }
+        fn push(
+            &self,
+            _ctx: &ta_goal::CommitContext,
+        ) -> ta_submit::adapter::Result<ta_submit::PushResult> {
+            unimplemented!()
+        }
+        fn open_review(
+            &self,
+            _ctx: &ta_goal::CommitContext,
+            _pr: &ta_changeset::DraftPackage,
+        ) -> ta_submit::adapter::Result<ta_submit::ReviewResult> {
+            unimplemented!()
+        }
+        fn name(&self) -> &str {
+            "scripted"
+        }
+        fn check_review(
+            &self,
+            _review_id: &str,
+        ) -> ta_submit::adapter::Result<Option<ta_submit::ReviewStatus>> {
+            let mut count = self.call_count.lock().unwrap();
+            let idx = (*count).min(self.statuses.len().saturating_sub(1));
+            *count += 1;
+            Ok(self.statuses.get(idx).cloned().flatten())
+        }
+        fn check_failures(
+            &self,
+            _review_id: &str,
+        ) -> ta_submit::adapter::Result<Vec<ta_submit::CheckFailure>> {
+            Ok(self.failures.clone())
+        }
+    }
+
+    fn status(state: &str, checks_passing: Option<bool>) -> Option<ta_submit::ReviewStatus> {
+        Some(ta_submit::ReviewStatus {
+            state: state.to_string(),
+            checks_passing,
+        })
+    }
+
+    #[test]
+    fn ci_failure_trigger_fires_only_on_transition_to_false() {
+        // pass -> pass -> fail: must not fire on the first two polls, only
+        // once checks_passing actually transitions to Some(false).
+        let adapter = ScriptedAdapter::new(
+            vec![
+                status("open", Some(true)),
+                status("open", Some(true)),
+                status("open", Some(false)),
+            ],
+            vec![ta_submit::CheckFailure {
+                check_name: "build".to_string(),
+                log_excerpt: "error: something broke".to_string(),
+            }],
+        );
+        let trigger = CiFailureTrigger {
+            adapter: std::sync::Arc::new(adapter),
+            review_id: "42".to_string(),
+            poll_interval: std::time::Duration::ZERO,
+            max_polls: 5,
+        };
+        let project = TempDir::new().unwrap();
+        let ctx = GraphContext::new(project.path(), "test-run");
+
+        let payload = trigger.wait(&ctx).unwrap();
+
+        assert_eq!(payload.kind, "ci_failure");
+        assert_eq!(payload.data.get("check_name").unwrap(), "build");
+        assert!(payload
+            .data
+            .get("log_excerpt")
+            .unwrap()
+            .contains("something broke"));
+    }
+
+    #[test]
+    fn ci_failure_trigger_degrades_gracefully_when_check_failures_is_empty() {
+        // Simulates a non-Git adapter (Perforce/SVN/"none") staying on the
+        // check_failures() default (empty vec) — per constitution §16.4 this
+        // must degrade to an explicit "investigate manually" hint, not an
+        // empty/confusing payload.
+        let adapter = ScriptedAdapter::new(vec![status("open", Some(false))], vec![]);
+        let trigger = CiFailureTrigger {
+            adapter: std::sync::Arc::new(adapter),
+            review_id: "42".to_string(),
+            poll_interval: std::time::Duration::ZERO,
+            max_polls: 3,
+        };
+        let project = TempDir::new().unwrap();
+        let ctx = GraphContext::new(project.path(), "test-run");
+
+        let payload = trigger.wait(&ctx).unwrap();
+
+        assert_eq!(payload.data.get("check_name").unwrap(), "unknown");
+        assert_eq!(
+            payload.data.get("log_excerpt").unwrap(),
+            CI_DETAIL_UNAVAILABLE_MESSAGE
+        );
+    }
+
+    #[test]
+    fn vcs_task_completion_trigger_fires_on_terminal_state() {
+        let adapter = ScriptedAdapter::new(
+            vec![status("open", None), status("merged", Some(true))],
+            vec![],
+        );
+        let trigger = VcsTaskCompletionTrigger {
+            adapter: std::sync::Arc::new(adapter),
+            review_id: "7".to_string(),
+            poll_interval: std::time::Duration::ZERO,
+            max_polls: 5,
+        };
+        let project = TempDir::new().unwrap();
+        let ctx = GraphContext::new(project.path(), "test-run");
+
+        let payload = trigger.wait(&ctx).unwrap();
+
+        assert_eq!(payload.kind, "vcs_task_completion");
+        assert_eq!(payload.data.get("state").unwrap(), "merged");
+    }
+
+    #[test]
+    fn vcs_task_completion_trigger_errors_when_poll_budget_exhausted() {
+        let adapter = ScriptedAdapter::new(vec![status("open", Some(true))], vec![]);
+        let trigger = VcsTaskCompletionTrigger {
+            adapter: std::sync::Arc::new(adapter),
+            review_id: "7".to_string(),
+            poll_interval: std::time::Duration::ZERO,
+            max_polls: 3,
+        };
+        let project = TempDir::new().unwrap();
+        let ctx = GraphContext::new(project.path(), "test-run");
+
+        assert!(trigger.wait(&ctx).is_err());
+    }
+
+    #[test]
+    fn ci_failure_trigger_drives_corrective_goal_action_end_to_end() {
+        let project = TempDir::new().unwrap();
+        std::fs::write(project.path().join("README.md"), "# Original\n").unwrap();
+        let config = GatewayConfig::for_project(project.path());
+
+        let adapter = ScriptedAdapter::new(
+            vec![status("open", Some(false))],
+            vec![ta_submit::CheckFailure {
+                check_name: "build".to_string(),
+                log_excerpt: "error: something broke".to_string(),
+            }],
+        );
+        let trigger = CiFailureTrigger {
+            adapter: std::sync::Arc::new(adapter),
+            review_id: "42".to_string(),
+            poll_interval: std::time::Duration::ZERO,
+            max_polls: 3,
+        };
+        let mut ctx = GraphContext::new(project.path(), "test-run");
+
+        let payload = trigger.wait(&ctx).unwrap();
+        for (k, v) in payload.data {
+            ctx.vars.insert(k, v);
+        }
+        ctx.vars
+            .insert("ci_fix_attempt".to_string(), "1".to_string());
+
+        let action = CorrectiveGoalAction::new(config.clone(), 2);
+        let outcome = action.act(&passing_decision(), &ctx).unwrap();
+
+        assert!(outcome.applied, "must launch a follow-up fix goal");
+        assert_eq!(outcome.kind, "corrective_goal");
+        assert!(outcome.message.contains("build"));
+
+        let store = ta_goal::GoalRunStore::new(&config.goals_dir).unwrap();
+        let goals = store.list().unwrap();
+        assert!(
+            goals
+                .iter()
+                .any(|g| g.title.contains("Fix CI failure: build")),
+            "CorrectiveGoalAction must actually dispatch a goal via GoalDispatchAction \
+             machinery, not a stub — proven by a real goal existing in the store"
+        );
+    }
+
+    #[test]
+    fn corrective_goal_action_escalates_to_human_after_retry_cap_exhausted() {
+        let project = TempDir::new().unwrap();
+        let config = GatewayConfig::for_project(project.path());
+        let mut ctx = GraphContext::new(project.path(), "test-run");
+        ctx.vars
+            .insert("check_name".to_string(), "build".to_string());
+        ctx.vars
+            .insert("log_excerpt".to_string(), "still broken".to_string());
+        ctx.vars.insert("review_id".to_string(), "42".to_string());
+        // attempt (2) exceeds retry_cap (1) — must escalate, not retry again.
+        ctx.vars
+            .insert("ci_fix_attempt".to_string(), "2".to_string());
+
+        let action = CorrectiveGoalAction::new(config, 1);
+        let outcome = action.act(&passing_decision(), &ctx).unwrap();
+
+        assert!(
+            !outcome.applied,
+            "must not launch another follow-up fix goal past the retry cap"
+        );
+        assert_eq!(
+            outcome.metadata.get("escalated").map(String::as_str),
+            Some("true")
+        );
+        assert!(outcome.message.contains("escalating"));
+    }
+
+    #[test]
+    fn run_ci_failure_watch_launches_fix_then_escalates_after_repeat_failure() {
+        // Three consecutive CI failures with retry_cap=1: attempt 1 launches
+        // a follow-up fix, attempt 2 escalates — reusing v0.17.0.12.31's
+        // decide_gate_failure_action, not a second retry mechanism. The
+        // third scripted failure must never be reached (the loop stops at
+        // escalation).
+        let project = TempDir::new().unwrap();
+        std::fs::write(project.path().join("README.md"), "# Original\n").unwrap();
+        let config = GatewayConfig::for_project(project.path());
+
+        let failing = ta_submit::CheckFailure {
+            check_name: "build".to_string(),
+            log_excerpt: "still broken".to_string(),
+        };
+        let adapter = ScriptedAdapter::new(
+            vec![
+                status("open", Some(false)),
+                status("open", Some(true)),
+                status("open", Some(false)),
+                status("open", Some(true)),
+                status("open", Some(false)),
+            ],
+            vec![failing],
+        );
+
+        let outcomes = run_ci_failure_watch(
+            std::sync::Arc::new(adapter),
+            "42",
+            None,
+            1,
+            std::time::Duration::ZERO,
+            10,
+            &config,
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcomes.len(),
+            2,
+            "must stop after escalation, not retry a third time"
+        );
+        assert!(outcomes[0].applied, "attempt 1 launches a follow-up fix");
+        assert!(
+            !outcomes[1].applied,
+            "attempt 2 escalates instead of retrying again"
+        );
+        assert_eq!(
+            outcomes[1].metadata.get("escalated").map(String::as_str),
+            Some("true")
+        );
     }
 }

--- a/crates/ta-actions/Cargo.toml
+++ b/crates/ta-actions/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 toml = { workspace = true }
-ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.1" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-advisor/Cargo.toml
+++ b/crates/ta-advisor/Cargo.toml
@@ -17,12 +17,12 @@ tracing = { workspace = true }
 
 # Reuses the existing heuristic classifier as the substrate for the new
 # 4-way taxonomy rather than duplicating keyword-matching logic.
-ta-session = { path = "../ta-session", version = "0.17.7-alpha.1" }
+ta-session = { path = "../ta-session", version = "0.17.7-alpha.2" }
 # Team-coordinator capability (v0.17.0.12.20): reuses ta-intake's TriggerEvent
 # and ta-brain's routing/prioritization rather than a new persistent role —
 # see crates/ta-advisor/src/coordinator.rs for the decision rationale.
-ta-intake = { path = "../ta-intake", version = "0.17.7-alpha.1" }
-ta-brain = { path = "../ta-brain", version = "0.17.7-alpha.1" }
+ta-intake = { path = "../ta-intake", version = "0.17.7-alpha.2" }
+ta-brain = { path = "../ta-brain", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-brain/Cargo.toml
+++ b/crates/ta-brain/Cargo.toml
@@ -18,13 +18,13 @@ chrono = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
-ta-session = { path = "../ta-session", version = "0.17.7-alpha.1" }
-ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
-ta-intake = { path = "../ta-intake", version = "0.17.7-alpha.1" }
+ta-session = { path = "../ta-session", version = "0.17.7-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.2" }
+ta-intake = { path = "../ta-intake", version = "0.17.7-alpha.2" }
 # Folds ta-workflow's template-matching intent resolver in as one signal
 # route() consults (v0.17.0.12.23), rather than a second, parallel intent
 # system — see route.rs's resolve_workflow_template().
-ta-workflow = { path = "../ta-workflow", version = "0.17.7-alpha.1" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/comfyui/Cargo.toml
+++ b/crates/ta-connectors/comfyui/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.7-alpha.1" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/discord/Cargo.toml
+++ b/crates/ta-connectors/discord/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.7-alpha.1" }
+ta-events = { path = "../../ta-events", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/email/Cargo.toml
+++ b/crates/ta-connectors/email/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.7-alpha.1" }
+ta-events = { path = "../../ta-events", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/fs/Cargo.toml
+++ b/crates/ta-connectors/fs/Cargo.toml
@@ -16,10 +16,10 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.7-alpha.1" }
-ta-workspace = { path = "../../ta-workspace", version = "0.17.7-alpha.1" }
-ta-audit = { path = "../../ta-audit", version = "0.17.7-alpha.1" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.7-alpha.2" }
+ta-workspace = { path = "../../ta-workspace", version = "0.17.7-alpha.2" }
+ta-audit = { path = "../../ta-audit", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-ta-policy = { path = "../../ta-policy", version = "0.17.7-alpha.1" }
+ta-policy = { path = "../../ta-policy", version = "0.17.7-alpha.2" }

--- a/crates/ta-connectors/slack/Cargo.toml
+++ b/crates/ta-connectors/slack/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.7-alpha.1" }
+ta-events = { path = "../../ta-events", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/unreal/Cargo.toml
+++ b/crates/ta-connectors/unreal/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.7-alpha.1" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -31,23 +31,23 @@ async-stream = { workspace = true }
 sha2 = { workspace = true }
 
 # Internal crates
-ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.7-alpha.1" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.7-alpha.1" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
-ta-memory = { path = "../ta-memory", version = "0.17.7-alpha.1" }
-ta-events = { path = "../ta-events", version = "0.17.7-alpha.1" }
-ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
-ta-runtime = { path = "../ta-runtime", version = "0.17.7-alpha.1" }
-ta-audit = { path = "../ta-audit", version = "0.17.7-alpha.1" }
-ta-policy = { path = "../ta-policy", version = "0.17.7-alpha.1" }
-ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.7-alpha.1" }
-ta-connector-email = { path = "../ta-connectors/email", version = "0.17.7-alpha.1" }
+ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.7-alpha.2" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.7-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.2" }
+ta-memory = { path = "../ta-memory", version = "0.17.7-alpha.2" }
+ta-events = { path = "../ta-events", version = "0.17.7-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.2" }
+ta-runtime = { path = "../ta-runtime", version = "0.17.7-alpha.2" }
+ta-audit = { path = "../ta-audit", version = "0.17.7-alpha.2" }
+ta-policy = { path = "../ta-policy", version = "0.17.7-alpha.2" }
+ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.7-alpha.2" }
+ta-connector-email = { path = "../ta-connectors/email", version = "0.17.7-alpha.2" }
 reqwest = { workspace = true }
-ta-output-schema = { path = "../ta-output-schema", version = "0.17.7-alpha.1" }
-ta-extension = { path = "../ta-extension", version = "0.17.7-alpha.1" }
-ta-session = { path = "../ta-session", version = "0.17.7-alpha.1" }
-ta-advisor = { path = "../ta-advisor", version = "0.17.7-alpha.1" }
-ta-data-spec = { path = "../ta-data-spec", version = "0.17.7-alpha.1" }
+ta-output-schema = { path = "../ta-output-schema", version = "0.17.7-alpha.2" }
+ta-extension = { path = "../ta-extension", version = "0.17.7-alpha.2" }
+ta-session = { path = "../ta-session", version = "0.17.7-alpha.2" }
+ta-advisor = { path = "../ta-advisor", version = "0.17.7-alpha.2" }
+ta-data-spec = { path = "../ta-data-spec", version = "0.17.7-alpha.2" }
 which = "7"
 libc = { workspace = true }
 async-trait = "0.1"

--- a/crates/ta-data-spec/Cargo.toml
+++ b/crates/ta-data-spec/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 [dependencies]
 schemars = { workspace = true }
 serde_json = { workspace = true }
-ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
-ta-brain = { path = "../ta-brain", version = "0.17.7-alpha.1" }
-ta-intake = { path = "../ta-intake", version = "0.17.7-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.2" }
+ta-brain = { path = "../ta-brain", version = "0.17.7-alpha.2" }
+ta-intake = { path = "../ta-intake", version = "0.17.7-alpha.2" }

--- a/crates/ta-db-proxy/Cargo.toml
+++ b/crates/ta-db-proxy/Cargo.toml
@@ -17,10 +17,10 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.7-alpha.1" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.1" }
-ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.1" }
-ta-actions = { path = "../ta-actions", version = "0.17.7-alpha.1" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.7-alpha.2" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.2" }
+ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.2" }
+ta-actions = { path = "../ta-actions", version = "0.17.7-alpha.2" }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ta-intake/Cargo.toml
+++ b/crates/ta-intake/Cargo.toml
@@ -19,8 +19,8 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 regex = { workspace = true }
-ta-submit = { path = "../ta-submit", version = "0.17.7-alpha.1" }
-ta-events = { path = "../ta-events", version = "0.17.7-alpha.1" }
+ta-submit = { path = "../ta-submit", version = "0.17.7-alpha.2" }
+ta-events = { path = "../ta-events", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -25,23 +25,23 @@ which = { workspace = true }
 toml = { workspace = true }
 
 # Internal crates
-ta-audit = { path = "../ta-audit", version = "0.17.7-alpha.1" }
-ta-events = { path = "../ta-events", version = "0.17.7-alpha.1" }
-ta-memory = { path = "../ta-memory", version = "0.17.7-alpha.1" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
-ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.7-alpha.1" }
-ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.7-alpha.1" }
-ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.7-alpha.1" }
-ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.7-alpha.1" }
-ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
-ta-policy = { path = "../ta-policy", version = "0.17.7-alpha.1" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.7-alpha.1" }
-ta-workflow = { path = "../ta-workflow", version = "0.17.7-alpha.1" }
-ta-actions = { path = "../ta-actions", version = "0.17.7-alpha.1" }
-ta-submit = { path = "../ta-submit", version = "0.17.7-alpha.1" }
-ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.1" }
-ta-credentials = { path = "../ta-credentials", version = "0.17.7-alpha.1" }
-ta-session = { path = "../ta-session", version = "0.17.7-alpha.1" }
+ta-audit = { path = "../ta-audit", version = "0.17.7-alpha.2" }
+ta-events = { path = "../ta-events", version = "0.17.7-alpha.2" }
+ta-memory = { path = "../ta-memory", version = "0.17.7-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.2" }
+ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.7-alpha.2" }
+ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.7-alpha.2" }
+ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.7-alpha.2" }
+ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.7-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.2" }
+ta-policy = { path = "../ta-policy", version = "0.17.7-alpha.2" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.7-alpha.2" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.7-alpha.2" }
+ta-actions = { path = "../ta-actions", version = "0.17.7-alpha.2" }
+ta-submit = { path = "../ta-submit", version = "0.17.7-alpha.2" }
+ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.2" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.7-alpha.2" }
+ta-session = { path = "../ta-session", version = "0.17.7-alpha.2" }
 
 
 [dev-dependencies]

--- a/crates/ta-mediation/Cargo.toml
+++ b/crates/ta-mediation/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates for FsMediator
-ta-workspace = { path = "../ta-workspace", version = "0.17.7-alpha.1" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.7-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-release/Cargo.toml
+++ b/crates/ta-release/Cargo.toml
@@ -18,7 +18,7 @@ toml = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true, features = ["multipart"] }
-ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.1" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-runtime/Cargo.toml
+++ b/crates/ta-runtime/Cargo.toml
@@ -23,8 +23,8 @@ which = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
 
-ta-credentials = { path = "../ta-credentials", version = "0.17.7-alpha.1" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.1" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.7-alpha.2" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.2" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }
-ta-policy = { path = "../ta-policy", version = "0.17.7-alpha.1" }
+ta-policy = { path = "../ta-policy", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-session/Cargo.toml
+++ b/crates/ta-session/Cargo.toml
@@ -25,9 +25,9 @@ notify = { workspace = true }
 toml = { workspace = true }
 
 # Workspace crates
-ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
-ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.1" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.2" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.2" }
+ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -16,11 +16,11 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
-ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.7-alpha.1" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.1" }
-ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.2" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.7-alpha.2" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.7-alpha.2" }
+ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.2" }
 toml = "0.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/ta-submit/src/adapter.rs
+++ b/crates/ta-submit/src/adapter.rs
@@ -285,6 +285,23 @@ pub trait SourceAdapter: Send + Sync {
         })
     }
 
+    /// Fetch per-check failure detail for a review, if the adapter's platform
+    /// exposes it (v0.17.7.2). `check_review()` only reports an opaque
+    /// `checks_passing: Option<bool>` — this method fills in *what* failed so
+    /// a `CiFailureTrigger`/`CorrectiveGoalAction` can diagnose without any
+    /// Git-specific code outside this adapter (constitution §16.4).
+    ///
+    /// Git: shells `gh run view --log-failed` for the PR's failing checks.
+    /// Perforce/SVN/"none": no CI concept — default applies unchanged.
+    ///
+    /// Default: empty vec. Not an error — a platform lacking this concept
+    /// (e.g. Perforce has no "CI check") is compliant, not a gap. Callers
+    /// must degrade gracefully (e.g. "investigate manually") on an empty
+    /// result rather than treating it as a failure to fetch.
+    fn check_failures(&self, _review_id: &str) -> Result<Vec<CheckFailure>> {
+        Ok(vec![])
+    }
+
     /// Auto-detect whether this adapter applies to the given project root.
     ///
     /// Git: checks for .git/ directory
@@ -467,6 +484,17 @@ pub struct CommitSummary {
     pub subject: String,
 }
 
+/// One failing check on a review, returned by `SourceAdapter::check_failures()`
+/// (v0.17.7.2). `log_excerpt` is adapter-specific: a truncated tail of the
+/// real failure log where available, or a hint for how to fetch it manually.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CheckFailure {
+    /// Name of the failing check (e.g. a GitHub Actions job name).
+    pub check_name: String,
+    /// Excerpt of the failure log, or guidance for fetching it manually.
+    pub log_excerpt: String,
+}
+
 /// Backward-compatible alias: `SubmitAdapter` is the old name for `SourceAdapter`.
 ///
 /// Deprecated in v0.11.1. Use `SourceAdapter` instead.
@@ -553,5 +581,11 @@ mod tests {
     fn commit_diff_default_returns_none() {
         let adapter = MockAdapter;
         assert_eq!(adapter.commit_diff(), None);
+    }
+
+    #[test]
+    fn check_failures_default_returns_empty_vec() {
+        let adapter = MockAdapter;
+        assert_eq!(adapter.check_failures("123").unwrap(), Vec::new());
     }
 }

--- a/crates/ta-submit/src/git.rs
+++ b/crates/ta-submit/src/git.rs
@@ -6,8 +6,8 @@ use ta_changeset::DraftPackage;
 use ta_goal::CommitContext;
 
 use crate::adapter::{
-    CommitResult, CommitSummary, MergeResult, PushResult, Result, ReviewResult, ReviewStatus,
-    SavedVcsState, SourceAdapter, SubmitError, SyncResult,
+    CheckFailure, CommitResult, CommitSummary, MergeResult, PushResult, Result, ReviewResult,
+    ReviewStatus, SavedVcsState, SourceAdapter, SubmitError, SyncResult,
 };
 use crate::config::SubmitConfig;
 use crate::config::SyncConfig;
@@ -75,6 +75,43 @@ fn strip_ansi_controls(s: &str) -> String {
         }
     }
     out
+}
+
+/// Extract the numeric Actions run ID from a `gh pr checks --json link`
+/// URL, e.g. `https://github.com/OWNER/REPO/actions/runs/1234567890/job/999`.
+/// Kept as a pure function (no `Command` dependency) so it's unit-testable
+/// without `gh` installed.
+fn extract_run_id(link: &str) -> Option<String> {
+    let idx = link.find("/runs/")?;
+    let rest = &link[idx + "/runs/".len()..];
+    let run_id: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if run_id.is_empty() {
+        None
+    } else {
+        Some(run_id)
+    }
+}
+
+/// Cap on how many trailing lines of a failed-run log to keep — `gh run view
+/// --log-failed` can return megabytes for a busy job, and this excerpt gets
+/// injected directly into a follow-up goal's objective (`CorrectiveGoalAction`,
+/// v0.17.7.2).
+const MAX_LOG_EXCERPT_LINES: usize = 200;
+
+/// Keep only the last `MAX_LOG_EXCERPT_LINES` lines of `full`, noting how
+/// many were dropped. Pure function, unit-testable without `gh`.
+fn truncate_log_excerpt(full: &str) -> String {
+    let lines: Vec<&str> = full.lines().collect();
+    if lines.len() <= MAX_LOG_EXCERPT_LINES {
+        full.to_string()
+    } else {
+        let start = lines.len() - MAX_LOG_EXCERPT_LINES;
+        format!(
+            "... ({} earlier line(s) truncated) ...\n{}",
+            start,
+            lines[start..].join("\n")
+        )
+    }
 }
 
 /// Truncate `s` to at most `max_chars` Unicode scalar values.
@@ -176,6 +213,23 @@ impl GitAdapter {
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
+    }
+
+    /// Fetch and truncate the failed-step log for one Actions run, used by
+    /// `check_failures()`. Returns `None` on any failure — the caller
+    /// degrades to a manual-lookup hint rather than propagating an error.
+    fn fetch_failed_run_log(&self, run_id: &str) -> Option<String> {
+        let output = Command::new("gh")
+            .args(["run", "view", run_id, "--log-failed"])
+            .current_dir(&self.work_dir)
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        Some(truncate_log_excerpt(&String::from_utf8_lossy(
+            &output.stdout,
+        )))
     }
 
     /// Get current branch name
@@ -1444,6 +1498,64 @@ impl SourceAdapter for GitAdapter {
         }
     }
 
+    fn check_failures(&self, review_id: &str) -> Result<Vec<CheckFailure>> {
+        if !self.has_gh_cli() {
+            return Ok(vec![]);
+        }
+
+        // Step 1: list this PR's checks with their pass/fail bucket + a link
+        // we can pull an Actions run ID out of. Degrades to an empty vec on
+        // any failure here (best-effort, matching check_review's style) —
+        // check_failures is read-only diagnostic detail, never a hard error.
+        let output = Command::new("gh")
+            .args(["pr", "checks", review_id, "--json", "name,bucket,link"])
+            .current_dir(&self.work_dir)
+            .output();
+        let checks: Vec<serde_json::Value> = match output {
+            Ok(o) if o.status.success() => match serde_json::from_slice(&o.stdout) {
+                Ok(v) => v,
+                Err(_) => return Ok(vec![]),
+            },
+            _ => return Ok(vec![]),
+        };
+
+        let mut failures = Vec::new();
+        for check in checks
+            .iter()
+            .filter(|c| c.get("bucket").and_then(|v| v.as_str()) == Some("fail"))
+        {
+            let check_name = check
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string();
+
+            // Step 2: pull the failing job's log via the run ID embedded in
+            // its link. Falls back to a manual-lookup hint if the link can't
+            // be parsed or `gh run view` itself fails — never blocks the
+            // overall check_failures() call on one bad check.
+            let log_excerpt = check
+                .get("link")
+                .and_then(|v| v.as_str())
+                .and_then(extract_run_id)
+                .and_then(|run_id| self.fetch_failed_run_log(&run_id))
+                .unwrap_or_else(|| {
+                    format!(
+                        "Log unavailable — run `gh run view --log-failed` for the failing \
+                         run, or `gh pr checks {} --web` to inspect in the browser.",
+                        review_id
+                    )
+                });
+
+            failures.push(CheckFailure {
+                check_name,
+                log_excerpt,
+            });
+        }
+
+        Ok(failures)
+    }
+
     fn file_at_head(&self, repo_root: &Path, rel_path: &str) -> Option<Vec<u8>> {
         let out = Command::new("git")
             .args(["show", &format!("HEAD:{}", rel_path)])
@@ -2632,5 +2744,64 @@ mod tests {
             current, feature_branch,
             "second prepare() must switch to existing branch, not create a new one"
         );
+    }
+
+    // ── check_failures() (v0.17.7.2) ────────────────────────────────
+
+    #[test]
+    fn extract_run_id_parses_actions_run_url() {
+        let link = "https://github.com/acme/widgets/actions/runs/1234567890/job/999";
+        assert_eq!(extract_run_id(link), Some("1234567890".to_string()));
+    }
+
+    #[test]
+    fn extract_run_id_returns_none_for_non_run_url() {
+        assert_eq!(
+            extract_run_id("https://github.com/acme/widgets/pull/42"),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_run_id_returns_none_for_empty_run_segment() {
+        assert_eq!(
+            extract_run_id("https://github.com/acme/widgets/actions/runs/"),
+            None
+        );
+    }
+
+    #[test]
+    fn truncate_log_excerpt_leaves_short_logs_untouched() {
+        let log = "line one\nline two\nline three";
+        assert_eq!(truncate_log_excerpt(log), log);
+    }
+
+    #[test]
+    fn truncate_log_excerpt_keeps_only_the_tail_of_long_logs() {
+        let lines: Vec<String> = (0..300).map(|i| format!("line {i}")).collect();
+        let log = lines.join("\n");
+
+        let excerpt = truncate_log_excerpt(&log);
+
+        assert!(excerpt.contains("100 earlier line(s) truncated"));
+        assert!(excerpt.contains("line 299"), "must keep the final line");
+        assert!(
+            !excerpt.contains("line 0\n"),
+            "must drop the earliest lines, not the latest"
+        );
+        assert_eq!(excerpt.lines().count(), MAX_LOG_EXCERPT_LINES + 1);
+    }
+
+    #[test]
+    fn check_failures_degrades_to_empty_vec_without_gh_cli() {
+        // The sandboxed test environment may or may not have `gh` on PATH;
+        // either way check_failures() must never error — it degrades to an
+        // empty vec for any review ID that doesn't correspond to a real,
+        // authenticated PR (constitution §1.4: never a hard failure for a
+        // read-only diagnostic path).
+        let dir = tempdir().unwrap();
+        let adapter = GitAdapter::new(dir.path());
+        let result = adapter.check_failures("not-a-real-review-id");
+        assert!(result.is_ok());
     }
 }

--- a/crates/ta-submit/src/lib.rs
+++ b/crates/ta-submit/src/lib.rs
@@ -33,7 +33,7 @@ pub mod vcs_plugin_protocol;
 
 // Primary exports (v0.11.1+)
 pub use adapter::{
-    CommitResult, CommitSummary, MergeResult, PushResult, ReviewResult, ReviewStatus,
+    CheckFailure, CommitResult, CommitSummary, MergeResult, PushResult, ReviewResult, ReviewStatus,
     SavedVcsState, SourceAdapter, SyncResult,
 };
 

--- a/crates/ta-submit/src/svn.rs
+++ b/crates/ta-submit/src/svn.rs
@@ -354,6 +354,17 @@ mod tests {
         assert!(targets.contains(&"/trunk".to_string()));
     }
 
+    /// v0.17.7.2 item 5: a non-CI adapter (SVN has no "CI check" concept)
+    /// must stay on `SourceAdapter::check_failures()`'s empty-vec default —
+    /// verified against the real `SvnAdapter`, not just a mock, since
+    /// `CiFailureTrigger` degrades based on this exact return value.
+    #[test]
+    fn test_svn_adapter_check_failures_uses_default_empty_vec() {
+        let dir = tempfile::tempdir().unwrap();
+        let adapter = SvnAdapter::new(dir.path());
+        assert_eq!(adapter.check_failures("1234").unwrap(), Vec::new());
+    }
+
     #[test]
     fn test_svn_adapter_verify_degrades_without_svn() {
         // Without svn CLI or a real working copy, verify should degrade gracefully.

--- a/crates/ta-workflow/Cargo.toml
+++ b/crates/ta-workflow/Cargo.toml
@@ -21,15 +21,15 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.2" }
 # Reused by graph::nodes::PolicyReviewer (v0.17.7.1) — wraps the existing
 # should_auto_approve_draft rule evaluation as one ReviewerNode, per
 # constitution §1.7 (reuse before reinventing). Leaf crate, no cycle risk.
-ta-policy = { path = "../ta-policy", version = "0.17.7-alpha.1" }
+ta-policy = { path = "../ta-policy", version = "0.17.7-alpha.2" }
 # Reused by graph::nodes::AdvisorConfidenceReviewer (v0.17.7.1) — wraps the
 # existing gate::decide() confidence check as one ReviewerNode. Leaf crate,
 # no cycle risk.
-ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.1" }
+ta-decision = { path = "../ta-decision", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -21,8 +21,8 @@ reqwest = { workspace = true }
 anyhow = { workspace = true }
 sha2 = "0.10"
 base64 = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.1" }
-ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.1" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.7-alpha.2" }
+ta-goal = { path = "../ta-goal", version = "0.17.7-alpha.2" }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: 0.17.7-alpha.1
+**Version**: 0.17.7-alpha.2
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 
@@ -501,8 +501,8 @@ Workflow graphs are a separate, lower-level engine (`ta-workflow::graph`) from t
 | `[[worker]]` | Dispatches new work (starts a goal) | `goal_dispatch` |
 | `[[reviewer]]` | Produces one scored vote on a draft/decision | `policy`, `advisor_confidence` |
 | `[decision]` | Fans in every reviewer vote, applies weights/threshold/algorithm | `weighted` |
-| `[action]` | Acts on the decision | `recommend`, `auto_approve` |
-| `[[trigger]]` | Fires the graph on an external event (parses today; execution wiring lands in a later release) | `vcs_task_completion` |
+| `[action]` | Acts on the decision | `recommend`, `auto_approve`, `corrective_goal` |
+| `[[trigger]]` | Fires on an external event — parses and is runnable standalone via `ta workflow watch-ci` today; full `ta workflow graph-run` wiring lands in a later release | `vcs_task_completion`, `ci_failure` |
 
 **Recommendation vs. auto-approval is the same decision, different wiring.** A `[decision]` node never encodes whether its output is binding or advisory — that's purely which `[action] kind` the graph is wired to. Swap `kind = "recommend"` for `kind = "auto_approve"` in an otherwise identical graph, and the exact same decision goes from "surfaced to a human" to "applied automatically." **New graphs default to `recommend`** — a human must explicitly edit a graph to `auto_approve` before it can act on its own.
 
@@ -575,6 +575,32 @@ ta workflow graph-run dispatch-and-review --title "New logo" --verb create --wor
 ```
 
 `ta workflow graph-run <name>` is a synchronous "run now" entry point for testing and debugging a graph definition — it does not yet wait on `[[trigger]]` sources or replace `ta draft apply`'s real approval gate (that wiring lands in a later phase). Flags: `--title`, `--objective`, `--verb` (default `implement`), `--workload-hint`, `--phase`.
+
+### CI-Failure Watch & Corrective Goals
+
+`ta workflow watch-ci <review-id>` generalizes the "watch CI, read the failing job log, diagnose, fix, push, repeat" loop into two graph nodes:
+
+- **`CiFailureTrigger`** polls your configured VCS adapter's review status and fires the moment CI status flips from passing (or unknown) to failing — not on every poll while it stays red.
+- **`CorrectiveGoalAction`** responds to that failure by launching a follow-up fix goal (via the same dispatch path `[[worker]] kind = "goal_dispatch"` uses) with the failing check's name and a log excerpt injected directly into the goal's objective.
+
+```bash
+ta workflow watch-ci 123 --retry-cap 2
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--retry-cap` | `1` | Max consecutive auto-fix attempts before escalating to a human. |
+| `--poll-interval-secs` | `30` | Seconds between CI status polls. |
+| `--max-polls` | `120` | Max polls per wait cycle before giving up on that review. |
+
+Both triggers go through `SourceAdapter` only — never a platform-specific API call directly, per the constitution's VCS-adapter invariant (§16.4). This has two consequences:
+
+- Any adapter that implements `check_review()` (Git today; a future Perforce/SVN CI integration tomorrow) gets `VcsTaskCompletionTrigger`/`CiFailureTrigger` support automatically, with no trigger-side code change.
+- An adapter with no per-check failure detail (Perforce, SVN, "none" — or Git without the `gh` CLI installed) is fully compliant, not a gap: `SourceAdapter::check_failures()` defaults to an empty list, and `CiFailureTrigger` degrades to `"CI failure detail unavailable for this VCS adapter, investigate manually"` instead of guessing or erroring.
+
+**Retry cap and escalation** reuse the exact same auto-fix mechanism as `ta workflow build-milestone --on-gate-failure=auto-fix` (`decide_gate_failure_action`/`GateFailureMode::AutoFix`) — not a second, parallel retry mechanism. Each new CI failure on the same review counts as one attempt; once the attempt count exceeds `--retry-cap`, the watch stops launching fixes and reports an escalation instead of retrying forever.
+
+`ta workflow watch-ci` doesn't yet know which goal originally opened the review it's watching, so each corrective fix lands as its own new goal rather than continuing the original goal's branch. A future release (chaining this into the advisor's multi-phase entry point) will seed that link automatically so fixes land on the same PR.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a defaulted `SourceAdapter::check_failures()` method (empty-vec default, matching the existing `check_review()`/`merge_review()` pattern) per constitution §16.4.
- Implements it for the Git adapter.
- Adds the trigger/action nodes that replace the manual watch-CI/diagnose/fix/push loop.
- Documented deviation: item 4 originally specified literal `ta run --follow-up`; that flag doesn't exist in the codebase, so the functionally-equivalent `GoalDispatchAction` mechanism was used instead — noted directly in PLAN.md.
- Version bumped `0.17.7-alpha.1` → `0.17.7-alpha.2`.

## Test plan
- `cargo build --workspace`, `cargo test --workspace` (1552+ tests passed, 0 failed), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all pass in an isolated worktree.