### PR TITLE
implement v0.17.6.5 — Swarm Fan-Out Cryptographic Attenuation

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -10185,16 +10185,16 @@ Code releases use semver. Content releases don't. Decide:
 
 ---
 ### v0.17.6.5 — Swarm Fan-Out Cryptographic Attenuation
-<!-- status: pending -->
+<!-- status: done -->
 **Depends on**: v0.17.6.4
 
 **Goal**: Replace v0.17.6.1's manual scope-intersection/handoff with real `biscuit.attenuate()` — cryptographically, not just conventionally, narrower-than-parent for every concurrent sub-goal.
 
 **Items**:
-1. [ ] At the same spawn point identified in v0.17.6.1 (`run_one_swarm_sub_goal`, before `Command::new`), attenuate the parent's biscuit in-process (no network call, no broker round-trip) with an appended block scoping the child to its declared resource glob and a `ttl = min(parent_remaining_ttl, sub_goal_wave_deadline)`.
-2. [ ] The attenuated child biscuit is passed explicitly into the recursive `ta run` invocation via the handoff mechanism built in v0.17.6.1 item 3.
-3. [ ] Nested fan-out (a sub-goal spawning its own sub-sub-goals) repeats the identical attenuation operation recursively — `ta-workflow::concurrent::run_concurrently` itself stays generic and credential-blind, no new component added there.
-4. [ ] Tests: a two-level-deep nested swarm produces a grandchild token that is provably a subset of the grandparent's grant, verified via the authorizer rejecting an out-of-scope request at every hop.
+1. [x] At the same spawn point identified in v0.17.6.1 (`run_one_swarm_sub_goal`, before `Command::new`), attenuate the parent's biscuit in-process (no network call, no broker round-trip) with an appended block scoping the child to its declared resource glob and a `ttl = min(parent_remaining_ttl, sub_goal_wave_deadline)`.
+2. [x] The attenuated child biscuit is passed explicitly into the recursive `ta run` invocation via the handoff mechanism built in v0.17.6.1 item 3.
+3. [x] Nested fan-out (a sub-goal spawning its own sub-sub-goals) repeats the identical attenuation operation recursively — `ta-workflow::concurrent::run_concurrently` itself stays generic and credential-blind, no new component added there.
+4. [x] Tests: a two-level-deep nested swarm produces a grandchild token that is provably a subset of the grandparent's grant, verified via the authorizer rejecting an out-of-scope request at every hop.
 
 #### Version: `0.17.6-alpha.5`
 

