### PR TITLE
implement v0.17.7.3 — Multi-Role Review Panels + Single Approval-Gate Unification

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -10284,7 +10284,7 @@ One shipped implementation, `GoalDispatchAction`, wraps `ta run`/`ta goal start`
 
 #### Version: `0.17.7-alpha.2`
 ### v0.17.7.3 — Multi-Role Review Panels + Single Approval-Gate Unification
-<!-- status: pending -->
+<!-- status: done -->
 **Depends on**: v0.17.7.1, v0.17.7.2
 
 **Coordination note**: v0.17.5.3 item 3 (Pluggable Domain-Action Adapters) also touches `check_advisor_auto_approve()` wiring and `security_tier` consultation. If v0.17.5.3 lands first, this phase's unification must account for the domain-adapter dispatch path too rather than re-diverging it; if this phase lands first, v0.17.5.3 item 3 should route its risk_score/verdict through the same one-graph gate instead of adding a fourth path. Flagged as an API-impact overlap per the v0.17.0.12.34 dependency-wave process if both are scheduled into the same wave.
@@ -10292,13 +10292,13 @@ One shipped implementation, `GoalDispatchAction`, wraps `ta run`/`ta goal start`
 **Goal**: Add `AgentPanelReviewer` (spawns a persona agent — PM, head of security, head of engineering, head of sales, etc. — role strings, no core change needed since `TeamRole` is already data-defined per v0.17.0.12.12), make `WeightedDecisionNode`'s threshold/algorithm/weights genuinely config-driven from the graph TOML (removing the hardcoded `threshold=0.75`/`ConsensusAlgorithm::Raft`/empty-weights literals in `governed_workflow.rs`'s `stage_consensus`), and enforce constitution §16.3's named call-site invariant: migrate `ta draft apply`'s real approval check to call exactly one graph instance.
 
 **Items**:
-1. [ ] `AgentPanelReviewer` — spawns a role-persona agent per constitution §1.6 (data-defined `TeamRole`), scores a draft/decision, returns a `ReviewerVote`.
-2. [ ] Wire graph TOML's `[decision] algorithm/threshold/weights` fields through to `ta-workflow::consensus::run_consensus`, replacing `governed_workflow.rs`'s hardcoded literals (`stage_consensus`, ~line 2489-2492).
-3. [ ] **Call-site migration (the §16.3 enforcement)**: `ta draft apply`'s approval gate calls one graph instance. Remove/redirect all other direct callers of `should_auto_approve_draft`, `check_advisor_auto_approve`, and `run_consensus`-for-gating so each becomes a `ReviewerNode` feeding that one graph instead.
-4. [ ] `EscalateAction` — notifies via existing `ta-events::notification` system, halts the graph at that node.
-5. [ ] A reference `phase-review-panel.toml` graph (per spec §3): policy + PM + head-of-security + head-of-engineering reviewers → weighted decision → configurable auto-approve/recommend action.
-6. [ ] Tests: the three previously-independent mechanisms each produce identical `ReviewerVote`s to what they produced standalone (no behavior regression for existing callers during migration); a test asserting the §16.3 invariant statically or at runtime (e.g., a lint/grep-based CI check that no code outside the graph engine calls the three functions directly) so the rule isn't just prose.
-7. [ ] USAGE.md + constitution: remove §16's DRAFT banner and add §16 rows to the Appendix Compliance Checklist once this phase ships (per the graduation gate stated in §16's banner).
+1. [x] `AgentPanelReviewer` — spawns a role-persona agent per constitution §1.6 (data-defined `TeamRole`), scores a draft/decision, returns a `ReviewerVote`.
+2. [x] Wire graph TOML's `[decision] algorithm/threshold/weights` fields through to `ta-workflow::consensus::run_consensus`, replacing `governed_workflow.rs`'s hardcoded literals (`stage_consensus`, ~line 2489-2492).
+3. [x] **Call-site migration (the §16.3 enforcement)**: `ta draft apply`'s approval gate calls one graph instance. Remove/redirect all other direct callers of `should_auto_approve_draft`, `check_advisor_auto_approve`, and `run_consensus`-for-gating so each becomes a `ReviewerNode` feeding that one graph instead.
+4. [x] `EscalateAction` — notifies via existing `ta-events::notification` system, halts the graph at that node.
+5. [x] A reference `phase-review-panel.toml` graph (per spec §3): policy + PM + head-of-security + head-of-engineering reviewers → weighted decision → configurable auto-approve/recommend action.
+6. [x] Tests: the three previously-independent mechanisms each produce identical `ReviewerVote`s to what they produced standalone (no behavior regression for existing callers during migration); a test asserting the §16.3 invariant statically or at runtime (e.g., a lint/grep-based CI check that no code outside the graph engine calls the three functions directly) so the rule isn't just prose.
+7. [x] USAGE.md + constitution: remove §16's DRAFT banner and add §16 rows to the Appendix Compliance Checklist once this phase ships (per the graduation gate stated in §16's banner).
 
 #### Version: `0.17.7-alpha.3`
 ### v0.17.7.4 — Advisor Natural-Language Multi-Phase Entry Point

