### PR TITLE
implement v0.17.6.7 — Shell/CLI Credential Isolation (the Dominant Real-World Path)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,19 +102,8 @@ jobs:
         timeout-minutes: 30
 
       - name: Run tests
-        # DIAGNOSTIC (temporary): --test-threads=1 to get strictly
-        # sequential output. Both --test-threads=4 and =2 hang on this
-        # Windows runner with no per-test error -- reducing thread count
-        # made the hang appear *earlier* (immediately after "running N
-        # tests", zero individual results), which points to a specific
-        # test deterministically hanging rather than general resource
-        # starvation (fewer threads means a stuck test blocks a larger
-        # fraction of the pool immediately, instead of others interleaving
-        # around it). Single-threaded execution will show the exact test
-        # name in the log right before it stalls. Revert to a parallel
-        # value once that test is identified and fixed/gated.
-        run: cargo test --workspace -- --test-threads=1
-        timeout-minutes: 25
+        run: cargo test --workspace -- --test-threads=4
+        timeout-minutes: 15
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,15 @@ jobs:
         timeout-minutes: 30
 
       - name: Run tests
-        run: cargo test --workspace -- --test-threads=4
-        timeout-minutes: 15
+        # test-threads capped at 2 (not 4) on Windows specifically: standard
+        # GitHub-hosted Windows runners are 2 cores / 7GB RAM, and this
+        # workspace's growing subprocess- and crypto-heavy test suite
+        # (real `git init` spawns, biscuit-auth key generation) has been
+        # observed pushing --test-threads=4 into runner-level resource
+        # starvation ("hosted runner lost communication with the server"),
+        # not a deterministic test hang.
+        run: cargo test --workspace -- --test-threads=2
+        timeout-minutes: 20
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,15 +102,19 @@ jobs:
         timeout-minutes: 30
 
       - name: Run tests
-        # test-threads capped at 2 (not 4) on Windows specifically: standard
-        # GitHub-hosted Windows runners are 2 cores / 7GB RAM, and this
-        # workspace's growing subprocess- and crypto-heavy test suite
-        # (real `git init` spawns, biscuit-auth key generation) has been
-        # observed pushing --test-threads=4 into runner-level resource
-        # starvation ("hosted runner lost communication with the server"),
-        # not a deterministic test hang.
-        run: cargo test --workspace -- --test-threads=2
-        timeout-minutes: 20
+        # DIAGNOSTIC (temporary): --test-threads=1 to get strictly
+        # sequential output. Both --test-threads=4 and =2 hang on this
+        # Windows runner with no per-test error -- reducing thread count
+        # made the hang appear *earlier* (immediately after "running N
+        # tests", zero individual results), which points to a specific
+        # test deterministically hanging rather than general resource
+        # starvation (fewer threads means a stuck test blocks a larger
+        # fraction of the pool immediately, instead of others interleaving
+        # around it). Single-threaded execution will show the exact test
+        # name in the log right before it stalls. Revert to a parallel
+        # value once that test is identified and fixed/gated.
+        run: cargo test --workspace -- --test-threads=1
+        timeout-minutes: 25
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,17 @@ jobs:
         timeout-minutes: 30
 
       - name: Run tests
-        run: cargo test --workspace -- --test-threads=4
-        timeout-minutes: 15
+        # DIAGNOSTIC (temporary, round 2): the doctor.rs and external_channel.rs
+        # hangs found via the first --test-threads=1 diagnostic run are fixed,
+        # but Windows Build still failed with "runner lost communication" over
+        # ~59 minutes (started 08:09:55, job died 09:09:33 -- far past this
+        # step's own 15-min budget, meaning the runner itself went unresponsive
+        # rather than this step's timeout firing). Re-running single-threaded
+        # again to check for a second, still-unidentified hanging test now that
+        # the first two are gone, before concluding this is Windows-runner
+        # infra flakiness independent of the code.
+        run: cargo test --workspace -- --test-threads=1
+        timeout-minutes: 25
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,17 +102,8 @@ jobs:
         timeout-minutes: 30
 
       - name: Run tests
-        # DIAGNOSTIC (temporary, round 2): the doctor.rs and external_channel.rs
-        # hangs found via the first --test-threads=1 diagnostic run are fixed,
-        # but Windows Build still failed with "runner lost communication" over
-        # ~59 minutes (started 08:09:55, job died 09:09:33 -- far past this
-        # step's own 15-min budget, meaning the runner itself went unresponsive
-        # rather than this step's timeout firing). Re-running single-threaded
-        # again to check for a second, still-unidentified hanging test now that
-        # the first two are gone, before concluding this is Windows-runner
-        # infra flakiness independent of the code.
-        run: cargo test --workspace -- --test-threads=1
-        timeout-minutes: 25
+        run: cargo test --workspace -- --test-threads=4
+        timeout-minutes: 15
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5182,6 +5182,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "ta-credentials",
  "tempfile",
  "thiserror 2.0.20",
  "tracing",

--- a/PLAN.md
+++ b/PLAN.md
@@ -10218,17 +10218,17 @@ Code releases use semver. Content releases don't. Decide:
 
 ---
 ### v0.17.6.7 — Shell/CLI Credential Isolation (the Dominant Real-World Path)
-<!-- status: pending -->
+<!-- status: done -->
 **Depends on**: v0.17.6.4 (broker must exist to back the credential shims)
 
 **Goal**: v0.17.6.3 closes the MCP-tool-call leak path, but a Bash-driven coding agent's *majority* credentialed actions — `git push`, `gh pr create`, `npm publish`, `docker login`, a raw `curl` with a bearer header — never touch an MCP tool call at all, and nothing in the earlier stages changes that without this one. Found by adversarial review of the original design draft, which had understated this as a "fallback edge case" rather than the dominant path it actually is for a shell-driven agent.
 
 **Items**:
-1. [ ] `git-credential-helper` backed by the broker (git already supports pluggable credential helpers — no git behavior change needed, just point `credential.helper` at a local broker-backed binary).
-2. [ ] `gh auth` shim for the GitHub CLI (same pattern — `gh` supports external auth token resolution).
-3. [ ] For the general case: evaluate a local loopback HTTPS forward proxy (`HTTPS_PROXY` pointed at it) that injects the `Authorization` header for allow-listed hosts server-side. **This requires the agent's process to trust a local CA for TLS interception on allow-listed hosts — a real trust tradeoff, not a footnote.** Resolve at implementation time whether this is acceptable or whether Stage 7 should stay scoped to helper-binary shims only (git/gh/npm/docker specifically) with the generic proxy case dropped or deferred (see design doc Open Question 4).
-4. [ ] Tests: a shell command using a broker-backed credential helper never has the raw secret in its own process environment; an unlisted host via the proxy path (if built) passes through unmodified with no credential injected.
-5. [ ] USAGE.md: document which CLI tools are covered by a credential shim and which still need the reduced-security fallback.
+1. [x] `git-credential-helper` backed by the broker (git already supports pluggable credential helpers — no git behavior change needed, just point `credential.helper` at a local broker-backed binary).
+2. [x] `gh auth` shim for the GitHub CLI (same pattern — `gh` supports external auth token resolution).
+3. [x] For the general case: evaluate a local loopback HTTPS forward proxy (`HTTPS_PROXY` pointed at it) that injects the `Authorization` header for allow-listed hosts server-side. **This requires the agent's process to trust a local CA for TLS interception on allow-listed hosts — a real trust tradeoff, not a footnote.** Resolve at implementation time whether this is acceptable or whether Stage 7 should stay scoped to helper-binary shims only (git/gh/npm/docker specifically) with the generic proxy case dropped or deferred (see design doc Open Question 4).
+4. [x] Tests: a shell command using a broker-backed credential helper never has the raw secret in its own process environment; an unlisted host via the proxy path (if built) passes through unmodified with no credential injected.
+5. [x] USAGE.md: document which CLI tools are covered by a credential shim and which still need the reduced-security fallback.
 
 #### Version: `0.17.6-alpha.7`
 

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -13,6 +13,14 @@ categories = ["command-line-utilities", "development-tools"]
 name = "ta"
 path = "src/main.rs"
 
+# `gh` PATH-shadow wrapper for broker-mediated GitHub credentials
+# (v0.17.6.7) — see src/bin/gh_shim.rs for the full design. Built as a
+# sibling binary of `ta` so `ta run` can stage a copy at
+# `<project_root>/.ta/bin/gh` from right next to the running `ta` binary.
+[[bin]]
+name = "gh"
+path = "src/bin/gh_shim.rs"
+
 [features]
 default = ["ruvector"]
 ruvector = ["ta-memory/ruvector"]

--- a/apps/ta-cli/src/bin/gh_shim.rs
+++ b/apps/ta-cli/src/bin/gh_shim.rs
@@ -98,6 +98,7 @@ fn find_real_gh(path_var: &str, exclude_dir: Option<&Path>, cwd: &Path) -> Optio
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use std::fs;
     #[cfg(unix)]
     use tempfile::TempDir;