--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -1671,17 +1671,19 @@ fn build_swarm_sub_goal_command(
     // derivation is needed.
     // No goal_id exists yet for this sub-goal (its `ta run` child mints its
     // own), so the title stands in as the token's `agent_id` for now — good
-    // enough for audit-trail purposes ahead of v0.17.6.5's cryptographic
-    // swarm attenuation, which replaces this whole handoff with a real
-    // attenuated biscuit.
+    // enough for audit-trail purposes when this spawn falls back to a fresh
+    // vault mint (the swarm root, or a non-broker-mediated credential); a
+    // spawn that instead inherits and attenuates a held token (v0.17.6.5)
+    // carries the original grantee's `agent_id` forward from the parent.
+    let current_env: std::collections::HashMap<String, String> = std::env::vars().collect();
     let available = load_vault_credentials(
         workspace_root,
         &format!("swarm:{sub_goal_title}"),
         credential_scopes,
         CREDENTIAL_TOKEN_TTL_SECS,
         use_keychain,
+        &current_env,
     );
-    let current_env: std::collections::HashMap<String, String> = std::env::vars().collect();
     let sub_goal_env = scoped_credential_env(&current_env, &available, credential_scopes);
 
     cmd.env_clear();
@@ -4900,9 +4902,16 @@ fn scoped_credential_env(
 
 /// Default TTL for the session grants minted by [`load_vault_credentials`]
 /// (v0.17.6.2). Generous enough to cover a typical single goal run without
-/// being unbounded; a real per-goal deadline arrives with swarm attenuation
-/// in v0.17.6.5.
+/// being unbounded.
 const CREDENTIAL_TOKEN_TTL_SECS: u64 = 3600;
+
+/// Default per-wave TTL ceiling for a swarm sub-goal's *attenuated* grant
+/// (v0.17.6.5) — deliberately tighter than [`CREDENTIAL_TOKEN_TTL_SECS`]'s
+/// whole-goal budget, since a single wave is expected to be a fraction of a
+/// full run. Only ever narrows further (never widens) the parent's actual
+/// remaining validity: see [`load_vault_credentials`]'s `ttl_secs =
+/// min(parent_remaining_ttl, wave_deadline)` computation.
+const SWARM_WAVE_TTL_SECS: u64 = 1800;
 
 /// Load every credential currently registered in `<project_root>/.ta/credentials.json`
 /// (via `ta credentials add`) as a `ScopedCredential`, secret value included.
@@ -4911,14 +4920,29 @@ const CREDENTIAL_TOKEN_TTL_SECS: u64 = 3600;
 /// read. For each credential eligible for `required_scopes` (same
 /// eligibility rule `apply_credentials_to_env` enforces: unscoped credentials
 /// are always eligible, scoped ones need at least one overlapping scope), a
-/// grant is minted via `ta_credential_broker::CredentialBroker::grant`
-/// (v0.17.6.4 — previously a vault-local `SessionToken`) and immediately
-/// checked via `CredentialBroker::verify` *before* the secret is ever read.
-/// A credential that fails either step (e.g. the mint fails, or — once TTLs
-/// shorter than a spawn are used — the grant is already expired) is
+/// grant is obtained and immediately checked *before* the secret is ever
+/// read. A credential that fails either step (e.g. the mint fails, or — once
+/// TTLs shorter than a spawn are used — the grant is already expired) is
 /// withheld, not silently granted. This makes every credential handed to an
 /// agent process correspond to a recorded, time-boxed, cryptographically
 /// verifiable grant rather than an unconditional `vault.get`.
+///
+/// v0.17.6.5: the grant is obtained one of two ways, chosen per credential:
+/// - **Attenuation** (the common case for a swarm sub-goal): if `parent_env`
+///   already carries a `TA_SESSION_TOKEN_<name>` — meaning *this* process
+///   itself was handed a broker-mediated token for this exact credential by
+///   its own parent spawn — that held token is attenuated in-process via
+///   `CredentialBroker::attenuate`, narrowing scope to `required_scopes` and
+///   TTL to `min(parent_remaining_ttl, SWARM_WAVE_TTL_SECS)`. No root key or
+///   network round-trip. This is what makes the resulting child grant
+///   cryptographically, not just conventionally, narrower: it can never
+///   exceed what the parent's own token actually embeds, regardless of what
+///   `required_scopes` claims.
+/// - **Fresh mint** (the root case: no inherited token exists, e.g. the
+///   top-level `ta run` invocation, or a credential that isn't
+///   broker-mediated for this connector): `CredentialBroker::grant` as
+///   before v0.17.6.5 — every attenuation chain has to start somewhere, and
+///   the vault is that root of trust.
 ///
 /// Returns an empty list (not an error) when the vault doesn't exist or is
 /// unreadable — an unpopulated vault is the common case today, and callers
@@ -4928,13 +4952,20 @@ const CREDENTIAL_TOKEN_TTL_SECS: u64 = 3600;
 /// `use_keychain` should be `true` for every real invocation; it exists so
 /// tests can force file-based key custody instead of touching the real,
 /// process-global OS keychain (see `CredentialsConfig::use_keychain`).
+///
+/// `parent_env` should be this process's own environment (`std::env::vars()`
+/// collected by the caller) — passed in rather than read here so the
+/// attenuation-vs-fresh-mint decision is a pure function of its input and
+/// directly testable.
 fn load_vault_credentials(
     project_root: &Path,
     agent_id: &str,
     required_scopes: &[String],
     ttl_secs: u64,
     use_keychain: bool,
+    parent_env: &std::collections::HashMap<String, String>,
 ) -> Vec<ta_runtime::ScopedCredential> {
+    use chrono::{DateTime, Utc};
     use ta_credentials::CredentialVault;
 
     let mut cred_config = ta_credentials::CredentialsConfig::for_project(project_root);
@@ -4959,6 +4990,7 @@ fn load_vault_credentials(
     // presents the minted session token to `ta_external_action` instead,
     // and the gateway broker resolves the real secret server-side.
     let connector_registry = ta_credentials::ConnectorRegistry::load(&project_root.join(".ta"));
+    let now = Utc::now();
     summaries
         .into_iter()
         .filter_map(|summary| {
@@ -4978,18 +5010,74 @@ fn load_vault_credentials(
                 return None;
             }
 
-            let granted = match broker.grant(summary.id, agent_id, granted_scopes, ttl_secs) {
-                Ok(granted) => granted,
-                Err(e) => {
+            let parent_token_key = format!("TA_SESSION_TOKEN_{}", summary.name);
+            let inherited = parent_env.get(&parent_token_key).and_then(|parent_token| {
+                let parent_remaining = parent_env
+                    .get(&format!("{parent_token_key}_EXPIRES_AT"))
+                    .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                    .map(|dt| (dt.with_timezone(&Utc) - now).num_seconds().max(0) as u64)
+                    .unwrap_or(ttl_secs);
+                let hop_ttl = parent_remaining.min(ttl_secs).min(SWARM_WAVE_TTL_SECS);
+                match broker.attenuate(parent_token, granted_scopes.clone(), hop_ttl) {
+                    Ok(g) => Some(g),
+                    Err(e) => {
+                        tracing::warn!(
+                            credential = %summary.name,
+                            error = %e,
+                            "failed to attenuate inherited session grant; \
+                             falling back to a fresh vault mint"
+                        );
+                        None
+                    }
+                }
+            });
+
+            let (granted, attenuated) = match inherited {
+                Some(granted) => {
+                    if granted.allowed_scopes.is_empty() && !granted_scopes.is_empty() {
+                        // Attenuation narrowed this credential to nothing —
+                        // the parent's own token no longer covers any scope
+                        // this sub-goal declared, so withhold it entirely
+                        // rather than hand over a token that can never
+                        // authorize anything.
+                        return None;
+                    }
+                    (granted, true)
+                }
+                None => match broker.grant(summary.id, agent_id, granted_scopes, ttl_secs) {
+                    Ok(granted) => (granted, false),
+                    Err(e) => {
+                        tracing::warn!(
+                            credential = %summary.name,
+                            error = %e,
+                            "failed to mint session grant; credential withheld"
+                        );
+                        return None;
+                    }
+                },
+            };
+            if attenuated {
+                // Attenuated grants embed a `requested_scope` check that
+                // plain `verify()` can't satisfy (see `CredentialBroker::
+                // attenuate`'s doc comment) — spot-check every scope this
+                // grant actually claims via the same mechanism that will
+                // gate real use downstream. An attenuation narrowed to zero
+                // scopes needs no such check (nothing to spot-check) and was
+                // already validated structurally by `attenuate()` itself
+                // succeeding.
+                if let Some(bad) = granted
+                    .allowed_scopes
+                    .iter()
+                    .find(|s| broker.authorize_scope(&granted.token, s).is_err())
+                {
                     tracing::warn!(
                         credential = %summary.name,
-                        error = %e,
-                        "failed to mint session grant; credential withheld"
+                        scope = %bad,
+                        "attenuated session grant failed verification; credential withheld"
                     );
                     return None;
                 }
-            };
-            if let Err(e) = broker.verify(&granted.token) {
+            } else if let Err(e) = broker.verify(&granted.token) {
                 tracing::warn!(
                     credential = %summary.name,
                     error = %e,
@@ -5004,6 +5092,7 @@ fn load_vault_credentials(
                     ta_runtime::ScopedCredential::with_scopes(full.name, full.secret, full.scopes);
                 if broker_mediated {
                     cred.with_broker_mediation(granted.token)
+                        .with_expiry(granted.expires_at)
                 } else {
                     cred
                 }
@@ -5065,6 +5154,7 @@ fn launch_agent_via_runtime(
     let mut env: std::collections::HashMap<String, String> = match credential_scopes {
         Some(scopes) => {
             let project_root = project_root_from_staging(staging_path);
+            let current_env: std::collections::HashMap<String, String> = std::env::vars().collect();
             let available = project_root
                 .as_deref()
                 .map(|root| {
@@ -5074,10 +5164,10 @@ fn launch_agent_via_runtime(
                         scopes,
                         CREDENTIAL_TOKEN_TTL_SECS,
                         true,
+                        &current_env,
                     )
                 })
                 .unwrap_or_default();
-            let current_env: std::collections::HashMap<String, String> = std::env::vars().collect();
             scoped_credential_env(&current_env, &available, scopes)
         }
         None => std::collections::HashMap::new(),
@@ -11147,7 +11237,15 @@ plan_pending_window = 7
     #[test]
     fn load_vault_credentials_returns_empty_for_unpopulated_vault() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(load_vault_credentials(dir.path(), "agent-1", &[], 3600, false).is_empty());
+        assert!(load_vault_credentials(
+            dir.path(),
+            "agent-1",
+            &[],
+            3600,
+            false,
+            &Default::default()
+        )
+        .is_empty());
     }
 
     #[test]
@@ -11173,6 +11271,7 @@ plan_pending_window = 7
             &["repo.read".to_string()],
             3600,
             false,
+            &Default::default(),
         );
         assert_eq!(creds.len(), 1);
         assert_eq!(creds[0].name, "GITHUB_TOKEN");
@@ -11200,6 +11299,7 @@ plan_pending_window = 7
             &["repo.read".to_string()],
             3600,
             false,
+            &Default::default(),
         );
         assert!(creds.is_empty());
     }
@@ -11221,7 +11321,8 @@ plan_pending_window = 7
                 .unwrap();
         }
 
-        let creds = load_vault_credentials(dir.path(), "agent-1", &[], 0, false);
+        let creds =
+            load_vault_credentials(dir.path(), "agent-1", &[], 0, false, &Default::default());
         assert!(creds.is_empty());
     }
 
@@ -11251,7 +11352,8 @@ plan_pending_window = 7
                 .id
         };
 
-        let creds = load_vault_credentials(dir.path(), "agent-1", &[], 3600, false);
+        let creds =
+            load_vault_credentials(dir.path(), "agent-1", &[], 3600, false, &Default::default());
         assert_eq!(creds.len(), 1);
         assert!(creds[0].broker_mediated);
         let session_token = creds[0]
@@ -11263,6 +11365,136 @@ plan_pending_window = 7
         let verified = broker.verify(session_token).unwrap();
         assert_eq!(verified.credential_id, cred_id);
         assert_eq!(verified.agent_id, "agent-1");
+    }
+
+    /// Set up a broker-mediated `GITHUB_TOKEN` credential and mint a root
+    /// grant for it directly (bypassing `load_vault_credentials`, standing
+    /// in for "what this test process's own parent already handed it").
+    /// Returns `(project_dir, ta_dir, granted_root_token)`.
+    fn setup_broker_mediated_root_grant(
+        scopes: Vec<String>,
+    ) -> (
+        tempfile::TempDir,
+        std::path::PathBuf,
+        ta_credential_broker::GrantedToken,
+    ) {
+        use ta_credentials::{CredentialVault, FileVault};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ta_dir = dir.path().join(".ta");
+        std::fs::create_dir_all(&ta_dir).unwrap();
+        std::fs::write(
+            ta_dir.join("connectors.toml"),
+            "[connectors.github]\ncredential_name = \"GITHUB_TOKEN\"\nbroker_mediated = true\n",
+        )
+        .unwrap();
+
+        let cred_id = {
+            let mut vault = FileVault::open(&test_cred_config(dir.path())).unwrap();
+            vault
+                .add("GITHUB_TOKEN", "github", "ghp_secret", vec![])
+                .unwrap()
+                .id
+        };
+
+        let broker = ta_credential_broker::CredentialBroker::open(&ta_dir).unwrap();
+        let root = broker.grant(cred_id, "swarm-root", scopes, 3600).unwrap();
+        (dir, ta_dir, root)
+    }
+
+    #[test]
+    fn load_vault_credentials_attenuates_inherited_session_token_instead_of_fresh_minting() {
+        // v0.17.6.5: when this process's own environment already carries a
+        // `TA_SESSION_TOKEN_<name>` for a credential (i.e. this process was
+        // itself handed a broker-mediated grant by its own parent spawn),
+        // `load_vault_credentials` must attenuate that held token in-process
+        // rather than independently re-minting a fresh, unrelated grant from
+        // the vault. The proof that real attenuation happened (not a fresh
+        // grant that merely reports a smaller scope list): a scope present
+        // in the root grant but never requested here is cryptographically
+        // unusable on the resulting token, not just absent from a Rust-side
+        // list.
+        let (dir, ta_dir, root) =
+            setup_broker_mediated_root_grant(vec!["repo.read".into(), "repo.write".into()]);
+
+        let mut parent_env = std::collections::HashMap::new();
+        parent_env.insert(
+            "TA_SESSION_TOKEN_GITHUB_TOKEN".to_string(),
+            root.token.clone(),
+        );
+        parent_env.insert(
+            "TA_SESSION_TOKEN_GITHUB_TOKEN_EXPIRES_AT".to_string(),
+            root.expires_at.to_rfc3339(),
+        );
+
+        let creds = load_vault_credentials(
+            dir.path(),
+            "swarm:child-sub-goal",
+            &["repo.read".to_string()],
+            3600,
+            false,
+            &parent_env,
+        );
+
+        assert_eq!(creds.len(), 1);
+        let child_token = creds[0]
+            .session_token_id
+            .as_deref()
+            .expect("broker-mediated credential must carry a session token");
+        // Must be a genuinely different (attenuated) token, not the parent's
+        // own token string handed straight through.
+        assert_ne!(child_token, root.token);
+
+        let broker = ta_credential_broker::CredentialBroker::open(&ta_dir).unwrap();
+        assert!(broker.authorize_scope(child_token, "repo.read").is_ok());
+        // "repo.write" was in the root grant but never requested by this
+        // hop — the authorizer itself must reject it, proving this is real
+        // attenuation and not a fresh, independently-scoped grant.
+        assert!(broker.authorize_scope(child_token, "repo.write").is_err());
+    }
+
+    #[test]
+    fn load_vault_credentials_attenuation_ttl_never_exceeds_parent_remaining() {
+        // The child's effective TTL must be bounded by the parent's actual
+        // remaining validity, not just the caller's requested `ttl_secs` —
+        // proven here by granting the parent a ~3-second remaining TTL and
+        // requesting an hour for the child; the child must still expire
+        // within a few seconds, not an hour.
+        let (dir, ta_dir, root) = setup_broker_mediated_root_grant(vec!["repo.read".into()]);
+
+        let mut parent_env = std::collections::HashMap::new();
+        parent_env.insert(
+            "TA_SESSION_TOKEN_GITHUB_TOKEN".to_string(),
+            root.token.clone(),
+        );
+        parent_env.insert(
+            "TA_SESSION_TOKEN_GITHUB_TOKEN_EXPIRES_AT".to_string(),
+            // Override the root's real (3600s) expiry with one a few
+            // seconds out (comfortably more than one whole second so
+            // truncating `.num_seconds()` doesn't round it down to zero
+            // before `load_vault_credentials` even runs), standing in for
+            // "the parent's own grant is about to expire" without needing a
+            // slow real-time 3600s test.
+            (chrono::Utc::now() + chrono::Duration::seconds(3)).to_rfc3339(),
+        );
+
+        let creds = load_vault_credentials(
+            dir.path(),
+            "swarm:child-sub-goal",
+            &["repo.read".to_string()],
+            3600, // caller asks for an hour...
+            false,
+            &parent_env,
+        );
+        assert_eq!(creds.len(), 1);
+        let child_token = creds[0].session_token_id.clone().unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(3200));
+
+        let broker = ta_credential_broker::CredentialBroker::open(&ta_dir).unwrap();
+        // ...but the parent only had ~1 second left, so the child must
+        // already be expired.
+        assert!(broker.authorize_scope(&child_token, "repo.read").is_err());
     }
 
     #[test]

--- a/crates/ta-credential-broker/src/broker.rs
+++ b/crates/ta-credential-broker/src/broker.rs
@@ -15,7 +15,9 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use biscuit_auth::{Algorithm, AuthorizerBuilder, AuthorizerLimits, Biscuit, KeyPair, PrivateKey};
+use biscuit_auth::{
+    Algorithm, AuthorizerBuilder, AuthorizerLimits, Biscuit, BlockBuilder, KeyPair, PrivateKey,
+};
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use tracing::info;
@@ -186,6 +188,146 @@ impl CredentialBroker {
         })
     }
 
+    /// Attenuate `token` (a grant from [`Self::grant`] or a previously
+    /// attenuated token from this method) in-process: appends a new block
+    /// narrowing `scopes` to at most the token's *currently* effective
+    /// scopes and `ttl_secs` to at most its currently effective remaining
+    /// validity. No root key or network round-trip is used — biscuit's
+    /// holder-side [`Biscuit::append`] is exactly the primitive that makes
+    /// this possible, and is why the resulting attenuation is real
+    /// cryptographic narrowing rather than a fresh, independently-signed
+    /// grant that merely happens to declare a smaller scope list.
+    ///
+    /// The narrowing is enforced by an appended `check if requested_scope(...)`
+    /// clause, not by facts: biscuit facts can be freely added by any holder
+    /// (they are not restrictive), so a "latest fact wins" extraction would
+    /// let a malicious holder forge a wider-looking grant. Checks, by
+    /// contrast, are ANDed across every block ever appended and can only
+    /// narrow what [`Self::authorize_scope`] will accept — that's what makes
+    /// a two-hop-attenuated (grandchild) token provably narrower than its
+    /// grandparent: every check appended along the way must still pass.
+    ///
+    /// A `requested_scope` check requires the caller to supply that fact at
+    /// authorization time, which [`Self::verify`]'s scope-blind extraction
+    /// does not do — so `verify()` is not meaningful on an attenuated token
+    /// (nothing produces one before this method exists, so there is no
+    /// existing caller depending on that). Query effective scope narrowing
+    /// via [`Self::authorize_scope`] instead.
+    pub fn attenuate(
+        &self,
+        token: &str,
+        scopes: Vec<String>,
+        ttl_secs: u64,
+    ) -> Result<GrantedToken, BrokerError> {
+        let biscuit = self.decode_checked(token)?;
+        let (credential_id, agent_id, root_scopes) = root_claims(&biscuit)?;
+
+        // Currently-effective scopes: whichever root-declared scopes still
+        // clear every check appended by prior attenuation hops (if any).
+        // Probed independently per scope since a `check if` clause is
+        // existential over whatever facts are supplied.
+        let currently_allowed: Vec<String> = root_scopes
+            .into_iter()
+            .filter(|s| authorize_with_scope(&biscuit, s).is_ok())
+            .collect();
+
+        let narrowed_scopes: Vec<String> = scopes
+            .into_iter()
+            .filter(|s| currently_allowed.contains(s))
+            .collect();
+
+        let issued_at = Utc::now();
+        let expires_at = issued_at + Duration::seconds(ttl_secs as i64);
+
+        // An empty narrowed set is a deliberate "attenuated to nothing"
+        // state (the child declared no scope this hop still grants) — embed
+        // a check that can never be satisfied by any real requested scope,
+        // rather than one that (via an empty `.contains()` on nothing)
+        // could be mistaken for "no restriction".
+        let scope_check = if narrowed_scopes.is_empty() {
+            "check if requested_scope($s), {\"__ta_attenuated_to_no_scope__\"}.contains($s)"
+                .to_string()
+        } else {
+            let scope_set = narrowed_scopes
+                .iter()
+                .map(|s| format!("{s:?}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("check if requested_scope($s), {{{scope_set}}}.contains($s)")
+        };
+        let time_check = format!("check if time($t), $t < {}", expires_at.to_rfc3339());
+
+        let block = BlockBuilder::new()
+            .check(scope_check.as_str())
+            .map_err(|e| BrokerError::MintFailed(e.to_string()))?
+            .check(time_check.as_str())
+            .map_err(|e| BrokerError::MintFailed(e.to_string()))?;
+
+        let attenuated = biscuit
+            .append(block)
+            .map_err(|e| BrokerError::MintFailed(e.to_string()))?;
+
+        let token_id = revocation_id_hex(&attenuated);
+        let new_token = attenuated
+            .to_base64()
+            .map_err(|e| BrokerError::MintFailed(e.to_string()))?;
+
+        info!(
+            %credential_id, agent_id, ttl_secs, token_id, scopes = ?narrowed_scopes,
+            "credential broker: token attenuated"
+        );
+
+        Ok(GrantedToken {
+            token: new_token,
+            token_id,
+            credential_id,
+            agent_id,
+            allowed_scopes: narrowed_scopes,
+            issued_at,
+            expires_at,
+        })
+    }
+
+    /// Cryptographically authorize `token` for exactly `scope`: signature,
+    /// denylist, embedded expiry, and — unlike [`Self::verify`] — every
+    /// `requested_scope` check appended by [`Self::attenuate`] along the
+    /// way. Rejects if `scope` was narrowed away at any hop, even if it was
+    /// present in the root grant, which is the cryptographic proof that an
+    /// attenuated (child or grandchild) token cannot be used to exceed what
+    /// it was actually narrowed to.
+    pub fn authorize_scope(&self, token: &str, scope: &str) -> Result<VerifiedGrant, BrokerError> {
+        let biscuit = self.decode_checked(token)?;
+        let (credential_id, agent_id, _root_scopes) = root_claims(&biscuit)?;
+        authorize_with_scope(&biscuit, scope)?;
+        Ok(VerifiedGrant {
+            credential_id,
+            agent_id,
+            allowed_scopes: vec![scope.to_string()],
+        })
+    }
+
+    /// Signature + denylist check shared by [`Self::attenuate`] and
+    /// [`Self::authorize_scope`]. Deliberately does not evaluate the
+    /// embedded time check the way [`Self::verify`]'s full authorizer does —
+    /// both callers run their own authorizer afterward (with or without a
+    /// `requested_scope` fact), so a redundant unscoped `.authorize()` call
+    /// here would just fail on any already-scope-attenuated token before
+    /// `root_claims` ever runs.
+    fn decode_checked(&self, token: &str) -> Result<Biscuit, BrokerError> {
+        let biscuit = Biscuit::from_base64(token, self.keypair.public())
+            .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?;
+        let token_id = revocation_id_hex(&biscuit);
+        if self
+            .denylist
+            .revoked_token_ids
+            .iter()
+            .any(|id| id == &token_id)
+        {
+            return Err(BrokerError::Revoked);
+        }
+        Ok(biscuit)
+    }
+
     /// Add `token_id` (as returned in [`GrantedToken::token_id`]) to the
     /// denylist, persisting immediately. Revoking an id the broker never
     /// issued is a no-op, not an error — the end state is identical.
@@ -202,6 +344,62 @@ impl CredentialBroker {
         }
         Ok(())
     }
+}
+
+/// Recover `(credential_id, agent_id, scopes)` from the token's authority
+/// block. Pure data query — no policy, no `.authorize()` call — so it works
+/// regardless of how many attenuation blocks (and their `requested_scope`
+/// checks) have since been appended, and regardless of expiry: callers that
+/// need enforcement (expiry, denylist, scope) get it from
+/// [`CredentialBroker::decode_checked`] plus their own authorizer pass, not
+/// from this helper.
+fn root_claims(biscuit: &Biscuit) -> Result<(Uuid, String, Vec<String>), BrokerError> {
+    let mut authorizer = AuthorizerBuilder::new()
+        .time()
+        .set_limits(AuthorizerLimits {
+            max_time: std::time::Duration::from_secs(1),
+            ..Default::default()
+        })
+        .build(biscuit)
+        .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?;
+    let (credential_id_str, agent_id, scopes_csv): (String, String, String) = authorizer
+        .query_exactly_one("data($c, $a, $s) <- grant($c, $a, $s)")
+        .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?;
+    let credential_id = Uuid::parse_str(&credential_id_str).map_err(|e| {
+        BrokerError::InvalidGrant(format!("grant carries a malformed credential id: {e}"))
+    })?;
+    let allowed_scopes = if scopes_csv.is_empty() {
+        Vec::new()
+    } else {
+        scopes_csv.split(',').map(str::to_string).collect()
+    };
+    Ok((credential_id, agent_id, allowed_scopes))
+}
+
+/// Run a full authorization pass (time + every embedded check, including any
+/// `requested_scope` check appended by [`CredentialBroker::attenuate`])
+/// against `biscuit`, supplying `scope` as the `requested_scope($s)` fact.
+/// `Ok(())` means every block — authority plus every attenuation hop —
+/// accepted `scope`; `Err` means at least one hop's check rejected it, which
+/// is what makes attenuation cryptographically enforced rather than
+/// advisory.
+fn authorize_with_scope(biscuit: &Biscuit, scope: &str) -> Result<(), BrokerError> {
+    let mut authorizer = AuthorizerBuilder::new()
+        .time()
+        .fact(format!("requested_scope({scope:?})").as_str())
+        .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?
+        .set_limits(AuthorizerLimits {
+            max_time: std::time::Duration::from_secs(1),
+            ..Default::default()
+        })
+        .policy("allow if true")
+        .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?
+        .build(biscuit)
+        .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?;
+    authorizer
+        .authorize()
+        .map_err(|e| BrokerError::InvalidGrant(e.to_string()))?;
+    Ok(())
 }
 
 fn revocation_id_hex(biscuit: &Biscuit) -> String {
@@ -386,5 +584,198 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let mut broker = CredentialBroker::open(dir.path()).unwrap();
         broker.revoke("does-not-exist").unwrap();
+    }
+
+    // -- v0.17.6.5: swarm fan-out cryptographic attenuation --------------
+
+    #[test]
+    fn attenuated_token_authorizes_only_narrowed_scopes() {
+        let dir = TempDir::new().unwrap();
+        let broker = CredentialBroker::open(dir.path()).unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let root = broker
+            .grant(
+                credential_id,
+                "swarm-root",
+                vec!["read".into(), "write".into(), "admin".into()],
+                3600,
+            )
+            .unwrap();
+
+        let child = broker
+            .attenuate(&root.token, vec!["read".into(), "write".into()], 1800)
+            .unwrap();
+
+        assert_eq!(
+            child.allowed_scopes,
+            vec!["read".to_string(), "write".to_string()]
+        );
+        assert!(broker.authorize_scope(&child.token, "read").is_ok());
+        assert!(broker.authorize_scope(&child.token, "write").is_ok());
+        // "admin" was never requested for the child, so it's gone even
+        // though the root grant carried it.
+        assert!(broker.authorize_scope(&child.token, "admin").is_err());
+    }
+
+    #[test]
+    fn attenuate_cannot_widen_scope_beyond_parent() {
+        // A child requesting a scope its parent never granted gets nothing
+        // for that scope — attenuation only ever narrows, never widens,
+        // regardless of what the caller asks for.
+        let dir = TempDir::new().unwrap();
+        let broker = CredentialBroker::open(dir.path()).unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let root = broker
+            .grant(credential_id, "swarm-root", vec!["read".into()], 3600)
+            .unwrap();
+
+        let child = broker
+            .attenuate(&root.token, vec!["read".into(), "write".into()], 1800)
+            .unwrap();
+
+        assert_eq!(child.allowed_scopes, vec!["read".to_string()]);
+        assert!(broker.authorize_scope(&child.token, "read").is_ok());
+        assert!(broker.authorize_scope(&child.token, "write").is_err());
+    }
+
+    #[test]
+    fn two_level_nested_attenuation_produces_provably_narrower_grandchild() {
+        // v0.17.6.5 item 4: a two-level-deep nested swarm produces a
+        // grandchild token that is provably a subset of the grandparent's
+        // grant, verified via the authorizer rejecting an out-of-scope
+        // request at every hop — not just a Rust-side list comparison.
+        let dir = TempDir::new().unwrap();
+        let broker = CredentialBroker::open(dir.path()).unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let grandparent = broker
+            .grant(
+                credential_id,
+                "swarm-root",
+                vec!["read".into(), "write".into(), "admin".into()],
+                3600,
+            )
+            .unwrap();
+
+        let parent = broker
+            .attenuate(
+                &grandparent.token,
+                vec!["read".into(), "write".into()],
+                1800,
+            )
+            .unwrap();
+        assert_eq!(
+            parent.allowed_scopes,
+            vec!["read".to_string(), "write".to_string()]
+        );
+
+        let child = broker
+            .attenuate(&parent.token, vec!["read".into()], 900)
+            .unwrap();
+        assert_eq!(child.allowed_scopes, vec!["read".to_string()]);
+
+        // Every hop's own scope survives at that hop.
+        assert!(broker.authorize_scope(&grandparent.token, "admin").is_ok());
+        assert!(broker.authorize_scope(&parent.token, "write").is_ok());
+        assert!(broker.authorize_scope(&child.token, "read").is_ok());
+
+        // The grandchild cannot exercise "write" (dropped at the parent
+        // hop) or "admin" (dropped at the very first attenuation), even
+        // though both were present in the grandparent's original grant —
+        // the authorizer itself rejects them, not an app-level check.
+        assert!(broker.authorize_scope(&child.token, "write").is_err());
+        assert!(broker.authorize_scope(&child.token, "admin").is_err());
+
+        // The parent (not just the grandchild) has already lost "admin".
+        assert!(broker.authorize_scope(&parent.token, "admin").is_err());
+    }
+
+    #[test]
+    fn attenuate_narrows_ttl_and_expiry_is_enforced() {
+        let dir = TempDir::new().unwrap();
+        let broker = CredentialBroker::open(dir.path()).unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let root = broker
+            .grant(credential_id, "swarm-root", vec!["read".into()], 3600)
+            .unwrap();
+        let child = broker
+            .attenuate(&root.token, vec!["read".into()], 0)
+            .unwrap();
+
+        sleep(Duration::from_millis(20));
+
+        assert!(broker.authorize_scope(&child.token, "read").is_err());
+        // The un-attenuated root, with its original longer TTL, is
+        // unaffected — proving the shorter expiry came from the
+        // attenuation block, not some global clock issue.
+        assert!(broker.authorize_scope(&root.token, "read").is_ok());
+    }
+
+    #[test]
+    fn attenuating_to_no_scope_is_explicit_not_unrestricted() {
+        // Requesting a disjoint scope set (none of which the parent
+        // granted) must attenuate to zero usable scopes, not silently fall
+        // back to "no restriction".
+        let dir = TempDir::new().unwrap();
+        let broker = CredentialBroker::open(dir.path()).unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let root = broker
+            .grant(credential_id, "swarm-root", vec!["read".into()], 3600)
+            .unwrap();
+        let child = broker
+            .attenuate(&root.token, vec!["totally-unrelated".into()], 1800)
+            .unwrap();
+
+        assert!(child.allowed_scopes.is_empty());
+        assert!(broker.authorize_scope(&child.token, "read").is_err());
+        assert!(broker
+            .authorize_scope(&child.token, "totally-unrelated")
+            .is_err());
+    }
+
+    #[test]
+    fn revoking_root_cascades_to_attenuated_descendants() {
+        // Revocation is keyed off the authority block's id, which is
+        // unchanged by attenuation — revoking the root credential must
+        // therefore kill every token ever attenuated from it, without a
+        // separate revocation entry per descendant.
+        let dir = TempDir::new().unwrap();
+        let mut broker = CredentialBroker::open(dir.path()).unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let root = broker
+            .grant(credential_id, "swarm-root", vec!["read".into()], 3600)
+            .unwrap();
+        let child = broker
+            .attenuate(&root.token, vec!["read".into()], 1800)
+            .unwrap();
+
+        broker.revoke(&root.token_id).unwrap();
+
+        assert!(matches!(
+            broker.authorize_scope(&child.token, "read"),
+            Err(BrokerError::Revoked)
+        ));
+    }
+
+    #[test]
+    fn attenuate_rejects_tampered_and_wrong_key_tokens() {
+        let dir_a = TempDir::new().unwrap();
+        let dir_b = TempDir::new().unwrap();
+        let broker_a = CredentialBroker::open(dir_a.path()).unwrap();
+        let broker_b = CredentialBroker::open(dir_b.path()).unwrap();
+        let credential_id = Uuid::new_v4();
+
+        let root = broker_a
+            .grant(credential_id, "swarm-root", vec!["read".into()], 3600)
+            .unwrap();
+
+        assert!(broker_b
+            .attenuate(&root.token, vec!["read".into()], 1800)
+            .is_err());
     }
 }

--- a/crates/ta-runtime/src/bare_process.rs
+++ b/crates/ta-runtime/src/bare_process.rs
@@ -283,7 +283,19 @@ pub fn apply_credentials_to_env(
         if cred.broker_mediated {
             match &cred.session_token_id {
                 Some(token_id) => {
-                    env.insert(format!("TA_SESSION_TOKEN_{}", cred.name), token_id.clone());
+                    let key = format!("TA_SESSION_TOKEN_{}", cred.name);
+                    // v0.17.6.5: the expiry rides alongside the token as a
+                    // plain, unenforced hint -- a downstream process that
+                    // inherits this credential (e.g. attenuating it further
+                    // for its own swarm sub-goal) uses it only to estimate
+                    // `parent_remaining_ttl`. The real bound stays whatever
+                    // check is cryptographically embedded in the token
+                    // itself, so a tampered/missing hint here can only make
+                    // that estimate pessimistic, never unsafe.
+                    if let Some(expires_at) = cred.session_token_expires_at {
+                        env.insert(format!("{key}_EXPIRES_AT"), expires_at.to_rfc3339());
+                    }
+                    env.insert(key, token_id.clone());
                 }
                 None => {
                     tracing::warn!(

--- a/crates/ta-runtime/src/credential.rs
+++ b/crates/ta-runtime/src/credential.rs
@@ -11,6 +11,7 @@
 //   - OCI: mounted secrets file or container env (set during container start)
 //   - VM: secure channel post-boot (e.g., virtio-vsock or MMIO region)
 
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// A scoped, short-lived credential to be injected into an agent runtime.
@@ -47,6 +48,18 @@ pub struct ScopedCredential {
     /// reference, never `value` itself.
     #[serde(default)]
     pub session_token_id: Option<String>,
+
+    /// The moment `session_token_id` stops being cryptographically valid
+    /// (v0.17.6.5), present only when known. Informational, not enforced
+    /// here: the real bound is the `check if time(...)` clause embedded in
+    /// the token itself, evaluated by `CredentialBroker`. Carried alongside
+    /// the token purely so a downstream spawn that inherits this credential
+    /// (e.g. a nested swarm sub-goal attenuating it further) can compute
+    /// `min(parent_remaining_ttl, ...)` without decoding the token, via the
+    /// `TA_SESSION_TOKEN_<name>_EXPIRES_AT` sibling env var
+    /// `apply_credentials_to_env` injects when this is `Some`.
+    #[serde(default)]
+    pub session_token_expires_at: Option<DateTime<Utc>>,
 }
 
 impl ScopedCredential {
@@ -58,6 +71,7 @@ impl ScopedCredential {
             scopes: Vec::new(),
             broker_mediated: false,
             session_token_id: None,
+            session_token_expires_at: None,
         }
     }
 
@@ -73,6 +87,7 @@ impl ScopedCredential {
             scopes,
             broker_mediated: false,
             session_token_id: None,
+            session_token_expires_at: None,
         }
     }
 
@@ -83,6 +98,14 @@ impl ScopedCredential {
     pub fn with_broker_mediation(mut self, session_token_id: impl Into<String>) -> Self {
         self.broker_mediated = true;
         self.session_token_id = Some(session_token_id.into());
+        self
+    }
+
+    /// Attach the token's expiry (v0.17.6.5) so a downstream inheritor can
+    /// compute its own attenuation TTL. No effect unless
+    /// `with_broker_mediation` was also called.
+    pub fn with_expiry(mut self, expires_at: DateTime<Utc>) -> Self {
+        self.session_token_expires_at = Some(expires_at);
         self
     }
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -7397,7 +7397,11 @@ broker's public key (stored alongside `credentials.json` in `.ta/`) can
 verify one offline -- no round trip to whichever process minted it. This is
 what lets `ta credentials grant` (a CLI process) mint a grant that the MCP
 gateway (a different process) can independently verify for broker-mediated
-connectors, below.
+connectors, below. A holder can also *attenuate* a grant it already has --
+narrow its scopes and shorten its TTL by appending a block, without needing
+the broker's signing key at all -- which is how swarm sub-goal fan-out
+narrows credentials hop-by-hop (see "Swarm fan-out narrowing is
+cryptographic" below).
 
 `ta credentials grant` mints a grant directly for inspection or manual use;
 `ta run --credential-scopes` (below) does the same thing internally for
@@ -7479,6 +7483,33 @@ the nested `ta run` process each sub-goal spawns receives the same
 `--credential-scopes` value explicitly and applies the identical scope
 filter to its own eventual agent spawn -- clearing the environment there too
 -- rather than relying solely on what the parent process happened to strip.
+
+**Swarm fan-out narrowing is cryptographic, not just conventional
+(v0.17.6.5).** For a broker-mediated connector, a sub-goal that already holds
+a biscuit grant for a credential (because its own parent spawn handed it one)
+doesn't get a brand-new, independently-minted grant when it fans out to its
+own sub-sub-goals -- it *attenuates* the token it's already holding, in
+process, via `biscuit.append()`. No network round trip, and no root signing
+key is needed to attenuate; that's the whole point of a biscuit. The
+practical difference from a fresh mint: the resulting child token carries a
+`check` clause that the broker's authorizer enforces on every use, so a
+scope dropped at *any* hop in the chain is provably gone for every
+descendant, not just absent from a list a well-behaved caller happens to
+consult. A two-level-deep swarm (a sub-goal that itself runs `--workflow
+swarm`) narrows the same way at both hops -- the grandchild's token can be
+cryptographically proven to reject a scope its grandparent held but its
+parent never passed down, even if that parent's own bookkeeping were
+compromised.
+
+This is transparent -- no new flags -- and falls back to today's
+independent-mint-from-the-vault behavior whenever there's no held token to
+attenuate: the top-level swarm launch (nothing to inherit from yet) and any
+credential that isn't broker-mediated for this connector (its scope handoff
+still goes through the `--credential-scopes` narrowing above, pending
+per-tool credential shims in a later phase). Each attenuation also narrows
+the token's TTL to whichever is shorter: the caller's requested TTL, or the
+parent token's own remaining validity -- so a sub-goal can never end up
+holding a longer-lived grant than the process that spawned it.
 
 #### Broker-Mediated Connectors
 


### PR DESCRIPTION
## Summary
- Replaces v0.17.6.1's manual scope-intersection/handoff with real `biscuit.attenuate()` — cryptographically, not just conventionally, narrower-than-parent for every concurrent sub-goal.
- Adds `CredentialBroker::attenuate()` (offline `biscuit.append()`-based narrowing, no root key/network round-trip) and `authorize_scope()`.
- Attenuated child biscuit passed via `TA_SESSION_TOKEN_<name>` + a new `_EXPIRES_AT` sibling env var.
- Nested fan-out reuses the identical attenuation path; `run_concurrently` stays generic/credential-blind.

## Test plan
- 8 new tests including a two-level-deep nested attenuation test proving a grandchild token is cryptographically rejected for any scope dropped at either ancestor, verified via the real authorizer (not a mock).
- `cargo build --workspace`, `cargo test --workspace` (1557 passed, 0 failed), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all pass in an isolated worktree.