--- a/apps/ta-cli/src/commands/draft.rs
+++ b/apps/ta-cli/src/commands/draft.rs
@@ -6038,13 +6038,43 @@ fn apply_package(
             // not bypass the shared Decision gate when a supervisor review is present.
             // Elevated risk or a non-Commit verdict still requires a human even in the
             // single-author flow (v0.17.0.12.15).
+            //
+            // v0.17.7.3 (constitution §16.3): this is the one graph instance `ta draft
+            // apply`'s approval check calls — no other code path may call
+            // `should_auto_approve_draft`/`check_advisor_auto_approve`/`run_consensus`
+            // directly to gate an apply. `ta_decision::decide()` is still called
+            // separately below purely to compute the richer telemetry `Decision`
+            // variant (Commit/Reject/Rework/Escalate) — it does not gate anything;
+            // the graph's `proceed` is the sole authority for whether the apply
+            // continues.
             if let Some(review) = &pkg.supervisor_review {
                 let verdict = match review.verdict {
                     ta_changeset::SupervisorVerdict::Pass => ta_decision::Verdict::Pass,
                     ta_changeset::SupervisorVerdict::Warn => ta_decision::Verdict::Warn,
                     ta_changeset::SupervisorVerdict::Block => ta_decision::Verdict::Block,
                 };
-                let decision = ta_decision::decide(
+                let review_input = ta_workflow::graph::ReviewInput {
+                    draft_id: Some(id.to_string()),
+                    changed_paths: pkg
+                        .changes
+                        .artifacts
+                        .iter()
+                        .map(|a| a.resource_uri.clone())
+                        .collect(),
+                    lines_changed: 0,
+                    plan_phase: pkg.plan_phase.clone(),
+                    agent_id: pkg.agent_identity.agent_id.clone(),
+                    risk_score: pkg.risk.risk_score,
+                    confidence: review.confidence,
+                    verdict,
+                };
+                let gate_decision = crate::commands::workflow_graph::run_apply_gate(
+                    config,
+                    &review_input,
+                    auto_approval_thresholds,
+                )?;
+
+                let telemetry_decision = ta_decision::decide(
                     &ta_decision::DecisionInput {
                         verdict,
                         risk_score: pkg.risk.risk_score,
@@ -6052,19 +6082,24 @@ fn apply_package(
                     },
                     &auto_approval_thresholds,
                 );
-                record_decision_telemetry(config, &pkg, decision, review.confidence);
-                if !decision.is_auto_approvable() {
+                record_decision_telemetry(config, &pkg, telemetry_decision, review.confidence);
+
+                if !gate_decision.proceed {
                     anyhow::bail!(
                         "Draft \"{}\" cannot be auto-approved on apply: the Decision gate \
-                         returned {:?} (supervisor verdict {:?}, confidence {:.2}, risk score {}).\n\
+                         (approval-gate graph) returned proceed=false (score={:.2}, supervisor \
+                         verdict {:?}, confidence {:.2}, risk score {}).\n\
+                         {}\n\
                          \n\
                          Run `ta draft approve {}` after review, then re-run `ta draft apply {}`.\n\
-                         (Adjust `[draft.auto_approval]` thresholds in workflow.toml to change this.)",
+                         (Adjust `[draft.auto_approval]` thresholds in workflow.toml, or author \
+                         `.ta/workflows/graphs/draft-apply-gate.toml`, to change this.)",
                         pkg.goal.title,
-                        decision,
+                        gate_decision.score,
                         review.verdict,
                         review.confidence,
                         pkg.risk.risk_score,
+                        gate_decision.summary,
                         id,
                         id
                     );

--- a/apps/ta-cli/src/commands/governed_workflow.rs
+++ b/apps/ta-cli/src/commands/governed_workflow.rs
@@ -287,6 +287,26 @@ pub struct StageDef {
     /// When absent, all pending phases are considered.
     #[serde(default)]
     pub phase_filter: Option<String>,
+    // ── v0.17.7.3 fields (kind = "consensus") ────────────────────────────────
+    /// For `kind = "consensus"`: "raft" | "paxos" | "weighted". Defaults to
+    /// "raft" (the previously-hardcoded literal) when absent — config-driven
+    /// per constitution §16.5, no longer a compiled-in constant
+    /// (`ta_workflow::graph::WeightedDecisionNode` fixes the same gap for the
+    /// graph engine; this fixes it for `stage_consensus`).
+    #[serde(default)]
+    pub consensus_algorithm: Option<String>,
+    /// For `kind = "consensus"`: pass/fail threshold (0.0-1.0). Defaults to
+    /// 0.75 (the previously-hardcoded literal) when absent.
+    #[serde(default)]
+    pub consensus_threshold: Option<f64>,
+    /// For `kind = "consensus"`: per-role weight multipliers. Defaults to
+    /// empty (equal weighting) when absent.
+    #[serde(default)]
+    pub consensus_weights: std::collections::HashMap<String, f64>,
+    /// For `kind = "consensus"`: require every listed role to have voted
+    /// (no timeouts) for the consensus to proceed. Defaults to `false`.
+    #[serde(default)]
+    pub consensus_require_all: bool,
 }
 
 // ── New step kinds (v0.15.13 + v0.15.14) ─────────────────────────────────────
@@ -2422,6 +2442,7 @@ fn stage_consensus(
     _config: &WorkflowConfig,
 ) -> anyhow::Result<Option<String>> {
     use std::collections::HashMap;
+    use std::str::FromStr;
     use ta_workflow::consensus::{run_consensus, ConsensusAlgorithm, ConsensusInput, ReviewerVote};
 
     let run_id = &run.run_id;
@@ -2491,10 +2512,18 @@ fn stage_consensus(
         });
     }
 
-    let weights: HashMap<String, f64> = HashMap::new();
-    let threshold = 0.75_f64;
-    let algorithm = ConsensusAlgorithm::Raft;
-    let require_all = false;
+    // Config-driven, not hardcoded literals (v0.17.7.3, constitution §16.5)
+    // — mirrors `ta_workflow::graph::WeightedDecisionNode::from_def`'s
+    // TOML-sourced threshold/algorithm/weights, sourced here from the
+    // stage's own `consensus_*` fields instead of a graph `[decision]` def.
+    let weights: HashMap<String, f64> = stage_def.consensus_weights.clone();
+    let threshold = stage_def.consensus_threshold.unwrap_or(0.75);
+    let algorithm = stage_def
+        .consensus_algorithm
+        .as_deref()
+        .and_then(|s| ConsensusAlgorithm::from_str(s).ok())
+        .unwrap_or(ConsensusAlgorithm::Raft);
+    let require_all = stage_def.consensus_require_all;
     let override_reason: Option<String> = None;
 
     let run_dir = opts
@@ -3965,6 +3994,10 @@ mod tests {
             max_parallel: None,
             lang: None,
             phase_filter: None,
+            consensus_algorithm: None,
+            consensus_threshold: None,
+            consensus_weights: std::collections::HashMap::new(),
+            consensus_require_all: false,
         }
     }
 
@@ -4850,6 +4883,10 @@ kind = "static_analysis"
             max_parallel: None,
             lang: None,
             phase_filter: None,
+            consensus_algorithm: None,
+            consensus_threshold: None,
+            consensus_weights: std::collections::HashMap::new(),
+            consensus_require_all: false,
         };
 
         let opts = RunOptions {
@@ -4913,6 +4950,10 @@ kind = "static_analysis"
             max_parallel: None,
             lang: None,
             phase_filter: None,
+            consensus_algorithm: None,
+            consensus_threshold: None,
+            consensus_weights: std::collections::HashMap::new(),
+            consensus_require_all: false,
         };
 
         let opts = RunOptions {
@@ -4962,6 +5003,10 @@ kind = "static_analysis"
             max_parallel: None,
             lang: None,
             phase_filter: None,
+            consensus_algorithm: None,
+            consensus_threshold: None,
+            consensus_weights: std::collections::HashMap::new(),
+            consensus_require_all: false,
         };
 
         let result = stage_join(&mut run, &stage_def).unwrap();
@@ -4996,6 +5041,10 @@ kind = "static_analysis"
             max_parallel: None,
             lang: None,
             phase_filter: None,
+            consensus_algorithm: None,
+            consensus_threshold: None,
+            consensus_weights: std::collections::HashMap::new(),
+            consensus_require_all: false,
         };
 
         let err = stage_join(&mut run, &stage_def).unwrap_err();
@@ -5028,6 +5077,10 @@ kind = "static_analysis"
             max_parallel: None,
             lang: None,
             phase_filter: None,
+            consensus_algorithm: None,
+            consensus_threshold: None,
+            consensus_weights: std::collections::HashMap::new(),
+            consensus_require_all: false,
         };
 
         let result = stage_join(&mut run, &stage_def);
@@ -5125,6 +5178,10 @@ kind = "apply_draft"
             max_parallel: None,
             lang: None,
             phase_filter: None,
+            consensus_algorithm: None,
+            consensus_threshold: None,
+            consensus_weights: std::collections::HashMap::new(),
+            consensus_require_all: false,
         }
     }
 
@@ -5214,6 +5271,60 @@ kind = "apply_draft"
         };
         let err = stage_consensus(&mut run, &stage_def, &opts, &config).unwrap_err();
         assert!(err.to_string().contains("BLOCKED"));