--- a/apps/ta-cli/src/bin/gh_shim.rs
+++ b/apps/ta-cli/src/bin/gh_shim.rs
@@ -1,0 +1,161 @@
+// gh_shim.rs — `gh` PATH-shadow wrapper for broker-mediated GitHub
+// credentials (v0.17.6.7, PLAN item 2).
+//
+// `gh` has no pluggable "credential helper" hook the way git does, so
+// closing this shell/CLI leak path for the GitHub CLI needs a different
+// mechanism: `ta run` stages a copy of this binary at
+// `<project_root>/.ta/bin/gh` and prepends that directory to the agent's
+// `PATH`, but only when a broker-mediated connector declares
+// `hosts = ["github.com", ...]` in `.ta/connectors.toml` (see
+// `run.rs::install_credential_shims`). The agent's own shell then resolves
+// bare `gh` invocations to this wrapper before the real CLI further down
+// `PATH`.
+//
+// Each invocation: resolve the real secret via
+// `ta_credential_broker::resolve_for_host` (the same broker/vault lookup
+// `ta credential-helper` uses for git), find the *real* `gh` binary by
+// searching `PATH` with this wrapper's own directory excluded (otherwise a
+// naive search just finds this same binary again and recurses forever), and
+// exec it with `GH_TOKEN` set only on that one child process — never on
+// this wrapper's own environment, and never touching the agent's own
+// long-lived shell environment (`std::env::set_var` is never called here).
+//
+// Fails open: no matching connector, no session token, or no real `gh`
+// found on `PATH` all fall through to "run the real `gh` with no token
+// injected" wherever a real `gh` can still be located — the same reduced-
+// security fallback behavior as if this shim had never been installed —
+// rather than blocking the agent's workflow over a broker misconfiguration.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+const GH_HOST: &str = "github.com";
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let path_var = std::env::var("PATH").unwrap_or_default();
+    let self_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(Path::to_path_buf));
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+    let real_gh = match find_real_gh(&path_var, self_dir.as_deref(), &cwd) {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "ta gh-shim: no other 'gh' binary found on PATH besides this wrapper — \
+                 install the GitHub CLI, or remove .ta/bin from PATH to bypass the shim"
+            );
+            std::process::exit(127);
+        }
+    };
+
+    let project_root = std::env::var("TA_PROJECT_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| cwd.clone());
+
+    let secret = ta_credential_broker::resolve_for_host(&project_root, GH_HOST, true)
+        .map(|resolution| resolution.secret)
+        .ok();
+
+    let mut cmd = std::process::Command::new(&real_gh);
+    cmd.args(&args);
+    if let Some(secret) = &secret {
+        cmd.env("GH_TOKEN", secret);
+    }
+
+    let status = match cmd.status() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!(
+                "ta gh-shim: failed to launch real gh at {}: {e}",
+                real_gh.display()
+            );
+            std::process::exit(127);
+        }
+    };
+    std::process::exit(status.code().unwrap_or(1));
+}
+
+/// Build a `PATH`-shaped value with `exclude_dir` removed — pure, so it's
+/// directly testable without touching the real process environment.
+fn filtered_path(path_var: &str, exclude_dir: Option<&Path>) -> OsString {
+    let dirs: Vec<PathBuf> = std::env::split_paths(path_var)
+        .filter(|d| Some(d.as_path()) != exclude_dir)
+        .collect();
+    std::env::join_paths(dirs).unwrap_or_default()
+}
+
+/// Locate the real `gh` binary on `path_var`, skipping `exclude_dir` (this
+/// wrapper's own directory). Delegates to `which::which_in`, which already
+/// handles `PATHEXT`/executable-bit resolution correctly per platform —
+/// only the exclusion + PATH plumbing around it is this shim's own logic.
+fn find_real_gh(path_var: &str, exclude_dir: Option<&Path>, cwd: &Path) -> Option<PathBuf> {
+    let candidate_path = filtered_path(path_var, exclude_dir);
+    which::which_in("gh", Some(candidate_path), cwd).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_executable(path: &Path) {
+        fs::write(path, "#!/bin/sh\necho fake-gh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+
+    #[test]
+    fn filtered_path_removes_only_the_excluded_dir() {
+        let path_var = if cfg!(windows) {
+            r"C:\wrapper;C:\real;C:\other"
+        } else {
+            "/wrapper:/real:/other"
+        };
+        let exclude = if cfg!(windows) {
+            PathBuf::from(r"C:\wrapper")
+        } else {
+            PathBuf::from("/wrapper")
+        };
+        let filtered = filtered_path(path_var, Some(&exclude));
+        let filtered_str = filtered.to_string_lossy();
+        assert!(!filtered_str.contains("wrapper"));
+        assert!(filtered_str.contains("real"));
+        assert!(filtered_str.contains("other"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn find_real_gh_skips_own_directory_and_finds_the_real_binary() {
+        let dir = TempDir::new().unwrap();
+        let wrapper_dir = dir.path().join("wrapper");
+        let real_dir = dir.path().join("real");
+        fs::create_dir_all(&wrapper_dir).unwrap();
+        fs::create_dir_all(&real_dir).unwrap();
+        // A same-named file in the wrapper's own dir must never be returned
+        // — that would just be this wrapper re-invoking itself forever.
+        make_executable(&wrapper_dir.join("gh"));
+        make_executable(&real_dir.join("gh"));
+
+        let path_var = format!("{}:{}", wrapper_dir.display(), real_dir.display());
+        let found = find_real_gh(&path_var, Some(&wrapper_dir), dir.path()).unwrap();
+        assert_eq!(found, real_dir.join("gh"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn find_real_gh_returns_none_when_only_the_wrapper_is_on_path() {
+        let dir = TempDir::new().unwrap();
+        let wrapper_dir = dir.path().join("wrapper");
+        fs::create_dir_all(&wrapper_dir).unwrap();
+        make_executable(&wrapper_dir.join("gh"));
+
+        let path_var = wrapper_dir.display().to_string();
+        assert!(find_real_gh(&path_var, Some(&wrapper_dir), dir.path()).is_none());
+    }
+}

--- a/apps/ta-cli/src/bin/gh_shim.rs
+++ b/apps/ta-cli/src/bin/gh_shim.rs
@@ -99,15 +99,14 @@ fn find_real_gh(path_var: &str, exclude_dir: Option<&Path>, cwd: &Path) -> Optio
 mod tests {
     use super::*;
     use std::fs;
+    #[cfg(unix)]
     use tempfile::TempDir;
 
+    #[cfg(unix)]
     fn make_executable(path: &Path) {
+        use std::os::unix::fs::PermissionsExt;
         fs::write(path, "#!/bin/sh\necho fake-gh\n").unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
-        }
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
     }
 
     #[test]

--- a/apps/ta-cli/src/commands/credential_helper.rs
+++ b/apps/ta-cli/src/commands/credential_helper.rs
@@ -1,0 +1,204 @@
+// credential_helper.rs — `ta credential-helper`: a git credential.helper
+// backend for broker-mediated connectors (v0.17.6.7, PLAN item 1).
+//
+// git already supports pluggable credential helpers (see
+// `gitcredentials(7)`): `credential.helper` is invoked as
+// `<helper> <get|store|erase>` with a `key=value\n`-per-line request on
+// stdin, and (for `get`) responds with `key=value\n` lines on stdout. No
+// change to git's own behavior is needed — this just points
+// `credential.helper` at this subcommand for repos where a connector
+// declares a matching `hosts` entry in `.ta/connectors.toml`.
+//
+// The raw secret only ever exists in this short-lived helper process's own
+// memory and in git's stdin/stdout pipe to it — the agent's own persistent
+// shell environment and the LLM's context never see it, unlike the
+// reduced-security `bare_process.rs` env-injection fallback this replaces
+// for broker-mediated connectors.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::path::Path;
+
+use ta_credential_broker::{resolve_for_host, ShimError};
+
+/// Parse a git credential-protocol request body (`key=value\n` lines,
+/// terminated by a blank line or EOF — `gitcredentials(7)`).
+///
+/// Pure function: no I/O, so the protocol parsing is directly testable
+/// without spawning a process or faking stdin.
+fn parse_request(body: &str) -> HashMap<String, String> {
+    body.lines()
+        .take_while(|line| !line.is_empty())
+        .filter_map(|line| line.split_once('='))
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+/// git's `host=` field may carry a port (`github.com:443`); connectors
+/// declare bare hostnames, so strip it before matching.
+fn host_without_port(host: &str) -> &str {
+    host.split(':').next().unwrap_or(host)
+}
+
+/// Format a successful `get` response. Git expects `username`/`password`
+/// (or just `password`, but a username makes the resulting log/URL more
+/// legible) followed by a blank-line-equivalent EOF — git reads until the
+/// pipe closes, so no explicit trailing blank line is required.
+fn format_response(connector_id: &str, secret: &str) -> String {
+    format!("username={connector_id}\npassword={secret}\n")
+}
+
+/// Run `ta credential-helper <operation>` for git.
+///
+/// `operation` is `get`, `store`, or `erase` (whatever git passes as
+/// `argv[1]`). Only `get` produces output; `store`/`erase` read and discard
+/// their input and exit cleanly — the broker is the sole source of truth
+/// for credential lifecycle, so there is nothing for this helper to persist
+/// or delete on disk (unlike git's built-in `store`/`cache` helpers).
+///
+/// A host that no broker-mediated connector declares (or a missing/invalid
+/// session token) is **not** an error: `get` silently produces no output,
+/// exactly as git's own protocol expects when a helper "doesn't know" a
+/// credential — git then falls through to its next configured helper or its
+/// interactive prompt. Only a genuine broker/vault failure (unreadable
+/// vault, mismatched credential) is surfaced as an error, since that's a
+/// misconfiguration worth the operator seeing rather than a silent stall.
+/// `use_keychain` should be `true` for every real invocation (the default
+/// call site in `main.rs` always passes `true`); `false` only in tests, to
+/// match the vault fixture's own `CredentialsConfig::use_keychain = false`
+/// (see that field's doc comment for why tests must not touch the real OS
+/// keychain).
+pub fn execute(
+    operation: &str,
+    project_root: &Path,
+    reader: &mut impl Read,
+    writer: &mut impl Write,
+    use_keychain: bool,
+) -> anyhow::Result<()> {
+    let mut body = String::new();
+    reader.read_to_string(&mut body)?;
+
+    if operation != "get" {
+        // `store` / `erase`: consciously a no-op (see doc comment above).
+        return Ok(());
+    }
+
+    let fields = parse_request(&body);
+    let Some(host) = fields.get("host") else {
+        return Ok(());
+    };
+    let host = host_without_port(host);
+
+    match resolve_for_host(project_root, host, use_keychain) {
+        Ok(resolution) => {
+            write!(
+                writer,
+                "{}",
+                format_response(&resolution.connector_id, &resolution.secret)
+            )?;
+            Ok(())
+        }
+        Err(ShimError::NoConnector(_)) | Err(ShimError::NoSessionToken { .. }) => {
+            // Silent fallback — see doc comment above.
+            Ok(())
+        }
+        Err(e) => {
+            tracing::warn!(host, error = %e, "ta credential-helper: broker-mediated lookup failed");
+            Err(e.into())
+        }
+    }
+}
+
+/// Resolve the project root a credential-helper invocation should use:
+/// `TA_PROJECT_ROOT` (set at agent spawn — see `run.rs::install_credential_shims`)
+/// if present, otherwise `fallback` (the parsed `--project-root`, itself
+/// defaulted to the current working directory). Mirrors
+/// `commands::serve::execute`'s existing `TA_PROJECT_ROOT` handling — git
+/// invokes this helper with its own CWD set to wherever the agent ran `git`
+/// from, which is very often a subdirectory of the staging workspace, not
+/// the project root `.ta/` actually lives under.
+pub fn resolve_project_root(fallback: &Path) -> std::path::PathBuf {
+    std::env::var("TA_PROJECT_ROOT")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| fallback.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use ta_credentials::CredentialVault;
+    use tempfile::TempDir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn parse_request_reads_key_value_lines_until_blank() {
+        let body = "protocol=https\nhost=github.com\n\nusername=ignored\n";
+        let fields = parse_request(body);
+        assert_eq!(fields.get("protocol").map(String::as_str), Some("https"));
+        assert_eq!(fields.get("host").map(String::as_str), Some("github.com"));
+        // Everything after the blank line is a new (unrelated) request and
+        // must not leak into this one.
+        assert!(!fields.contains_key("username"));
+    }
+
+    #[test]
+    fn host_without_port_strips_trailing_port() {
+        assert_eq!(host_without_port("github.com:443"), "github.com");
+        assert_eq!(host_without_port("github.com"), "github.com");
+    }
+
+    #[test]
+    fn get_for_broker_mediated_host_prints_credential_protocol_response() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".ta")).unwrap();
+        std::fs::write(
+            dir.path().join(".ta/connectors.toml"),
+            "[connectors.github]\ncredential_name = \"GITHUB_TOKEN\"\n\
+             broker_mediated = true\nhosts = [\"github.com\"]\n",
+        )
+        .unwrap();
+
+        let mut cred_config = ta_credentials::CredentialsConfig::for_project(dir.path());
+        cred_config.use_keychain = false;
+        let mut vault = ta_credentials::FileVault::open(&cred_config).unwrap();
+        let cred = vault
+            .add("GITHUB_TOKEN", "github", "ghp_real_secret", vec![])
+            .unwrap();
+        let broker = ta_credential_broker::CredentialBroker::open(&dir.path().join(".ta")).unwrap();
+        let granted = broker.grant(cred.id, "agent-1", vec![], 3600).unwrap();
+
+        std::env::set_var("TA_SESSION_TOKEN_GITHUB_TOKEN", &granted.token);
+        let mut input = std::io::Cursor::new("protocol=https\nhost=github.com\n\n");
+        let mut output = Vec::new();
+        let result = execute("get", dir.path(), &mut input, &mut output, false);
+        std::env::remove_var("TA_SESSION_TOKEN_GITHUB_TOKEN");
+
+        result.unwrap();
+        let response = String::from_utf8(output).unwrap();
+        assert!(response.contains("password=ghp_real_secret"));
+        assert!(!response.is_empty());
+    }
+
+    #[test]
+    fn get_for_unlisted_host_produces_no_output_and_no_error() {
+        let dir = TempDir::new().unwrap();
+        let mut input = std::io::Cursor::new("protocol=https\nhost=gitlab.com\n\n");
+        let mut output = Vec::new();
+        execute("get", dir.path(), &mut input, &mut output, false).unwrap();
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn store_and_erase_are_no_ops() {
+        let dir = TempDir::new().unwrap();
+        for op in ["store", "erase"] {
+            let mut input = std::io::Cursor::new("protocol=https\nhost=github.com\n\n");
+            let mut output = Vec::new();
+            execute(op, dir.path(), &mut input, &mut output, false).unwrap();
+            assert!(output.is_empty());
+        }
+    }
+}

--- a/apps/ta-cli/src/commands/doctor.rs
+++ b/apps/ta-cli/src/commands/doctor.rs
@@ -388,14 +388,7 @@ fn check_agent_binary(agent_name: &str, project_root: &Path) -> CheckResult {
 fn check_gh_cli() -> CheckResult {
     match which::which("gh") {
         Ok(path) => {
-            // Check auth status.
-            let auth_ok = std::process::Command::new("gh")
-                .args(["auth", "status"])
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false);
+            let auth_ok = run_gh_auth_status_bounded(std::time::Duration::from_secs(5));
             if auth_ok {
                 CheckResult::ok("gh CLI", format!("{} -- authenticated", path.display()))
             } else {
@@ -411,6 +404,43 @@ fn check_gh_cli() -> CheckResult {
             "not found on PATH".to_string(),
             "Install GitHub CLI: https://cli.github.com",
         ),
+    }
+}
+
+/// Runs `gh auth status` with a hard wall-clock deadline, never blocking
+/// indefinitely. `gh auth status` can hang (slow/unreachable network,
+/// or -- since v0.17.6.7 -- a `gh`-named credential shim on `PATH` in turn
+/// spawning a real `gh` child of its own) and this check must never let a
+/// hung subprocess block `ta doctor` itself. Output is discarded (only
+/// success/failure is used), which also sidesteps any pipe-inheritance
+/// hang from a nested child process holding an inherited handle open.
+fn run_gh_auth_status_bounded(timeout: std::time::Duration) -> bool {
+    use std::process::{Command, Stdio};
+
+    let mut child = match Command::new("gh")
+        .args(["auth", "status"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+
+    let start = std::time::Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status.success(),
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return false;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            Err(_) => return false,
+        }
     }
 }
 

--- a/apps/ta-cli/src/commands/mod.rs
+++ b/apps/ta-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod consent;
 pub mod constitution;
 pub mod context;
 pub mod conversation;
+pub mod credential_helper;
 pub mod credentials;
 pub mod daemon;
 pub mod dev;

--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -4898,6 +4898,164 @@ fn scoped_credential_env(
     env
 }
 
+// ── Shell/CLI credential shims (v0.17.6.7) ────────────────────────────────
+//
+// v0.17.6.3 built the gateway's live interception point for MCP tool calls,
+// but a Bash-driven coding agent's *majority* credentialed actions — `git
+// push`, `gh pr create`, `npm publish`, a raw `curl` with a bearer header —
+// never touch an MCP tool call at all. These helpers wire the two concrete
+// shims that close this for git and the GitHub CLI (`docs/superpowers/specs/
+// 2026-08-03-agent-credential-security-design.md`, Stage 7 items 1-2):
+// git's pluggable `credential.helper` protocol (`apps/ta-cli/src/commands/
+// credential_helper.rs`), and a `gh` PATH-shadow wrapper binary
+// (`apps/ta-cli/src/bin/gh_shim.rs`). The general case (arbitrary
+// `curl`/`npm`/`docker` calls via a local TLS-intercepting forward proxy,
+// PLAN item 3) is deliberately out of scope — see `docs/USAGE.md` "Shell/CLI
+// Credential Isolation" for the resolved trust-model tradeoff (design doc
+// Open Question 4: a MITM-capable local CA is a real, separate trust
+// decision that deserves its own phase, not a rider on this one).
+
+/// Filename of the `gh` wrapper binary this process was built alongside —
+/// same binary name on every platform except the `.exe` suffix on Windows.
+fn gh_wrapper_filename() -> &'static str {
+    if cfg!(windows) {
+        "gh.exe"
+    } else {
+        "gh"
+    }
+}
+
+/// Minimal POSIX-shell quoting for a path that may contain spaces — git
+/// invokes a `!`-prefixed `credential.helper` value through `sh -c`, so an
+/// unquoted space in the `ta` binary's own path would break the command.
+/// Not a general-purpose shell-quoting utility, just enough for this one
+/// call site.
+fn shell_quote_path(path: &Path) -> String {
+    let s = path.display().to_string();
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || "/_.-".contains(c))
+    {
+        s
+    } else {
+        format!("'{}'", s.replace('\'', r"'\''"))
+    }
+}
+
+/// The `credential.helper` value to write into a repo's local git config.
+/// The leading `!` tells git to run the rest as a shell command rather than
+/// searching `PATH` for `git-credential-<value>` — needed because `ta`'s
+/// own binary name doesn't follow that convention. Pure string formatting;
+/// the actual git-config mutation happens in `install_credential_shims`.
+fn git_credential_helper_value(ta_bin: &Path) -> String {
+    format!("!{} credential-helper", shell_quote_path(ta_bin))
+}
+
+/// Prepend `dir` to an existing `PATH` value (or start fresh if there was
+/// none) using the platform path-list separator.
+fn prepend_path(existing: Option<&str>, dir: &Path) -> String {
+    let sep = if cfg!(windows) { ";" } else { ":" };
+    match existing {
+        Some(existing) if !existing.is_empty() => format!("{}{sep}{existing}", dir.display()),
+        _ => dir.display().to_string(),
+    }
+}
+
+/// Wire up Stage 7 shell/CLI credential shims for one agent spawn.
+///
+/// No-op (env untouched) unless `registry` declares at least one
+/// broker-mediated connector with `hosts` set — see
+/// `ConnectorRegistry::has_shell_shim_connector`. Both individual shims
+/// fail open: any error staging them (missing sibling `gh` binary,
+/// unwritable git config, `working_dir` not a git repo) is logged at `warn`
+/// and skipped, never blocks agent launch — narrowing how a credential
+/// already withheld from `env` (broker-mediated credentials never appear
+/// there; see `ta_runtime::apply_credentials_to_env`) is strictly additive,
+/// not something agent launch should ever depend on succeeding.
+fn install_credential_shims(
+    env: &mut std::collections::HashMap<String, String>,
+    project_root: &Path,
+    working_dir: &Path,
+    registry: &ta_credentials::ConnectorRegistry,
+) {
+    if !registry.has_shell_shim_connector() {
+        return;
+    }
+
+    // git: point this repo's local credential.helper at `ta credential-helper`.
+    if working_dir.join(".git").exists() {
+        match std::env::current_exe() {
+            Ok(ta_bin) => {
+                let helper_value = git_credential_helper_value(&ta_bin);
+                let status = std::process::Command::new("git")
+                    .args(["config", "--local", "credential.helper", &helper_value])
+                    .current_dir(working_dir)
+                    .status();
+                match status {
+                    Ok(s) if s.success() => {
+                        tracing::debug!(
+                            working_dir = %working_dir.display(),
+                            "installed broker-backed git credential.helper"
+                        );
+                    }
+                    Ok(s) => tracing::warn!(
+                        code = ?s.code(),
+                        "git config credential.helper failed; git push/pull for broker-mediated \
+                         connectors will fall back to git's own credential resolution"
+                    ),
+                    Err(e) => tracing::warn!(
+                        error = %e,
+                        "could not run `git config` to install the credential helper"
+                    ),
+                }
+            }
+            Err(e) => tracing::warn!(
+                error = %e,
+                "could not resolve the running ta binary's path; skipping git credential.helper setup"
+            ),
+        }
+    }
+
+    // gh: stage the wrapper binary next to it and prepend its directory to PATH.
+    if let Ok(ta_bin) = std::env::current_exe() {
+        if let Some(bin_dir) = ta_bin.parent() {
+            let src = bin_dir.join(gh_wrapper_filename());
+            if src.is_file() {
+                let shim_dir = project_root.join(".ta").join("bin");
+                if let Err(e) = std::fs::create_dir_all(&shim_dir) {
+                    tracing::warn!(error = %e, "could not create .ta/bin for the gh credential shim");
+                } else {
+                    let dest = shim_dir.join(gh_wrapper_filename());
+                    match std::fs::copy(&src, &dest) {
+                        Ok(_) => {
+                            #[cfg(unix)]
+                            {
+                                use std::os::unix::fs::PermissionsExt;
+                                let _ = std::fs::set_permissions(
+                                    &dest,
+                                    std::fs::Permissions::from_mode(0o755),
+                                );
+                            }
+                            let existing = env.get("PATH").map(String::as_str);
+                            env.insert("PATH".to_string(), prepend_path(existing, &shim_dir));
+                            tracing::debug!(dest = %dest.display(), "installed gh credential shim");
+                        }
+                        Err(e) => tracing::warn!(
+                            error = %e,
+                            "could not stage the gh credential shim binary"
+                        ),
+                    }
+                }
+            } else {
+                tracing::debug!(
+                    src = %src.display(),
+                    "no gh wrapper binary found next to ta; gh calls use the reduced-security \
+                     env-injection fallback"
+                );
+            }
+        }
+    }
+}
+
 /// Default TTL for the session grants minted by [`load_vault_credentials`]
 /// (v0.17.6.2). Generous enough to cover a typical single goal run without
 /// being unbounded; a real per-goal deadline arrives with swarm attenuation
@@ -5090,6 +5248,21 @@ fn launch_agent_via_runtime(
     // Inject ANTHROPIC_BASE_URL when context compression is enabled (v0.17.0.7).
     // staging_path = project_root/.ta/staging/<uuid>  →  3 parents up = project_root.
     inject_compression_url(&mut env, config, staging_path);
+
+    // Stage 7 shell/CLI credential shims (v0.17.6.7): TA_PROJECT_ROOT lets
+    // `ta credential-helper` / the `gh` wrapper find `.ta/` regardless of the
+    // agent's own working directory (which is `staging_path`, not
+    // necessarily where `.ta/` lives), the same convention `ta serve`
+    // already uses. `install_credential_shims` is itself a no-op unless a
+    // broker-mediated connector declares `hosts` in `.ta/connectors.toml`.
+    if let Some(project_root) = project_root_from_staging(staging_path) {
+        env.insert(
+            "TA_PROJECT_ROOT".to_string(),
+            project_root.display().to_string(),
+        );
+        let registry = ta_credentials::ConnectorRegistry::load(&project_root.join(".ta"));
+        install_credential_shims(&mut env, &project_root, staging_path, &registry);
+    }
 
     // Expand args (replace {prompt} template variable).
     let mut args: Vec<String> = config
@@ -11263,6 +11436,129 @@ plan_pending_window = 7
         let verified = broker.verify(session_token).unwrap();
         assert_eq!(verified.credential_id, cred_id);
         assert_eq!(verified.agent_id, "agent-1");
+    }
+
+    // ── Shell/CLI credential shims (v0.17.6.7) ────────────────────────────
+
+    #[test]
+    fn shell_quote_path_leaves_simple_paths_unquoted() {
+        assert_eq!(
+            shell_quote_path(Path::new("/usr/local/bin/ta")),
+            "/usr/local/bin/ta"
+        );
+    }
+
+    #[test]
+    fn shell_quote_path_quotes_and_escapes_paths_with_spaces() {
+        let quoted = shell_quote_path(Path::new("/Users/me/My Apps/ta"));
+        assert_eq!(quoted, "'/Users/me/My Apps/ta'");
+    }
+
+    #[test]
+    fn git_credential_helper_value_uses_bang_prefix_and_subcommand() {
+        let value = git_credential_helper_value(Path::new("/usr/local/bin/ta"));
+        assert_eq!(value, "!/usr/local/bin/ta credential-helper");
+    }
+
+    #[test]
+    fn prepend_path_adds_separator_when_path_already_set() {
+        let sep = if cfg!(windows) { ";" } else { ":" };
+        let result = prepend_path(Some("/usr/bin"), Path::new("/proj/.ta/bin"));
+        assert_eq!(result, format!("/proj/.ta/bin{sep}/usr/bin"));
+    }
+
+    #[test]
+    fn prepend_path_with_no_existing_path_is_just_the_dir() {
+        assert_eq!(
+            prepend_path(None, Path::new("/proj/.ta/bin")),
+            "/proj/.ta/bin"
+        );
+        assert_eq!(
+            prepend_path(Some(""), Path::new("/proj/.ta/bin")),
+            "/proj/.ta/bin"
+        );
+    }
+
+    #[test]
+    fn install_credential_shims_is_a_no_op_without_a_shell_shim_connector() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = ta_credentials::ConnectorRegistry::default();
+        let mut env = std::collections::HashMap::new();
+        env.insert("PATH".to_string(), "/usr/bin".to_string());
+
+        install_credential_shims(&mut env, dir.path(), dir.path(), &registry);
+
+        // Untouched: no PATH mutation, and no .ta/bin directory materialized.
+        assert_eq!(env.get("PATH").map(String::as_str), Some("/usr/bin"));
+        assert!(!dir.path().join(".ta/bin").exists());
+    }
+
+    #[test]
+    fn install_credential_shims_writes_git_config_when_working_dir_is_a_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let init = std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&repo)
+            .status();
+        if !matches!(init, Ok(s) if s.success()) {
+            eprintln!("skipping: `git init` unavailable in this environment");
+            return;
+        }
+        // `git init` runs as a real subprocess; on some sandboxed
+        // filesystems the new `.git` directory isn't immediately visible to
+        // this process's own `Path::exists()` calls. Poll briefly rather
+        // than assume synchronous visibility -- bounded to 500ms, a no-op
+        // on any normal filesystem where the first check already succeeds.
+        for _ in 0..50 {
+            if repo.join(".git").exists() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        std::fs::create_dir_all(dir.path().join(".ta")).unwrap();
+        std::fs::write(
+            dir.path().join(".ta/connectors.toml"),
+            "[connectors.github]\ncredential_name = \"GITHUB_TOKEN\"\n\
+             broker_mediated = true\nhosts = [\"github.com\"]\n",
+        )
+        .unwrap();
+        let registry = ta_credentials::ConnectorRegistry::load(&dir.path().join(".ta"));
+        let mut env = std::collections::HashMap::new();
+        install_credential_shims(&mut env, dir.path(), &repo, &registry);
+
+        let helper = std::process::Command::new("git")
+            .args(["config", "--local", "--get", "credential.helper"])
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+        let value = String::from_utf8_lossy(&helper.stdout);
+        assert!(
+            value.contains("credential-helper"),
+            "expected credential.helper to be set, got: {value:?}"
+        );
+    }
+
+    #[test]
+    fn install_credential_shims_does_not_touch_git_config_outside_a_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let not_a_repo = dir.path().join("not-a-repo");
+        std::fs::create_dir_all(&not_a_repo).unwrap();
+
+        std::fs::create_dir_all(dir.path().join(".ta")).unwrap();
+        std::fs::write(
+            dir.path().join(".ta/connectors.toml"),
+            "[connectors.github]\ncredential_name = \"GITHUB_TOKEN\"\n\
+             broker_mediated = true\nhosts = [\"github.com\"]\n",
+        )
+        .unwrap();
+        let registry = ta_credentials::ConnectorRegistry::load(&dir.path().join(".ta"));
+        let mut env = std::collections::HashMap::new();
+        // Must not panic or attempt a git-config write with no `.git` present.
+        install_credential_shims(&mut env, dir.path(), &not_a_repo, &registry);
+        assert!(!not_a_repo.join(".git").exists());
     }
 
     #[test]

--- a/apps/ta-cli/src/main.rs
+++ b/apps/ta-cli/src/main.rs
@@ -997,6 +997,15 @@ enum Commands {
     /// Start the MCP server on stdio.
     #[command(hide = true)]
     Serve,
+    /// git `credential.helper` backend for broker-mediated connectors
+    /// (v0.17.6.7). Not meant to be invoked directly — `ta run` points a
+    /// git repo's `credential.helper` config at this subcommand when a
+    /// connector in `.ta/connectors.toml` declares a matching `hosts` entry.
+    #[command(hide = true)]
+    CredentialHelper {
+        /// git's operation: `get`, `store`, or `erase` (see `gitcredentials(7)`).
+        operation: String,
+    },
     /// Build the project using the configured build adapter.
     ///
     /// Auto-detects the build system (Cargo, npm, Make) or uses the adapter
@@ -1913,6 +1922,14 @@ fn dispatch_raw(
             let skip = std::env::var("TA_SKIP_ONBOARD_CHECK").is_ok_and(|v| v == "1");
             commands::onboard::check_provider_configured(skip)?;
             commands::serve::execute(project_root)
+        }
+        Commands::CredentialHelper { operation } => {
+            let root = commands::credential_helper::resolve_project_root(project_root);
+            let stdin = std::io::stdin();
+            let mut reader = stdin.lock();
+            let stdout = std::io::stdout();
+            let mut writer = stdout.lock();
+            commands::credential_helper::execute(operation, &root, &mut reader, &mut writer, true)
         }
         Commands::Build { test } => commands::build::execute(config, *test),
         Commands::Sync { noun, extra } => match noun {

--- a/crates/ta-credential-broker/Cargo.toml
+++ b/crates/ta-credential-broker/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
+ta-credentials = { path = "../ta-credentials", version = "0.17.7-alpha.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-credential-broker/src/lib.rs
+++ b/crates/ta-credential-broker/src/lib.rs
@@ -8,6 +8,8 @@
 
 pub mod broker;
 pub mod error;
+pub mod shim;
 
 pub use broker::{CredentialBroker, GrantedToken, VerifiedGrant};
 pub use error::BrokerError;
+pub use shim::{resolve_for_host, ShimError, ShimResolution};

--- a/crates/ta-credential-broker/src/shim.rs
+++ b/crates/ta-credential-broker/src/shim.rs
@@ -1,0 +1,261 @@
+// shim.rs — Shell/CLI credential shim resolution (v0.17.6.7).
+//
+// v0.17.6.3 built the gateway's live interception point for MCP tool calls,
+// but a Bash-driven coding agent's *majority* credentialed actions (`git
+// push`, `gh pr create`, a raw `curl` with a bearer header) never go through
+// an MCP tool call at all. This module is the shared resolution logic behind
+// the two concrete shims that close that gap for git and the GitHub CLI:
+// `ta credential-helper` (git's pluggable `credential.helper` protocol) and
+// the `gh` wrapper binary (PATH-shadows the real `gh`, injects the token
+// only into that one child process's environment).
+//
+// Both shims run as short-lived child processes of the agent's own shell,
+// inheriting `TA_SESSION_TOKEN_<credential>` (the biscuit grant — never the
+// raw secret; see `ta_runtime::apply_credentials_to_env`) but never the raw
+// secret itself. This function is what turns that grant back into the real
+// secret, entirely offline, the same way the gateway's own interception
+// point does for MCP tool calls.
+
+use std::path::Path;
+
+use ta_credentials::{ConnectorRegistry, CredentialVault, CredentialsConfig, FileVault};
+use thiserror::Error;
+
+use crate::broker::CredentialBroker;
+
+/// A resolved secret, ready to hand to the calling tool (git, `gh`) for
+/// exactly one operation. Never logged, never written to disk by the shim
+/// itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShimResolution {
+    pub secret: String,
+    pub credential_name: String,
+    pub connector_id: String,
+}
+
+/// Why a shim could not resolve a secret for `host`.
+///
+/// [`ShimError::NoConnector`] is the expected, silent-fallback case: `host`
+/// isn't declared by any broker-mediated connector, so the calling shim
+/// should behave as if it were never installed (git falls back to its own
+/// prompt/other helpers; the `gh` wrapper execs the real `gh` unmodified).
+/// Every other variant is an actionable misconfiguration or failure worth
+/// surfacing to the operator.
+#[derive(Debug, Error)]
+pub enum ShimError {
+    #[error("no broker-mediated connector declares host '{0}'")]
+    NoConnector(String),
+
+    #[error(
+        "connector '{connector_id}' is broker-mediated for host '{host}' but this process has \
+         no TA_SESSION_TOKEN_{credential_name} in its environment — the agent's own spawn must \
+         not have granted this credential (see `ta credentials grant` / `docs/USAGE.md`)"
+    )]
+    NoSessionToken {
+        connector_id: String,
+        host: String,
+        credential_name: String,
+    },
+
+    #[error("session token for connector '{connector_id}' failed verification: {reason}")]
+    VerifyFailed {
+        connector_id: String,
+        reason: String,
+    },
+
+    #[error("credential vault at {path} could not be opened: {reason}")]
+    VaultUnavailable { path: String, reason: String },
+
+    #[error("credential broker at {path} could not be opened: {reason}")]
+    BrokerUnavailable { path: String, reason: String },
+
+    #[error("failed to resolve credential for connector '{connector_id}': {reason}")]
+    CredentialLookupFailed {
+        connector_id: String,
+        reason: String,
+    },
+
+    #[error(
+        "session token for connector '{connector_id}' does not back the credential that \
+         connector declares ('{expected}' expected, token backs '{actual}')"
+    )]
+    CredentialMismatch {
+        connector_id: String,
+        expected: String,
+        actual: String,
+    },
+}
+
+/// Resolve the real secret backing `host` for a shell/CLI credential shim.
+///
+/// `project_root` is the directory containing `.ta/` (broker root key,
+/// `credentials.json`, `connectors.toml`) — callers resolve this from
+/// `TA_PROJECT_ROOT` (falling back to the current working directory), the
+/// same convention `ta serve` already uses for the MCP stdio subprocess.
+///
+/// `use_keychain` should be `true` for every real invocation; `false` only
+/// in tests, matching `CredentialsConfig::use_keychain`'s existing contract.
+pub fn resolve_for_host(
+    project_root: &Path,
+    host: &str,
+    use_keychain: bool,
+) -> Result<ShimResolution, ShimError> {
+    let registry = ConnectorRegistry::load(&project_root.join(".ta"));
+    let Some((connector_id, entry)) = registry.find_by_host(host) else {
+        return Err(ShimError::NoConnector(host.to_string()));
+    };
+    let connector_id = connector_id.to_string();
+
+    let env_var = format!("TA_SESSION_TOKEN_{}", entry.credential_name);
+    let Ok(session_token) = std::env::var(&env_var) else {
+        return Err(ShimError::NoSessionToken {
+            connector_id,
+            host: host.to_string(),
+            credential_name: entry.credential_name.clone(),
+        });
+    };
+
+    let broker_dir = project_root.join(".ta");
+    let broker = CredentialBroker::open(&broker_dir).map_err(|e| ShimError::BrokerUnavailable {
+        path: broker_dir.display().to_string(),
+        reason: e.to_string(),
+    })?;
+    let grant = broker
+        .verify(&session_token)
+        .map_err(|e| ShimError::VerifyFailed {
+            connector_id: connector_id.clone(),
+            reason: e.to_string(),
+        })?;
+
+    let mut cred_config = CredentialsConfig::for_project(project_root);
+    cred_config.use_keychain = use_keychain;
+    let vault = FileVault::open(&cred_config).map_err(|e| ShimError::VaultUnavailable {
+        path: cred_config.vault_path.display().to_string(),
+        reason: e.to_string(),
+    })?;
+    let credential =
+        vault
+            .get(grant.credential_id)
+            .map_err(|e| ShimError::CredentialLookupFailed {
+                connector_id: connector_id.clone(),
+                reason: e.to_string(),
+            })?;
+
+    if credential.name != entry.credential_name {
+        return Err(ShimError::CredentialMismatch {
+            connector_id,
+            expected: entry.credential_name.clone(),
+            actual: credential.name,
+        });
+    }
+
+    Ok(ShimResolution {
+        secret: credential.secret,
+        credential_name: credential.name,
+        connector_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    // `std::env::set_var`/`resolve_for_host` reads process-global env, so
+    // tests that touch `TA_SESSION_TOKEN_*` must not run concurrently.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn write_connectors_toml(project_root: &Path, body: &str) {
+        std::fs::create_dir_all(project_root.join(".ta")).unwrap();
+        std::fs::write(project_root.join(".ta/connectors.toml"), body).unwrap();
+    }
+
+    fn seed_credential(
+        project_root: &Path,
+        name: &str,
+        secret: &str,
+    ) -> (uuid::Uuid, CredentialBroker) {
+        let mut cred_config = CredentialsConfig::for_project(project_root);
+        cred_config.use_keychain = false;
+        let mut vault = FileVault::open(&cred_config).unwrap();
+        let cred = vault.add(name, "github", secret, vec![]).unwrap();
+        let broker = CredentialBroker::open(&project_root.join(".ta")).unwrap();
+        (cred.id, broker)
+    }
+
+    #[test]
+    fn resolves_real_secret_for_matching_host() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        write_connectors_toml(
+            dir.path(),
+            "[connectors.github]\ncredential_name = \"GITHUB_TOKEN\"\n\
+             broker_mediated = true\nhosts = [\"github.com\"]\n",
+        );
+        let (cred_id, broker) = seed_credential(dir.path(), "GITHUB_TOKEN", "ghp_real_secret");
+        let granted = broker.grant(cred_id, "agent-1", vec![], 3600).unwrap();
+
+        std::env::set_var("TA_SESSION_TOKEN_GITHUB_TOKEN", &granted.token);
+        let result = resolve_for_host(dir.path(), "github.com", false);
+        std::env::remove_var("TA_SESSION_TOKEN_GITHUB_TOKEN");
+
+        let resolution = result.unwrap();
+        assert_eq!(resolution.secret, "ghp_real_secret");
+        assert_eq!(resolution.credential_name, "GITHUB_TOKEN");
+        assert_eq!(resolution.connector_id, "github");
+    }
+
+    #[test]
+    fn unlisted_host_falls_through_silently() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        write_connectors_toml(
+            dir.path(),
+            "[connectors.github]\ncredential_name = \"GITHUB_TOKEN\"\n\
+             broker_mediated = true\nhosts = [\"github.com\"]\n",
+        );
+
+        let result = resolve_for_host(dir.path(), "gitlab.com", false);
+        assert!(matches!(result, Err(ShimError::NoConnector(host)) if host == "gitlab.com"));
+    }
+
+    #[test]
+    fn missing_session_token_is_actionable_not_silent() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        write_connectors_toml(
+            dir.path(),
+            "[connectors.github]\ncredential_name = \"GITHUB_TOKEN\"\n\
+             broker_mediated = true\nhosts = [\"github.com\"]\n",
+        );
+        std::env::remove_var("TA_SESSION_TOKEN_GITHUB_TOKEN");
+
+        let result = resolve_for_host(dir.path(), "github.com", false);
+        assert!(matches!(
+            result,
+            Err(ShimError::NoSessionToken { credential_name, .. })
+                if credential_name == "GITHUB_TOKEN"
+        ));
+    }
+
+    #[test]
+    fn revoked_token_is_rejected() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        write_connectors_toml(
+            dir.path(),
+            "[connectors.github]\ncredential_name = \"GITHUB_TOKEN\"\n\
+             broker_mediated = true\nhosts = [\"github.com\"]\n",
+        );
+        let (cred_id, mut broker) = seed_credential(dir.path(), "GITHUB_TOKEN", "ghp_real_secret");
+        let granted = broker.grant(cred_id, "agent-1", vec![], 3600).unwrap();
+        broker.revoke(&granted.token_id).unwrap();
+
+        std::env::set_var("TA_SESSION_TOKEN_GITHUB_TOKEN", &granted.token);
+        let result = resolve_for_host(dir.path(), "github.com", false);
+        std::env::remove_var("TA_SESSION_TOKEN_GITHUB_TOKEN");
+
+        assert!(matches!(result, Err(ShimError::VerifyFailed { .. })));
+    }
+}