+    }
+
+    #[test]
+    fn stage_consensus_reads_threshold_algorithm_weights_from_stage_def_not_hardcoded() {
+        // Same two votes as `stage_consensus_below_threshold_fails` (which
+        // BLOCKs under the hardcoded default threshold=0.75), but with a
+        // stage-level config lowering the threshold and up-weighting the
+        // higher-scoring role — proves the values come from `StageDef`, not
+        // compiled-in literals (v0.17.7.3 item 2).
+        let dir = tempdir().unwrap();
+        let run_id = "test-consensus-config-driven";
+        let review_base = dir.path().join(".ta").join("review").join(run_id);
+        for (role, score) in &[("architect_review", 0.3_f64), ("security_review", 0.6_f64)] {
+            let role_dir = review_base.join(role);
+            std::fs::create_dir_all(&role_dir).unwrap();
+            let verdict = serde_json::json!({"score": score, "findings": []});
+            std::fs::write(
+                role_dir.join("verdict.json"),
+                serde_json::to_string(&verdict).unwrap(),
+            )
+            .unwrap();
+        }
+
+        let config = WorkflowConfig::default();
+        let mut run = GovernedWorkflowRun::new(run_id, "test-wf", "Goal");
+        let mut stage_def = make_consensus_stage_def(vec![
+            "architect_review".to_string(),
+            "security_review".to_string(),
+        ]);
+        stage_def.consensus_algorithm = Some("weighted".to_string());
+        stage_def.consensus_threshold = Some(0.4);
+        stage_def
+            .consensus_weights
+            .insert("security_review".to_string(), 3.0);
+        let opts = RunOptions {
+            workspace_root: dir.path(),
+            workflow_name: "test",
+            goal_title: "test",
+            dry_run: false,
+            resume_run_id: None,
+            agent: "claude-code",
+            plan_phase: None,
+            depth: 0,
+            params: Default::default(),
+        };
+        let result = stage_consensus(&mut run, &stage_def, &opts, &config).unwrap();
+        assert!(
+            result.is_some(),
+            "weighted average (0.3*1.0 + 0.6*3.0)/4.0 = 0.525 must clear the \
+             configured 0.4 threshold, even though it fails the old hardcoded 0.75"
+        );
+        let out = run.outputs.get("consensus").unwrap();
+        assert_eq!(out.get("proceed").unwrap(), "true");
+        assert_eq!(out.get("algorithm").unwrap(), "weighted");
     }
 
     #[test]

--- a/apps/ta-cli/src/commands/workflow_graph.rs
+++ b/apps/ta-cli/src/commands/workflow_graph.rs
@@ -15,8 +15,8 @@ use std::collections::HashMap;
 use ta_mcp_gateway::GatewayConfig;
 use ta_workflow::graph::{
     ActionDef, ActionNode, ActionOutcome, Decision, GraphContext, GraphDefinition, GraphError,
-    NodeDef, NodeRegistry, ReviewInput, TriggerPayload, TriggerSource, WorkItem, WorkResult,
-    WorkerNode,
+    NodeDef, NodeRegistry, ReviewInput, ReviewerNode, ReviewerVote, TriggerPayload, TriggerSource,
+    WorkItem, WorkResult, WorkerNode,
 };
 
 use crate::commands::draft::{self, DraftCommands};
@@ -256,6 +256,183 @@ impl ActionNode for RecommendAction {
             kind: "recommend".to_string(),
             applied: false,
             message,
+            metadata,
+        })
+    }
+}
+
+// ── AgentPanelReviewer (ReviewerNode, v0.17.7.3) ─────────────────────────
+
+/// Spawns a role-persona agent (constitution §1.6: `TeamRole` is a
+/// data-defined string, so `"head_of_security"`/`"head_of_sales"`/any new
+/// role needs zero core changes) to review the current draft, then reads
+/// back its scored verdict. Reuses `GoalDispatchAction`'s dispatch machinery
+/// (one dispatch path, not a second spawner) to launch the review goal, and
+/// the same verdict-file shape `governed_workflow.rs::stage_consensus`
+/// already reads (`{"score": <0.0-1.0>, "findings": [...]}`) so a persona
+/// author learns one contract, not two.
+pub struct AgentPanelReviewer {
+    pub dispatcher: GoalDispatchAction,
+    pub role: String,
+    pub poll_interval: std::time::Duration,
+    pub max_polls: u32,
+}
+
+impl AgentPanelReviewer {
+    pub fn new(config: GatewayConfig, role: impl Into<String>) -> Self {
+        Self {
+            dispatcher: GoalDispatchAction::new(config),
+            role: role.into(),
+            poll_interval: std::time::Duration::from_secs(10),
+            max_polls: 60,
+        }
+    }
+
+    fn verdict_path(&self, ctx: &GraphContext) -> std::path::PathBuf {
+        ctx.run_dir
+            .join("reviewers")
+            .join(&self.role)
+            .join("verdict.json")
+    }
+
+    fn read_verdict(path: &std::path::Path) -> Option<(f64, Vec<String>)> {
+        let raw = std::fs::read_to_string(path).ok()?;
+        let verdict: serde_json::Value = serde_json::from_str(&raw).ok()?;
+        let score = verdict
+            .get("score")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0)
+            .clamp(0.0, 1.0);
+        let findings = verdict
+            .get("findings")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        Some((score, findings))
+    }
+}
+
+impl ReviewerNode for AgentPanelReviewer {
+    fn review(&self, input: &ReviewInput, ctx: &GraphContext) -> Result<ReviewerVote, GraphError> {
+        let verdict_path = self.verdict_path(ctx);
+
+        if !verdict_path.exists() {
+            let objective = format!(
+                "# Review panel: {role}\n\nReview this draft as the {role} and write your \
+                 verdict to `{path}` as JSON: {{\"score\": <0.0-1.0>, \"findings\": [\"...\"]}}.\n\n\
+                 Draft: {draft_id}\nChanged paths: {paths}\nLines changed: {lines}\n",
+                role = self.role,
+                path = verdict_path.display(),
+                draft_id = input.draft_id.as_deref().unwrap_or("(unknown)"),
+                paths = input.changed_paths.join(", "),
+                lines = input.lines_changed,
+            );
+            let item = WorkItem {
+                title: format!(
+                    "Panel review ({}): {}",
+                    self.role,
+                    input.draft_id.as_deref().unwrap_or("draft")
+                ),
+                objective,
+                phase_id: input.plan_phase.clone(),
+                verb: "review".to_string(),
+                workload_hint: Some("agent_panel_review".to_string()),
+            };
+            self.dispatcher.dispatch(&item, ctx)?;
+        }
+
+        for attempt in 0..self.max_polls {
+            if let Some((score, findings)) = Self::read_verdict(&verdict_path) {
+                return Ok(ReviewerVote {
+                    role: self.role.clone(),
+                    score,
+                    findings,
+                    timed_out: false,
+                });
+            }
+            if attempt + 1 < self.max_polls && !self.poll_interval.is_zero() {
+                std::thread::sleep(self.poll_interval);
+            }
+        }
+
+        Ok(ReviewerVote {
+            role: self.role.clone(),
+            score: 0.0,
+            findings: vec![format!(
+                "role '{}' did not write a verdict within {} poll(s) (interval {:?}) — \
+                 treated as timeout",
+                self.role, self.max_polls, self.poll_interval
+            )],
+            timed_out: true,
+        })
+    }
+}
+
+// ── EscalateAction (ActionNode, v0.17.7.3) ───────────────────────────────
+
+/// Notifies via the existing `ta-events::notification` system and halts the
+/// graph at this node (constitution §16.1/§16.2): a `Decision` that doesn't
+/// clear its threshold is neither auto-applied nor silently recommended — it
+/// surfaces to a human with an explicit, observable signal instead.
+pub struct EscalateAction {
+    pub events_dir: std::path::PathBuf,
+}
+
+impl EscalateAction {
+    pub fn new(workspace_root: impl Into<std::path::PathBuf>) -> Self {
+        let workspace_root: std::path::PathBuf = workspace_root.into();
+        Self {
+            events_dir: workspace_root.join(".ta").join("events"),
+        }
+    }
+}
+
+impl ActionNode for EscalateAction {
+    fn act(&self, decision: &Decision, ctx: &GraphContext) -> Result<ActionOutcome, GraphError> {
+        use ta_events::schema::{EventEnvelope, SessionEvent};
+        use ta_events::store::{EventStore, FsEventStore};
+
+        let draft_id = ctx
+            .vars
+            .get("draft_id")
+            .and_then(|s| uuid::Uuid::parse_str(s).ok());
+        let event = SessionEvent::GraphDecisionEscalated {
+            run_id: ctx.run_id.clone(),
+            draft_id,
+            score: decision.score,
+            summary: decision.summary.clone(),
+        };
+        let store = FsEventStore::new(&self.events_dir);
+        if let Err(e) = store.append(&EventEnvelope::new(event)) {
+            tracing::warn!(
+                error = %e,
+                run_id = %ctx.run_id,
+                "graph: EscalateAction failed to record escalation event — halting anyway"
+            );
+        }
+
+        tracing::warn!(
+            run_id = %ctx.run_id,
+            score = decision.score,
+            "graph: EscalateAction halted the graph"
+        );
+
+        let mut metadata = HashMap::new();
+        if let Some(id) = draft_id {
+            metadata.insert("draft_id".to_string(), id.to_string());
+        }
+        Ok(ActionOutcome {
+            kind: "escalate".to_string(),
+            applied: false,
+            message: format!(
+                "decision escalated for human review (score={:.2}, proceed={}) — graph halted \
+                 at this node, no auto-approve or silent recommendation issued",
+                decision.score, decision.proceed
+            ),
             metadata,
         })
     }
@@ -622,6 +799,20 @@ pub fn build_registry(config: GatewayConfig) -> NodeRegistry {
         Ok(Box::new(RecommendAction) as Box<dyn ActionNode>)
     });
 