--- a/crates/ta-credentials/src/connector_registry.rs
+++ b/crates/ta-credentials/src/connector_registry.rs
@@ -50,6 +50,17 @@ pub struct ConnectorEntry {
     /// consulted when `broker_mediated` is `true`.
     #[serde(default)]
     pub required_scope: Option<String>,
+
+    /// Hostnames this connector's credential shim should match (v0.17.6.7),
+    /// e.g. `["github.com"]` for git's `host=` credential-protocol field or
+    /// the GitHub CLI's API host. Only consulted by the Stage 7 shell/CLI
+    /// shims (`ta credential-helper`, the `gh` wrapper binary) — the
+    /// MCP-tool-call broker path (v0.17.6.3) never needs a hostname, since
+    /// the agent already names the connector explicitly. Empty by default:
+    /// a connector with no declared hosts is invisible to the shell shims,
+    /// even if `broker_mediated` is `true`.
+    #[serde(default)]
+    pub hosts: Vec<String>,
 }
 
 /// Every connector declared in `.ta/connectors.toml`, keyed by symbolic id.
@@ -115,6 +126,33 @@ impl ConnectorRegistry {
         self.connectors
             .values()
             .any(|c| c.credential_name == credential_name && c.broker_mediated)
+    }
+
+    /// Find the broker-mediated connector entry declaring `host` (v0.17.6.7)
+    /// — used by the shell/CLI credential shims (`ta credential-helper`,
+    /// the `gh` wrapper) to map a request's hostname back to a vault
+    /// credential. A connector that isn't `broker_mediated`, or that
+    /// declares no `hosts` at all, is never returned here — those stay on
+    /// the reduced-security env-injection fallback, exactly as before this
+    /// connector existed.
+    pub fn find_by_host(&self, host: &str) -> Option<(&str, &ConnectorEntry)> {
+        self.connectors
+            .iter()
+            .find(|(_, entry)| {
+                entry.broker_mediated && entry.hosts.iter().any(|h| h.eq_ignore_ascii_case(host))
+            })
+            .map(|(id, entry)| (id.as_str(), entry))
+    }
+
+    /// Whether any declared connector is both `broker_mediated` and has at
+    /// least one `hosts` entry — the precondition for installing the Stage 7
+    /// shell/CLI shims at all (v0.17.6.7). A project with no such connector
+    /// gets no git-config mutation and no `PATH` change, keeping the shims
+    /// entirely opt-in per `.ta/connectors.toml`.
+    pub fn has_shell_shim_connector(&self) -> bool {
+        self.connectors
+            .values()
+            .any(|c| c.broker_mediated && !c.hosts.is_empty())
     }
 }
 
@@ -191,5 +229,76 @@ broker_mediated = false
         assert!(registry.is_broker_mediated_credential("GITHUB_TOKEN"));
         assert!(!registry.is_broker_mediated_credential("SLACK_BOT_TOKEN"));
         assert!(!registry.is_broker_mediated_credential("UNDECLARED_TOKEN"));
+    }
+
+    #[test]
+    fn find_by_host_matches_broker_mediated_connector_with_declared_hosts() {
+        let toml = r#"
+[connectors.github]
+credential_name = "GITHUB_TOKEN"
+broker_mediated = true
+hosts = ["github.com", "gist.github.com"]
+"#;
+        let registry = ConnectorRegistry::parse(toml);
+
+        let (id, entry) = registry.find_by_host("github.com").unwrap();
+        assert_eq!(id, "github");
+        assert_eq!(entry.credential_name, "GITHUB_TOKEN");
+
+        // Case-insensitive, and a second declared host resolves too.
+        let (id2, _) = registry.find_by_host("GIST.GITHUB.COM").unwrap();
+        assert_eq!(id2, "github");
+
+        assert!(registry.find_by_host("gitlab.com").is_none());
+    }
+
+    #[test]
+    fn find_by_host_ignores_non_broker_mediated_and_hostless_connectors() {
+        let toml = r#"
+[connectors.github]
+credential_name = "GITHUB_TOKEN"
+broker_mediated = false
+hosts = ["github.com"]
+
+[connectors.slack-ops]
+credential_name = "SLACK_BOT_TOKEN"
+broker_mediated = true
+"#;
+        let registry = ConnectorRegistry::parse(toml);
+
+        // Not broker_mediated -> never matched by the shell shims, even
+        // though it declares the host.
+        assert!(registry.find_by_host("github.com").is_none());
+        // broker_mediated but no `hosts` declared -> never matched either.
+        assert!(registry.find_by_host("slack.com").is_none());
+    }
+
+    #[test]
+    fn has_shell_shim_connector_requires_broker_mediated_and_hosts() {
+        assert!(!ConnectorRegistry::default().has_shell_shim_connector());
+
+        let none_qualify = ConnectorRegistry::parse(
+            r#"
+[connectors.github]
+credential_name = "GITHUB_TOKEN"
+broker_mediated = true
+
+[connectors.slack-ops]
+credential_name = "SLACK_BOT_TOKEN"
+broker_mediated = false
+hosts = ["slack.com"]
+"#,
+        );
+        assert!(!none_qualify.has_shell_shim_connector());
+
+        let qualifies = ConnectorRegistry::parse(
+            r#"
+[connectors.github]
+credential_name = "GITHUB_TOKEN"
+broker_mediated = true
+hosts = ["github.com"]
+"#,
+        );
+        assert!(qualifies.has_shell_shim_connector());
     }
 }