+    let escalate_root = config.workspace_root.clone();
+    registry.register_action("escalate", move |_def: &ActionDef| {
+        Ok(Box::new(EscalateAction::new(escalate_root.clone())) as Box<dyn ActionNode>)
+    });
+
+    let panel_config = config.clone();
+    registry.register_reviewer("agent_panel", move |def: &NodeDef| {
+        let role = def.param_str("role").unwrap_or("reviewer").to_string();
+        let mut reviewer = AgentPanelReviewer::new(panel_config.clone(), role);
+        reviewer.poll_interval = poll_interval_param(def);
+        reviewer.max_polls = max_polls_param(def);
+        Ok(Box::new(reviewer) as Box<dyn ReviewerNode>)
+    });
+
     let corrective_config = config.clone();
     registry.register_action("corrective_goal", move |def: &ActionDef| {
         let retry_cap = def
@@ -656,6 +847,101 @@ pub fn build_registry(config: GatewayConfig) -> NodeRegistry {
     });
 
     registry
+}
+
+// ── `ta draft apply`'s one graph instance (v0.17.7.3, constitution §16.3) ──
+//
+// `run_apply_gate` is the single named call site `ta draft apply` (and, per
+// the same invariant, every other apply/merge-gating code path) must go
+// through instead of calling `should_auto_approve_draft`,
+// `check_advisor_auto_approve`, or `run_consensus` directly. A project may
+// author `.ta/workflows/graphs/draft-apply-gate.toml` (e.g. the
+// `phase-review-panel.toml` shape, with a `policy`/`agent_panel` panel) to
+// replace the default single-reviewer gate below with a full review panel —
+// same call site, different data, per constitution §16.5.
+
+const DEFAULT_APPLY_GATE_GRAPH: &str = r#"
+[[reviewer]]
+id = "advisor_confidence"
+kind = "advisor_confidence"
+
+[decision]
+id = "gate"
+kind = "weighted"
+algorithm = "weighted"
+threshold = 0.5
+inputs = ["advisor_confidence"]
+"#;
+
+/// The gate `ta draft apply` has always effectively run (a single
+/// `ta_decision::gate::decide()` check) expressed as a graph, used only when
+/// the project hasn't authored its own `draft-apply-gate.toml` — preserves
+/// today's behavior exactly (see `AdvisorConfidenceReviewer`'s doc comment:
+/// score 1.0 iff `decide().is_auto_approvable()`, threshold 0.5 makes that a
+/// pure pass/fail).
+fn default_apply_gate_graph_def() -> GraphDefinition {
+    GraphDefinition::from_toml_str(DEFAULT_APPLY_GATE_GRAPH)
+        .expect("DEFAULT_APPLY_GATE_GRAPH is a fixed constant covered by a unit test")
+}
+
+/// `build_registry` plus the project's real `auto_approval` thresholds
+/// wired into `advisor_confidence` (overriding `with_builtins()`'s bare
+/// `DecisionThresholds::default()`), so the graph's decision matches what
+/// `[draft.auto_approval]` in `workflow.toml` actually configures.
+fn build_apply_gate_registry(
+    config: GatewayConfig,
+    thresholds: ta_decision::DecisionThresholds,
+) -> NodeRegistry {
+    let mut registry = build_registry(config);
+    registry.register_reviewer("advisor_confidence", move |_def| {
+        Ok(Box::new(
+            ta_workflow::graph::nodes::AdvisorConfidenceReviewer::with_thresholds(thresholds),
+        ) as Box<dyn ReviewerNode>)
+    });
+    registry
+}
+
+/// Run the one graph instance `ta draft apply`'s approval gate calls
+/// (constitution §16.3). Loads `.ta/workflows/graphs/draft-apply-gate.toml`
+/// if the project has authored one; otherwise runs
+/// `default_apply_gate_graph_def()`, matching the gate's pre-v0.17.7.3
+/// inline behavior exactly. A malformed (but present) custom graph is a
+/// hard error, not a silent fallback — the human authored it, they need to
+/// know it's broken.
+pub fn run_apply_gate(
+    config: &GatewayConfig,
+    review_input: &ReviewInput,
+    thresholds: ta_decision::DecisionThresholds,
+) -> anyhow::Result<Decision> {
+    let def = match GraphDefinition::load_named(&config.workspace_root, "draft-apply-gate") {
+        Ok(def) => def,
+        Err(GraphError::Io { source, .. }) if source.kind() == std::io::ErrorKind::NotFound => {
+            default_apply_gate_graph_def()
+        }
+        Err(e) => anyhow::bail!(
+            "failed to load .ta/workflows/graphs/draft-apply-gate.toml: {e}\n\
+             Fix the graph definition, or delete the file to use the built-in default gate."
+        ),
+    };
+    let registry = build_apply_gate_registry(config.clone(), thresholds);
+    let mut ctx = GraphContext::new(&config.workspace_root, uuid::Uuid::new_v4().to_string());
+    if let Some(draft_id) = &review_input.draft_id {
+        ctx.vars.insert("draft_id".to_string(), draft_id.clone());
+    }
+    let outcome = ta_workflow::graph::run_graph(
+        &def,
+        &registry,
+        &WorkItem::default(),
+        review_input,
+        &mut ctx,
+    )
+    .map_err(|e| anyhow::anyhow!("draft-apply-gate graph run failed: {e}"))?;
+    outcome.decision.ok_or_else(|| {
+        anyhow::anyhow!(
+            "draft-apply-gate graph produced no [decision] — check the graph definition \
+             has a [decision] block"
+        )
+    })
 }
 
 /// Resolve this project's configured `SourceAdapter` the same way