--- a/crates/ta-daemon/src/external_channel.rs
+++ b/crates/ta-daemon/src/external_channel.rs
@@ -836,11 +836,17 @@ mod tests {
 
     #[tokio::test]
     async fn stdio_delivery_invalid_json_output() {
+        // Windows has no standalone `echo` binary (it's a shell builtin, not
+        // a PATH-resolvable executable) -- Command::new("echo") fails to
+        // spawn at all there rather than producing non-JSON output, same
+        // pitfall `stdio_delivery_with_echo` above already works around.
+        // `sh -c` works cross-platform, including on Windows CI runners
+        // (Git for Windows ships sh.exe on PATH).
         let manifest = PluginManifest {
             name: "bad-json".into(),
             version: "0.1.0".into(),
-            command: Some("echo".into()),
-            args: vec!["not-json".into()],
+            command: Some("sh".into()),
+            args: vec!["-c".into(), "echo not-json".into()],
             protocol: PluginProtocol::JsonStdio,
             deliver_url: None,
             auth_token_env: None,

--- a/crates/ta-submit/src/git.rs
+++ b/crates/ta-submit/src/git.rs
@@ -271,9 +271,7 @@ impl GitAdapter {
 
     /// Check if gh CLI is available
     fn has_gh_cli(&self) -> bool {
-        Command::new("gh")
-            .arg("--version")
-            .output()
+        run_gh_bounded(&["--version"], &self.work_dir, Duration::from_secs(5))
             .map(|o| o.status.success())
             .unwrap_or(false)
     }

--- a/crates/ta-submit/src/git.rs
+++ b/crates/ta-submit/src/git.rs
@@ -1,7 +1,8 @@
 //! Git adapter for branch-based workflows with GitHub/GitLab PR creation
 
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 use ta_changeset::DraftPackage;
 use ta_goal::CommitContext;
 
@@ -114,6 +115,68 @@ fn truncate_log_excerpt(full: &str) -> String {
     }
 }
 
+/// Runs a `gh` subcommand with a hard wall-clock deadline, never blocking
+/// indefinitely. `gh` can hang (slow/unreachable network, or -- on Windows,
+/// where GitHub-hosted runners preinstall `gh` -- interaction with a
+/// `gh`-named credential shim v0.17.6.7 can put on `PATH`) and
+/// `check_failures()`/`fetch_failed_run_log()` are both best-effort,
+/// read-only diagnostic paths that must never let a hung subprocess block
+/// the caller. Output is drained concurrently on reader threads while
+/// polling for the deadline, which also avoids a full-pipe-buffer deadlock
+/// if `gh` produces enough output before the process exits (a real risk for
+/// `--log-failed`, which can be many KB). Returns `None` on spawn failure
+/// or timeout (in which case the child is killed).
+fn run_gh_bounded(args: &[&str], cwd: &Path, timeout: Duration) -> Option<std::process::Output> {
+    use std::io::Read;
+
+    let mut child = Command::new("gh")
+        .args(args)
+        .current_dir(cwd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stdout_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut s) = stdout_pipe {
+            let _ = s.read_to_end(&mut buf);
+        }
+        buf
+    });
+    let stderr_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut s) = stderr_pipe {
+            let _ = s.read_to_end(&mut buf);
+        }
+        buf
+    });
+
+    let start = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(_) => return None,
+        }
+    };
+
+    Some(std::process::Output {
+        status,
+        stdout: stdout_handle.join().unwrap_or_default(),
+        stderr: stderr_handle.join().unwrap_or_default(),
+    })
+}
+
 /// Truncate `s` to at most `max_chars` Unicode scalar values.
 ///
 /// Trims trailing whitespace and dashes after truncation to avoid ugly endings.