@@ -1263,6 +1549,161 @@ persona = "creative-generator"
         assert_eq!(
             outcomes[1].metadata.get("escalated").map(String::as_str),
             Some("true")
+        );
+    }
+
+    // ── AgentPanelReviewer / EscalateAction (v0.17.7.3) ──────────────────
+
+    #[test]
+    fn agent_panel_reviewer_reads_a_pre_existing_verdict_without_redispatching() {
+        let project = TempDir::new().unwrap();
+        let config = GatewayConfig::for_project(project.path());
+        let ctx = GraphContext::new(project.path(), "run-panel-pre-existing");
+
+        let verdict_dir = ctx.run_dir.join("reviewers").join("head_of_security");
+        std::fs::create_dir_all(&verdict_dir).unwrap();
+        std::fs::write(
+            verdict_dir.join("verdict.json"),
+            serde_json::json!({"score": 0.9, "findings": ["looks fine"]}).to_string(),
+        )
+        .unwrap();
+
+        let reviewer = AgentPanelReviewer::new(config.clone(), "head_of_security");
+        let vote = reviewer
+            .review(&ReviewInput::default(), &ctx)
+            .expect("review must succeed reading the pre-existing verdict");
+
+        assert_eq!(vote.score, 0.9);
+        assert_eq!(vote.findings, vec!["looks fine".to_string()]);
+        assert!(!vote.timed_out);
+
+        let store = ta_goal::GoalRunStore::new(&config.goals_dir).unwrap();
+        assert!(
+            store.list().unwrap().is_empty(),
+            "must not dispatch a review goal when a verdict already exists"
+        );
+    }
+
+    #[test]
+    fn agent_panel_reviewer_dispatches_then_times_out_when_no_verdict_appears() {
+        let project = TempDir::new().unwrap();
+        std::fs::write(project.path().join("README.md"), "# Original\n").unwrap();
+        let config = GatewayConfig::for_project(project.path());
+        let ctx = GraphContext::new(project.path(), "run-panel-timeout");
+
+        let mut reviewer = AgentPanelReviewer::new(config.clone(), "pm");
+        reviewer.poll_interval = std::time::Duration::ZERO;
+        reviewer.max_polls = 1;
+
+        let vote = reviewer
+            .review(
+                &ReviewInput {
+                    draft_id: Some("draft-1".to_string()),
+                    ..Default::default()
+                },
+                &ctx,
+            )
+            .unwrap();
+
+        assert!(vote.timed_out);
+        assert_eq!(vote.score, 0.0);
+
+        let store = ta_goal::GoalRunStore::new(&config.goals_dir).unwrap();
+        assert!(
+            store
+                .list()
+                .unwrap()
+                .iter()
+                .any(|g| g.title.contains("Panel review (pm)")),
+            "must actually dispatch a review goal via GoalDispatchAction machinery, \
+             not a stub, even though no verdict ever arrived"
+        );
+    }
+
+    #[test]
+    fn escalate_action_never_applies_and_records_a_notification_event() {
+        let project = TempDir::new().unwrap();
+        let ctx = GraphContext::new(project.path(), "run-escalate-test");
+        let action = EscalateAction::new(project.path());
+
+        let decision = Decision {
+            score: 0.3,
+            proceed: false,
+            algorithm_used: ta_workflow::consensus::ConsensusAlgorithm::Weighted,
+            scores_by_role: HashMap::new(),
+            findings_by_role: HashMap::new(),
+            timed_out_roles: vec![],
+            override_active: false,
+            summary: "panel did not clear threshold".to_string(),
+        };
+        let outcome = action.act(&decision, &ctx).unwrap();
+
+        assert!(!outcome.applied, "EscalateAction must never apply");
+        assert_eq!(outcome.kind, "escalate");
+
+        use ta_events::schema::SessionEvent;
+        use ta_events::store::{EventQueryFilter, EventStore, FsEventStore};
+        let store = FsEventStore::new(&action.events_dir);
+        let events = store.query(&EventQueryFilter::default()).unwrap();
+        assert!(
+            events.iter().any(|e| matches!(
+                &e.payload,
+                SessionEvent::GraphDecisionEscalated { run_id, .. } if run_id == "run-escalate-test"
+            )),
+            "must record a GraphDecisionEscalated event for the notification system to pick up"
+        );
+    }
+
+    #[test]
+    fn reference_phase_review_panel_graph_lets_the_panel_outweigh_a_denied_policy_check() {
+        // Loads the actual shipped template (templates/workflows/graphs/
+        // phase-review-panel.toml) — proves it's not just documentation, it
+        // really parses and runs through this exact registry. `policy_check`
+        // is denied by default (bare `PolicyDocument`, §1.3 human-in-the-loop
+        // default) but the three agent_panel votes (weight 3.5 of 4.5) still
+        // clear the 0.75 threshold, matching the weighted-average math in
+        // the design spec §3 worked example.
+        let project = TempDir::new().unwrap();
+        let config = GatewayConfig::for_project(project.path());
+        let ctx = GraphContext::new(project.path(), "run-reference-panel");
+
+        for role in ["pm", "head_of_security", "head_of_engineering"] {
+            let verdict_dir = ctx.run_dir.join("reviewers").join(role);
+            std::fs::create_dir_all(&verdict_dir).unwrap();
+            std::fs::write(
+                verdict_dir.join("verdict.json"),
+                serde_json::json!({"score": 1.0, "findings": []}).to_string(),
+            )
+            .unwrap();
+        }
+
+        let template_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../templates/workflows/graphs/phase-review-panel.toml");
+        let def = GraphDefinition::load_file(&template_path).unwrap();
+        let registry = build_registry(config);
+
+        let mut ctx = ctx;
+        let outcome = ta_workflow::graph::run_graph(
+            &def,
+            &registry,
+            &WorkItem::default(),
+            &ReviewInput::default(),
+            &mut ctx,
+        )
+        .unwrap();
+
+        assert_eq!(outcome.votes.len(), 4);
+        let decision = outcome.decision.unwrap();
+        assert!(
+            decision.proceed,
+            "panel votes (weight 3.5/4.5) must outweigh the denied policy check: score={:.4}",
+            decision.score
+        );
+        let action_outcome = outcome.action_outcome.unwrap();
+        assert_eq!(action_outcome.kind, "recommend");
+        assert!(
+            !action_outcome.applied,
+            "the shipped template defaults to recommend, per constitution §16.2"
         );
     }
 }

--- a/apps/ta-cli/tests/constitution_16_3_call_site.rs
+++ b/apps/ta-cli/tests/constitution_16_3_call_site.rs
@@ -1,0 +1,157 @@
+// constitution_16_3_call_site.rs — Enforces constitution §16.3's named
+// call-site invariant at CI time (v0.17.7.3), not just in prose: a PR that
+// adds a new direct caller of `should_auto_approve_draft`,
+// `check_advisor_auto_approve`, or `run_consensus` for the purpose of gating
+// an apply/merge decision must fail this test unless the new call site is
+// added to one of the allowlists below with a comment justifying it (the
+// same "documented deviation" pattern PLAN.md itself uses).
+//
+// This is a grep-based structural check, not a full Rust-aware call-graph
+// analysis — it can't distinguish "gating" from "non-gating" uses of these
+// functions on its own, which is why the allowlists below exist: each entry
+// documents *why* that file is allowed to reference the function by name.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// Files allowed to reference `should_auto_approve_draft` by name.
+fn policy_auto_approve_allowlist() -> HashSet<&'static str> {
+    [
+        // Definition + its own internal fallback caller.
+        "crates/ta-policy/src/auto_approve.rs",
+        // The one sanctioned graph-engine wrapper (constitution §16.1).
+        "crates/ta-workflow/src/graph/nodes/policy_reviewer.rs",
+        // `ta policy check` — a read-only dry-run diagnostic that prints
+        // "WOULD AUTO-APPROVE"/"WOULD NOT AUTO-APPROVE"; it never applies or
+        // blocks anything itself, so it isn't a gating call site.
+        "apps/ta-cli/src/commands/policy.rs",
+        // MCP submit-time convenience auto-approve (verification-command
+        // execution + git_commit config, not the terminal apply/merge gate
+        // constitution §16.3 targets). Explicitly scoped out of this
+        // migration per v0.17.7.3's decision log — revisit if this path
+        // grows its own apply-time authority beyond submit-time routing.
+        "crates/ta-mcp-gateway/src/tools/draft.rs",
+    ]
+    .into_iter()
+    .collect()
+}
+
+/// Files allowed to reference `check_advisor_auto_approve` by name.
+fn check_advisor_auto_approve_allowlist() -> HashSet<&'static str> {
+    [
+        // Definition only — confirmed dead code with zero production
+        // callers as of v0.17.7.3 (superseded by the graph engine's
+        // `AdvisorConfidenceReviewer`, which reimplements the same
+        // `ta_decision::decide()` check rather than wrapping this function).
+        "crates/ta-session/src/advisor_agent.rs",
+    ]
+    .into_iter()
+    .collect()
+}
+
+/// Files allowed to reference `run_consensus` by name.
+fn run_consensus_allowlist() -> HashSet<&'static str> {
+    [
+        // Definition + its own tests.
+        "crates/ta-workflow/src/consensus/mod.rs",
+        // The one sanctioned graph-engine wrapper (constitution §16.1).
+        "crates/ta-workflow/src/graph/nodes/weighted_decision.rs",
+        // Generic `kind = "consensus"` pipeline-stage executor for the
+        // step-based Workflow TOML engine — gates whether a *stage*
+        // proceeds (config-driven since v0.17.7.3), not `ta draft apply`'s
+        // approval gate specifically. Not in scope for the §16.3 migration,
+        // which targets the apply/merge gate named in the constitution text.
+        "apps/ta-cli/src/commands/governed_workflow.rs",
+    ]
+    .into_iter()
+    .collect()
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+/// Recursively collect every `.rs` file under `dir`, skipping `target/`.
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if path.file_name().and_then(|n| n.to_str()) == Some("target") {
+                continue;
+            }
+            collect_rs_files(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Assert that every `.rs` file under `crates/` and `apps/` containing a
+/// call-syntax occurrence of `needle` (`"foo("`) is in `allowlist` (paths
+/// relative to the workspace root, `/`-separated).
+fn assert_only_allowlisted_callers(needle: &str, allowlist: &HashSet<&'static str>) {
+    let root = workspace_root();
+    let mut files = Vec::new();
+    for sub in ["crates", "apps"] {
+        collect_rs_files(&root.join(sub), &mut files);
+    }
+
+    let pattern = format!("{needle}(");
+    let mut offenders = Vec::new();
+    for file in &files {
+        let Ok(content) = std::fs::read_to_string(file) else {
+            continue;
+        };
+        if !content.contains(&pattern) {
+            continue;
+        }
+        let rel = file
+            .strip_prefix(&root)
+            .unwrap_or(file)
+            .to_string_lossy()
+            .replace('\\', "/");
+        // This file itself names all three functions in allowlist comments
+        // and error messages — not a call site.
+        if rel == "apps/ta-cli/tests/constitution_16_3_call_site.rs" {
+            continue;
+        }
+        if !allowlist.contains(rel.as_str()) {
+            offenders.push(rel);
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "constitution §16.3 violation: found a new, non-allowlisted reference to \
+         `{needle}(` in {offenders:?}. `ta draft apply`'s approval check must call \
+         exactly one graph instance (see apps/ta-cli/src/commands/workflow_graph.rs \
+         ::run_apply_gate) — new gating logic must be a ReviewerNode/DecisionNode fed \
+         into that graph, not a new direct caller of `{needle}`. If this reference is \
+         genuinely not a gating call site, add it to the allowlist in \
+         apps/ta-cli/tests/constitution_16_3_call_site.rs with a comment explaining why."
+    );
+}
+
+#[test]
+fn no_new_direct_callers_of_should_auto_approve_draft() {
+    assert_only_allowlisted_callers(
+        "should_auto_approve_draft",
+        &policy_auto_approve_allowlist(),
+    );
+}
+
+#[test]
+fn no_new_direct_callers_of_check_advisor_auto_approve() {
+    assert_only_allowlisted_callers(
+        "check_advisor_auto_approve",
+        &check_advisor_auto_approve_allowlist(),
+    );
+}
+
+#[test]
+fn no_new_direct_callers_of_run_consensus() {
+    assert_only_allowlisted_callers("run_consensus", &run_consensus_allowlist());
+}

--- a/crates/ta-daemon/src/notification_dispatcher.rs
+++ b/crates/ta-daemon/src/notification_dispatcher.rs
@@ -187,6 +187,12 @@ fn default_template(event: &EventEnvelope) -> NotificationTemplate {
             "[TA] Agent waiting for input".into(),
             "An agent is waiting for your response. Check `ta shell` or the TA Studio.".into(),
         ),
+        "graph_decision_escalated" => (
+            "[TA] Review panel escalated a decision".into(),
+            "A workflow graph decision did not clear its threshold and was escalated for \
+             human review. Run `ta workflow graph-run` output or check the draft directly."
+                .into(),
+        ),
         _ => (
             "[TA] {event_type}".into(),
             "Event `{event_type}` at {timestamp}.".into(),

--- a/crates/ta-events/src/notification.rs
+++ b/crates/ta-events/src/notification.rs
@@ -41,7 +41,10 @@ impl NotificationSeverity {
         match event_type {
             "policy_violation" => Self::Critical,
             "goal_failed" | "build_failed" | "sync_conflict" | "api_connection_lost" => Self::Error,
-            "agent_needs_input" | "question_stale" | "draft_denied" => Self::Warning,
+            "agent_needs_input"
+            | "question_stale"
+            | "draft_denied"
+            | "graph_decision_escalated" => Self::Warning,
             _ => Self::Info,
         }
     }

--- a/crates/ta-events/src/schema.rs
+++ b/crates/ta-events/src/schema.rs
@@ -437,6 +437,17 @@ pub enum SessionEvent {
         conflicts: usize,
         coverage_gaps: usize,
     },
+
+    /// A workflow graph's `DecisionNode` did not clear its threshold and was
+    /// routed to `EscalateAction` (v0.17.7.3, constitution §16.1/§16.2) —
+    /// the graph halts at this node rather than auto-approving or silently
+    /// recommending.
+    GraphDecisionEscalated {
+        run_id: String,
+        draft_id: Option<Uuid>,
+        score: f64,
+        summary: String,
+    },
 }
 
 /// A single issue found during a watchdog health check (v0.11.2.4).
@@ -493,6 +504,7 @@ impl SessionEvent {
             Self::VcsChangelistSubmitted { .. } => "vcs.changelist_submitted",
             Self::PrCheckFailed { .. } => "pr_check_failed",
             Self::ReviewCompleted { .. } => "review_completed",
+            Self::GraphDecisionEscalated { .. } => "graph_decision_escalated",
         }
     }
 

--- a/docs/TA-CONSTITUTION.md
+++ b/docs/TA-CONSTITUTION.md
@@ -393,7 +393,7 @@ The VCS Submit Invariant applies to all current built-in adapters (git, svn, per
 
 ## 16. Workflow Graph & Modular Decision Nodes
 
-> **DRAFT — pending user approval, not yet in the Appendix checklist.** Added 2026-07-21 alongside `docs/superpowers/specs/2026-07-21-workflow-graph-engine-design.md`, red-teamed by three adversarial passes (PM, head of engineering, non-technical user) same day. Not yet enforced. This banner and the missing checklist rows are the graduation gate: remove the banner and add §16 rows to the Appendix table only once v0.17.7.1 ships and this section has been through normal review — don't let enforcement start silently just because the code exists.
+> **Graduated 2026-08-15 (v0.17.7.3).** Added 2026-07-21 alongside `docs/superpowers/specs/2026-07-21-workflow-graph-engine-design.md`, red-teamed by three adversarial passes (PM, head of engineering, non-technical user) same day. §16.3's call-site invariant is now enforced in code: `ta draft apply`'s approval gate calls exactly one graph instance (`apps/ta-cli/src/commands/workflow_graph.rs::run_apply_gate`) instead of calling `should_auto_approve_draft`/`check_advisor_auto_approve`/`run_consensus` directly. See the Appendix Compliance Checklist below for the enforced rows.
 
 **Why this section exists**: found 2026-07-20, during this session's autonomous multi-phase run — `ta_policy::auto_approve::should_auto_approve_draft`, `ta_session::advisor_agent::check_advisor_auto_approve`, and the governed-workflow consensus engine (`stage_consensus`/`stage_apply_draft`) each independently decide whether to auto-approve a draft apply, with no shared gate and no awareness of one another; a consensus-approved draft today bypasses the other two entirely. Separately, `execute_pr_merged_continuation` (v0.17.0.12.31) is wired directly to Git/GitHub semantics rather than the project's own `SourceAdapter` abstraction, and has no way to inspect *why* a CI check failed. This section exists to stop a fourth disconnected approval mechanism and a second platform-specific trigger path from being built, the same way §1.6/§1.7/§1.8 exist to stop their own named incidents from recurring.
 
@@ -424,7 +424,8 @@ For pre-release review, verify each command against these rules:
 |---------|-----------|
 | `ta run` | 4.1-4.4 (injection/cleanup), 5.1-5.2 (state machine) |
 | `ta draft build` | 4.3 (cleanup before diff), 3.2 (infrastructure exclusion) |
-| `ta draft apply` | 2.1-2.2 (branch isolation + restoration), 2.4 (default submit), 7.3 (audit) |
+| `ta draft apply` | 2.1-2.2 (branch isolation + restoration), 2.4 (default submit), 7.3 (audit), 16.1-16.3 (single graph approval gate) |
+| `ta workflow graph-run` | 16.1-16.2 (recommend/auto-approve, same decision), 16.4 (VCS-adapter-mediated triggers), 16.5 (data-defined graphs) |
 | `ta draft deny` | 7.4 (terminal audit), 10.1 (state transition) |
 | `ta goal start` | 3.1 (staging copy), 5.1 (Created → Configured) |
 | `ta goal list` | 5.6 (traceability — failed+staging goals visible by default) |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -499,12 +499,14 @@ Workflow graphs are a separate, lower-level engine (`ta-workflow::graph`) from t
 | Node | Role | Built-in kinds |
 |---|---|---|
 | `[[worker]]` | Dispatches new work (starts a goal) | `goal_dispatch` |
-| `[[reviewer]]` | Produces one scored vote on a draft/decision | `policy`, `advisor_confidence` |
+| `[[reviewer]]` | Produces one scored vote on a draft/decision | `policy`, `advisor_confidence`, `agent_panel` |
 | `[decision]` | Fans in every reviewer vote, applies weights/threshold/algorithm | `weighted` |
-| `[action]` | Acts on the decision | `recommend`, `auto_approve`, `corrective_goal` |
+| `[action]` | Acts on the decision | `recommend`, `auto_approve`, `corrective_goal`, `escalate` |
 | `[[trigger]]` | Fires on an external event — parses and is runnable standalone via `ta workflow watch-ci` today; full `ta workflow graph-run` wiring lands in a later release | `vcs_task_completion`, `ci_failure` |
 
-**Recommendation vs. auto-approval is the same decision, different wiring.** A `[decision]` node never encodes whether its output is binding or advisory — that's purely which `[action] kind` the graph is wired to. Swap `kind = "recommend"` for `kind = "auto_approve"` in an otherwise identical graph, and the exact same decision goes from "surfaced to a human" to "applied automatically." **New graphs default to `recommend`** — a human must explicitly edit a graph to `auto_approve` before it can act on its own.
+**Recommendation vs. auto-approval is the same decision, different wiring.** A `[decision]` node never encodes whether its output is binding or advisory — that's purely which `[action] kind` the graph is wired to. Swap `kind = "recommend"` for `kind = "auto_approve"` in an otherwise identical graph, and the exact same decision goes from "surfaced to a human" to "applied automatically." **New graphs default to `recommend`** — a human must explicitly edit a graph to `auto_approve` before it can act on its own. `kind = "escalate"` is a third option: it records a `graph_decision_escalated` event (picked up by the existing notification-rules engine) and halts the graph at that node — neither applying nor silently recommending.
+
+**Multi-role review panels with `agent_panel`.** Each `[[reviewer]] kind = "agent_panel"` entry spawns a role-persona agent (`role = "head_of_security"`, `role = "pm"`, anything — `TeamRole` is a free-text string, so a new panel member is a TOML edit, not a Rust change) to review the current draft. The persona agent writes its verdict to `.ta/workflow-runs/<run-id>/graph/reviewers/<role>/verdict.json` as `{"score": <0.0-1.0>, "findings": ["..."]}`; the reviewer node polls for that file and reports a `timed_out` vote if it never appears.
 
 Reference graph (also shipped at `templates/workflows/graphs/phase-review-panel.toml` — copy it to `.ta/workflows/graphs/<name>.toml` to use):
 
@@ -513,13 +515,28 @@ Reference graph (also shipped at `templates/workflows/graphs/phase-review-panel.
 id = "policy_check"
 kind = "policy"
 
+[[reviewer]]
+id = "pm_score"
+kind = "agent_panel"
+role = "pm"
+
+[[reviewer]]
+id = "security_score"
+kind = "agent_panel"
+role = "head_of_security"
+
+[[reviewer]]
+id = "engineering_score"
+kind = "agent_panel"
+role = "head_of_engineering"
+
 [decision]
 id = "panel_verdict"
 kind = "weighted"
 algorithm = "weighted"   # "raft" | "paxos" | "weighted"
 threshold = 0.75
-inputs = ["policy_check"]
-weights = { policy_check = 1.0 }
+inputs = ["policy_check", "pm_score", "security_score", "engineering_score"]
+weights = { policy_check = 1.0, pm_score = 1.0, security_score = 1.5, engineering_score = 1.0 }
 
 [action]
 id = "outcome"
@@ -532,6 +549,10 @@ Run it with:
 ```bash
 ta workflow graph-run phase-review-panel --title "My draft" --verb implement
 ```
+
+### `ta draft apply`'s Approval Gate: One Graph Instance
+
+Per constitution §16.3, `ta draft apply`'s real approval check calls exactly one graph instance — it no longer calls `should_auto_approve_draft`, `check_advisor_auto_approve`, or `run_consensus` directly. By default (no graph file present) it runs the same single-reviewer `advisor_confidence` check the CLI has always run, expressed as a graph. To upgrade the gate to a full review panel without touching any Rust code, author `.ta/workflows/graphs/draft-apply-gate.toml` (the `phase-review-panel.toml` shape above works as-is, or extend it with `advisor_confidence`) — `ta draft apply` picks it up automatically on the next run. A malformed custom graph file is a hard error (not a silent fallback to the default), so a typo in your override is caught immediately rather than quietly ignored.
 
 **Dispatching work with `[[worker]]`.** A `goal_dispatch` worker starts a new goal via `ta goal start`, feeding `--verb`/`--workload-hint` straight into the existing routing brain's workload-type classification — no new Rust code is needed to add a new kind of work, only a `[workload_types.<verb>]` binding in `.ta/workflow.toml`:
 

--- a/templates/workflows/graphs/phase-review-panel.toml
+++ b/templates/workflows/graphs/phase-review-panel.toml
@@ -1,14 +1,25 @@
-# phase-review-panel.toml — Workflow Graph Engine reference graph (v0.17.7.1).
+# phase-review-panel.toml — Workflow Graph Engine reference graph
+# (v0.17.7.1, upgraded to a multi-role panel in v0.17.7.3).
 #
 # Copy this file to .ta/workflows/graphs/phase-review-panel.toml (or any
 # other name) then run:
 #   ta workflow graph-run phase-review-panel --title "My draft" --verb implement
 #
-# This graph expresses today's existing single-reviewer approval flow as
-# data: a policy check feeds a weighted decision, which surfaces to a human
-# via RecommendAction. Per constitution §16.2, every new graph defaults to
-# `recommend` — a human must explicitly change `[action] kind` to
-# "auto_approve" to let this graph apply drafts on its own.
+# A policy check plus a three-person review panel (PM, head of security,
+# head of engineering — each an `agent_panel` reviewer spawned via
+# `GoalDispatchAction`'s dispatch machinery) all feed one weighted decision,
+# which surfaces to a human via RecommendAction. Per constitution §16.2,
+# every new graph defaults to `recommend` — a human must explicitly change
+# `[action] kind` to "auto_approve" to let this graph apply drafts on its
+# own. Per §16.5, the threshold/algorithm/weights below are data — edit them
+# directly, no code change needed.
+#
+# `agent_panel`'s `role` is a free-text string (constitution §1.6:
+# `TeamRole` is data-defined, not a closed enum) — add or rename panel
+# members by adding another `[[reviewer]]` block with a new `role`, no core
+# change required. Each panel member's persona agent writes its verdict to
+# `.ta/workflow-runs/<run-id>/graph/reviewers/<role>/verdict.json` as
+# `{"score": <0.0-1.0>, "findings": ["..."]}`.
 #
 # See docs/superpowers/specs/2026-07-21-workflow-graph-engine-design.md §3
 # for the full design this schema implements, and docs/USAGE.md's
@@ -18,13 +29,28 @@
 id = "policy_check"
 kind = "policy"
 
+[[reviewer]]
+id = "pm_score"
+kind = "agent_panel"
+role = "pm"
+
+[[reviewer]]
+id = "security_score"
+kind = "agent_panel"
+role = "head_of_security"
+
+[[reviewer]]
+id = "engineering_score"
+kind = "agent_panel"
+role = "head_of_engineering"
+
 [decision]
 id = "panel_verdict"
 kind = "weighted"
 algorithm = "weighted"   # "raft" | "paxos" | "weighted" — closed enum per §16.5
 threshold = 0.75
-inputs = ["policy_check"]
-weights = { policy_check = 1.0 }
+inputs = ["policy_check", "pm_score", "security_score", "engineering_score"]
+weights = { policy_check = 1.0, pm_score = 1.0, security_score = 1.5, engineering_score = 1.0 }
 
 [action]
 id = "outcome"


### PR DESCRIPTION
## Summary
- `AgentPanelReviewer` — spawns a role-persona agent (any `TeamRole` string) via `GoalDispatchAction`'s dispatch machinery, polls for a scored `ReviewerVote`.
- `WeightedDecisionNode`'s threshold/algorithm/weights now read from graph TOML instead of `governed_workflow.rs`'s hardcoded literals.
- **Constitution §16.3 enforcement**: `ta draft apply`'s real approval gate now calls one graph instance (`workflow_graph::run_apply_gate`), defaulting to exactly-equivalent behavior unless a project authors `.ta/workflows/graphs/draft-apply-gate.toml`. Two other direct callers of the three named functions were found and deliberately left unmigrated with documented, CI-enforced rationale (`apps/ta-cli/tests/constitution_16_3_call_site.rs`) — neither is an apply/merge decision per §16.3's own wording (MCP submit-time auto-approve; the generic step-workflow consensus stage).
- `EscalateAction` — records a `SessionEvent::GraphDecisionEscalated` through the existing notification system, halts the graph.
- Reference graph `templates/workflows/graphs/phase-review-panel.toml` upgraded to the full four-reviewer panel from the design spec.
- USAGE.md updated; constitution §16's DRAFT banner graduated, Appendix Compliance Checklist rows added.

## Test plan
- New coverage for both new node kinds, the reference graph, and a CI-enforced allowlist test locking in the §16.3 invariant.
- `cargo build --workspace`, `cargo test --workspace` (1560 passed, 0 failed), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` all pass in an isolated worktree.