@@ -219,11 +282,11 @@ impl GitAdapter {
     /// `check_failures()`. Returns `None` on any failure — the caller
     /// degrades to a manual-lookup hint rather than propagating an error.
     fn fetch_failed_run_log(&self, run_id: &str) -> Option<String> {
-        let output = Command::new("gh")
-            .args(["run", "view", run_id, "--log-failed"])
-            .current_dir(&self.work_dir)
-            .output()
-            .ok()?;
+        let output = run_gh_bounded(
+            &["run", "view", run_id, "--log-failed"],
+            &self.work_dir,
+            Duration::from_secs(10),
+        )?;
         if !output.status.success() {
             return None;
         }
@@ -1507,12 +1570,13 @@ impl SourceAdapter for GitAdapter {
         // we can pull an Actions run ID out of. Degrades to an empty vec on
         // any failure here (best-effort, matching check_review's style) —
         // check_failures is read-only diagnostic detail, never a hard error.
-        let output = Command::new("gh")
-            .args(["pr", "checks", review_id, "--json", "name,bucket,link"])
-            .current_dir(&self.work_dir)
-            .output();
+        let output = run_gh_bounded(
+            &["pr", "checks", review_id, "--json", "name,bucket,link"],
+            &self.work_dir,
+            Duration::from_secs(10),
+        );
         let checks: Vec<serde_json::Value> = match output {
-            Ok(o) if o.status.success() => match serde_json::from_slice(&o.stdout) {
+            Some(o) if o.status.success() => match serde_json::from_slice(&o.stdout) {
                 Ok(v) => v,
                 Err(_) => return Ok(vec![]),
             },

--- a/crates/ta-workflow/src/step_executor.rs
+++ b/crates/ta-workflow/src/step_executor.rs
@@ -10,6 +10,8 @@
 //   execute_step()        — full statechart executor with guards, actions, context patches
 
 use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::{Duration, Instant};
 
 use crate::step_action::{ActionRouter, StepAction};
 use crate::step_context::{StepInput, StepOutput, TransitionPayload, WorkflowContext};
@@ -270,10 +272,71 @@ pub enum PrCiStatus {
     Closed,
 }
 
+/// Runs a `gh` subcommand with a hard wall-clock deadline, never blocking
+/// indefinitely. `gh` can hang (slow/unreachable network, or -- on Windows,
+/// where GitHub-hosted runners preinstall `gh` -- a `gh`-named credential
+/// shim on `PATH`, see v0.17.6.7) and `poll_pr_ci_status()` is a
+/// best-effort polling call that must never let a hung subprocess block
+/// the whole step executor. Output is drained concurrently on reader
+/// threads while polling for the deadline, avoiding a full-pipe-buffer
+/// deadlock. Returns `None` on spawn failure or timeout (child is killed).
+/// Mirrors `ta_submit::git::run_gh_bounded` -- duplicated locally rather
+/// than shared across crates for now; see project memory for the case for
+/// extracting this into one shared low-level crate instead.
+fn run_gh_bounded(args: &[&str], timeout: Duration) -> Option<std::process::Output> {
+    use std::io::Read;
+
+    let mut child = std::process::Command::new("gh")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stdout_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut s) = stdout_pipe {
+            let _ = s.read_to_end(&mut buf);
+        }
+        buf
+    });
+    let stderr_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut s) = stderr_pipe {
+            let _ = s.read_to_end(&mut buf);
+        }
+        buf
+    });
+
+    let start = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(_) => return None,
+        }
+    };
+
+    Some(std::process::Output {
+        status,
+        stdout: stdout_handle.join().unwrap_or_default(),
+        stderr: stderr_handle.join().unwrap_or_default(),
+    })
+}
+
 /// Poll `gh pr view --json statusCheckRollup` and map the result to a `PrCiStatus`.
 pub fn poll_pr_ci_status(pr_number: u64) -> PrCiStatus {
-    let output = std::process::Command::new("gh")
-        .args([
+    let output = run_gh_bounded(
+        &[
             "pr",
             "view",
             &pr_number.to_string(),
@@ -281,11 +344,12 @@ pub fn poll_pr_ci_status(pr_number: u64) -> PrCiStatus {
             "state,statusCheckRollup",
             "--jq",
             ".state + \":\" + (if (.statusCheckRollup | length) == 0 then \"PENDING\" else (.statusCheckRollup | map(.conclusion) | if any(. == \"FAILURE\") then \"FAILURE\" elif all(. == \"SUCCESS\" or . == \"SKIPPED\") then \"SUCCESS\" else \"PENDING\" end) end)",
-        ])
-        .output();
+        ],
+        Duration::from_secs(10),
+    );
 
     match output {
-        Ok(out) if out.status.success() => {
+        Some(out) if out.status.success() => {
             let raw = String::from_utf8_lossy(&out.stdout);
             let line = raw.trim();
             if line.starts_with("MERGED") || line.contains("MERGED") {

--- a/crates/ta-workspace/src/partitioning.rs
+++ b/crates/ta-workspace/src/partitioning.rs
@@ -54,7 +54,8 @@ pub const LOCAL_TA_PATHS: &[&str] = &[
     "advisor-notes/",
     "team-sessions/", // persistent team session state (v0.17.5.1)
     "draft-build-ctx/",
-    "memory/",     // local memory cache (project-memory/ is the VCS-committed counterpart)
+    "bin/", // staged shell/CLI credential shim binaries (v0.17.6.7) — a machine-local copy of the `gh` wrapper, never committed
+    "memory/", // local memory cache (project-memory/ is the VCS-committed counterpart)
     "link-cache/", // cached remote project manifests (v0.16.1.5)
     // Runtime files
     "velocity-stats.jsonl",

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -7521,9 +7521,10 @@ marked `broker_mediated = true` are withheld from the agent's environment.
 
 The `broker_mediated = false` path is the same env-injection behavior TA
 has always had -- kept as an explicitly-flagged reduced-security fallback
-(logged at `debug`) until a per-tool credential shim (v0.17.6.7, for the
-dominant `git push`/`gh pr create`/`curl` shell-command case that never
-touches `ta_external_action` at all) closes it more broadly.
+(logged at `debug`). For the dominant `git push`/`gh pr create` shell-command
+case that never touches `ta_external_action` at all, see [Shell/CLI
+Credential Isolation](#shellcli-credential-isolation) below; `npm`/`docker`/
+raw `curl` remain on this fallback.
 
 **End-to-end flow for a broker-mediated connector:**
 
@@ -7565,6 +7566,48 @@ the broker-resolved secret from their own subprocess environment as
 exchanged with TA, so it cannot end up logged to `.ta/action-log.jsonl` or
 echoed into a plugin's own response by accident (a well-behaved plugin
 should not echo it either way).
+
+#### Shell/CLI Credential Isolation
+
+Broker mediation above closes the leak path for connectors used through
+`ta_external_action` -- but a Bash-driven coding agent's *majority*
+credentialed actions never touch an MCP tool call at all: `git push`,
+`gh pr create`, `npm publish`, `docker login`, a raw `curl` with a bearer
+header all read a raw secret straight out of the agent's own shell
+environment. Two concrete shims close this for the tools that support it;
+everything else stays on the reduced-security env-injection fallback below,
+same as before this section existed.
+
+Declare which hostnames a broker-mediated connector's credential shims
+should match by adding a `hosts` list to its `.ta/connectors.toml` entry:
+
+```toml
+[connectors.github]
+credential_name = "GITHUB_TOKEN"
+broker_mediated = true
+required_scope = "repo.write"
+hosts = ["github.com"]   # enables the git-credential-helper and gh shims below
+```
+
+A connector with no `hosts` entry is invisible to both shims -- only the
+`ta_external_action` broker path (above) applies to it, unchanged.
+
+**Covered today:**
+
+| Tool | Mechanism |
+|---|---|
+| `git` (`git push`, `git pull`, `git clone` over HTTPS) | `ta run` writes a repo-local `credential.helper = "!<ta binary> credential-helper"` into `.git/config` whenever a broker-mediated connector declares a matching `hosts` entry. git already supports pluggable credential helpers (`gitcredentials(7)`) -- no change to git's own behavior. On each auth request, `ta credential-helper get` reads git's `host=`/`protocol=` request from stdin, resolves the real secret via the broker/vault (the same lookup the `ta_external_action` path uses), and prints `username=`/`password=` back to git. The raw secret exists only in this short-lived helper process and in git's own pipe to it -- never in the agent's persistent shell environment or the LLM's context. A host no broker-mediated connector declares produces no output and no error, so git falls through to its own prompt/other configured helpers exactly as if this helper were never installed. |
+| `gh` (GitHub CLI) | The GitHub CLI has no external-auth-token-resolution hook the way git does, so this is a different mechanism: `ta run` stages a small `gh`-named wrapper binary at `<project root>/.ta/bin/gh` and prepends that directory onto the agent's `PATH`, so a bare `gh ...` invocation resolves to the wrapper before the real CLI. Each invocation resolves the real secret the same way the git helper does, finds the real `gh` binary by searching `PATH` with the wrapper's own directory excluded, and execs it with `GH_TOKEN` set only on that one child process -- never on the wrapper's own environment, and never on the agent's own long-lived shell environment. No matching connector, no session token, or no real `gh` found on `PATH` all fail open: the wrapper runs the real `gh` unmodified wherever it can still be found, the same behavior as if the shim had never been installed. |
+
+**Not covered yet** (stays on the `broker_mediated = false` reduced-security
+env-injection fallback, `bare_process.rs`, logged at `debug`): `npm`,
+`docker`, and any raw `curl`/HTTP client usage. Closing the general case
+would need a local loopback forward proxy that injects the `Authorization`
+header for allow-listed hosts server-side -- which requires the agent's
+process to trust a local CA for TLS interception on those hosts, a real,
+separate trust decision. That trust boundary is deliberately not bundled
+into the git/gh shims above; it's tracked as a future phase requiring its
+own explicit sign-off rather than an implicit rider on this one.
 
 #### Human Escalation for Credential Scope Elevation
 


### PR DESCRIPTION
## Summary
- `ta credential-helper` — a git `credential.helper` backend; `ta run` wires a repo's local `credential.helper` config to it whenever `.ta/connectors.toml` declares a broker-mediated connector with a matching `hosts` entry. Raw secret only ever transits git's own stdin/stdout pipe, never the agent's persistent shell env.
- `gh` PATH-shadow wrapper (`apps/ta-cli/src/bin/gh_shim.rs`) — staged at `.ta/bin/gh`, prepended onto PATH, resolves the secret and injects `GH_TOKEN` only into the one real-`gh` child process it execs (gh has no external-auth-hook like git's).
- Shared resolver (`crates/ta-credential-broker/src/shim.rs`) used by both shims, plus a new `hosts` field on `ConnectorRegistry` entries for hostname→connector matching.

## Scope decision (documented in `.ta-decisions.json`)
The generic local TLS-intercepting forward proxy for arbitrary `curl`/`npm`/`docker` (design doc Open Question 4) was deliberately deferred, not built — it requires trusting a local MITM CA, a distinct trust decision that deserves its own phase and human sign-off. `npm`/`docker`/raw `curl` remain on the existing reduced-security fallback.

## Test plan
- `cargo build --workspace`, `cargo test --workspace` (1568 passed, 0 failed), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all pass in an isolated worktree.