### PR TITLE
v0.17.6.3.1 — Draft Rebuild Window: Allow Rebuilding from pr_ready/approved

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -10131,17 +10131,17 @@ Code releases use semver. Content releases don't. Decide:
 
 ---
 ### v0.17.6.3.1 — Draft Rebuild Window: Allow Rebuilding from `pr_ready`/`approved`
-<!-- status: in_progress -->
+<!-- status: done -->
 **Depends on**: none
 
 **Why this exists**: found live, repeatedly, across this entire v0.17.5.x/v0.17.6.x arc (v0.17.5.1, v0.17.5.2, v0.17.5.3, v0.17.6.1, v0.17.6.2, v0.17.6.3 — six phases in a row, not a one-off). `ta draft build` refuses to rebuild once the parent goal has left `running`/`finalizing` state — `apps/ta-cli/src/commands/draft.rs:1964`, `"Goal is in {} state (must be running or finalizing to build draft)"`. In practice, review happens *after* a goal reaches `pr_ready`, so any bug found during review (however small) is architecturally unfixable through TA's own draft-build/apply path — the draft can never be live-patched. The only recovery every time this session was a full manual `git worktree` bypass: copy files out of staging by hand, fix, re-run the full verify suite, commit/push/PR/merge outside TA entirely. That is a TA product gap, not a one-off review inconvenience — the human reviewer should be able to fix a small issue and re-request a draft build without leaving the tool.
 
 **Items**:
-1. [ ] Extend the goal state machine (or add a narrow, explicitly-scoped exception) so `ta draft build` can rebuild from `pr_ready`/`approved` when the underlying staging workspace still exists and hasn't been torn down — re-diff against the (possibly hand-edited) staging directory rather than requiring a fresh agent run.
-2. [ ] Decide and document the trust boundary: rebuilding from `pr_ready` implies the *reviewer*, not the agent, may have edited staging directly — the resulting draft's provenance (agent-authored vs. reviewer-amended) should be visible in `ta draft view`, not silently blended.
-3. [ ] `ta draft build --latest` (and any explicit `--goal <id>` form) should surface a clear, actionable error distinguishing "goal genuinely finished/torn down, nothing to rebuild" from "goal is in a state that could support a rebuild but doesn't yet" — today both cases produce the same dead-end message.
-4. [ ] Tests: a goal that reaches `pr_ready`, gets a staging edit, and calls `ta draft build` again produces an updated draft reflecting the edit, without requiring a new goal run.
-5. [ ] USAGE.md: document the rebuild-from-`pr_ready` flow as the expected way to fix small review findings, replacing the manual-worktree-finish workaround in practice (not just in docs).
+1. [x] Extend the goal state machine (or add a narrow, explicitly-scoped exception) so `ta draft build` can rebuild from `pr_ready`/`approved` when the underlying staging workspace still exists and hasn't been torn down — re-diff against the (possibly hand-edited) staging directory rather than requiring a fresh agent run.
+2. [x] Decide and document the trust boundary: rebuilding from `pr_ready` implies the *reviewer*, not the agent, may have edited staging directly — the resulting draft's provenance (agent-authored vs. reviewer-amended) should be visible in `ta draft view`, not silently blended.
+3. [x] `ta draft build --latest` (and any explicit `--goal <id>` form) should surface a clear, actionable error distinguishing "goal genuinely finished/torn down, nothing to rebuild" from "goal is in a state that could support a rebuild but doesn't yet" — today both cases produce the same dead-end message.
+4. [x] Tests: a goal that reaches `pr_ready`, gets a staging edit, and calls `ta draft build` again produces an updated draft reflecting the edit, without requiring a new goal run.
+5. [x] USAGE.md: document the rebuild-from-`pr_ready` flow as the expected way to fix small review findings, replacing the manual-worktree-finish workaround in practice (not just in docs).
 
 #### Version: `0.17.6-alpha.3.1`
 

--- a/apps/ta-cli/src/commands/constitution.rs
+++ b/apps/ta-cli/src/commands/constitution.rs
@@ -1635,6 +1635,7 @@ fn create_constitution_amend_draft(
         draft_seq: 1,
         plan_phase: None,
         plan_md_base: None,
+        rebuilt_from: None,
     };
 
     super::draft::save_package(config, &pkg)
@@ -2443,6 +2444,7 @@ fn create_review_draft(
         draft_seq: 1,
         plan_phase: None,
         plan_md_base: None,
+        rebuilt_from: None,
     };
 
     super::draft::save_package(config, &pkg)

--- a/apps/ta-cli/src/commands/draft.rs
+++ b/apps/ta-cli/src/commands/draft.rs
@@ -16,8 +16,8 @@ use ta_changeset::draft_package::{
     assess_risk, AgentIdentity, AlternativeConsidered, AmendmentRecord, AmendmentType,
     ApplyProvenance, ApprovalRecord, Artifact, ArtifactDisposition, ChangeDependency, ChangeType,
     Changes, DecisionLogEntry, DependencyKind, DraftPackage, DraftStatus, ExplanationTiers, Goal,
-    Iteration, Plan, Provenance, RequestedAction, ReviewRequests, Signatures, Summary,
-    VerificationWarning, WorkspaceRef,
+    Iteration, Plan, Provenance, RebuildProvenance, RequestedAction, ReviewRequests, Signatures,
+    Summary, VerificationWarning, WorkspaceRef,
 };
 use ta_changeset::explanation::ExplanationSidecar;
 use ta_changeset::output_renderers::{
@@ -53,14 +53,22 @@ pub fn load_excludes_with_adapter(source_dir: &std::path::Path) -> ExcludePatter
 #[derive(Debug, Subcommand)]
 pub enum DraftCommands {
     /// Build a draft package from overlay workspace diffs.
+    ///
+    /// Also rebuilds an existing draft (v0.17.6.3.1): running this again against a
+    /// goal already at `pr_ready`/`approved` re-diffs the still-live staging
+    /// workspace — e.g. after hand-editing a small fix a reviewer found — instead of
+    /// requiring a fresh agent run. The prior draft is marked superseded and the new
+    /// one records `rebuilt_from` provenance so `ta draft view` shows it was rebuilt
+    /// from a non-running goal state.
     Build {
-        /// Goal run ID (omit with --latest to use most recent running goal).
+        /// Goal run ID (omit with --latest to use most recent running/rebuildable goal).
         #[arg(default_value = "")]
         goal_id: String,
         /// Summary of what changed and why.
         #[arg(long, default_value = "Changes from agent work")]
         summary: String,
-        /// Use the most recent running goal instead of specifying an ID.
+        /// Use the most recent running goal, or the most recent pr_ready/approved
+        /// goal if none is running, instead of specifying an ID.
         #[arg(long)]
         latest: bool,
         /// Path to a JSON context file to patch into the draft after building
@@ -1937,13 +1945,33 @@ pub(crate) fn build_package(
     let goal_store = GoalRunStore::new(&config.goals_dir)?;
 
     // Resolve the goal — either by ID or by finding the latest running goal.
+    // v0.17.6.3.1: if no goal is actively Running, fall back to the most recently
+    // updated pr_ready/approved goal as a rebuild candidate — `--latest` should
+    // resolve a rebuild target the same way an explicit `--goal <id>` would.
     let goal = if latest || goal_id.is_empty() {
         let goals = goal_store.list()?;
         goals
-            .into_iter()
+            .iter()
             .find(|g| matches!(g.state, GoalRunState::Running))
+            .cloned()
+            .or_else(|| {
+                let mut candidates: Vec<_> = goals
+                    .iter()
+                    .filter(|g| {
+                        matches!(
+                            g.state,
+                            GoalRunState::PrReady | GoalRunState::Approved { .. }
+                        )
+                    })
+                    .collect();
+                candidates.sort_by_key(|g| Reverse(g.updated_at));
+                candidates.into_iter().next().cloned()
+            })
             .ok_or_else(|| {
-                anyhow::anyhow!("No running goal found (use a goal ID or start a goal first)")
+                anyhow::anyhow!(
+                    "No running goal found, and no pr_ready/approved goal available to \
+                     rebuild (use a goal ID or start a goal first)"
+                )
             })?
     } else {
         let goal_uuid = resolve_goal_id_from_store(goal_id, &goal_store)?;
@@ -1956,15 +1984,74 @@ pub(crate) fn build_package(
     // v0.13.17.2: Accept both Running and Finalizing — the Finalizing state means
     // ta run exited and is building the draft; manual `ta draft build` during recovery
     // should work without requiring a state transition back to Running.
+    //
+    // v0.17.6.3.1: Draft Rebuild Window — also accept `pr_ready`/`approved`. Review
+    // happens after a goal reaches `pr_ready`, so a small bug found in review was
+    // previously architecturally unfixable through TA's own build/apply path (the
+    // only recovery was a manual git-worktree bypass entirely outside TA). Rebuilding
+    // re-diffs the still-live staging workspace instead of requiring a fresh agent run.
+    let is_rebuild = matches!(
+        goal.state,
+        GoalRunState::PrReady | GoalRunState::Approved { .. }
+    );
+
     if !matches!(
         goal.state,
         GoalRunState::Running | GoalRunState::Finalizing { .. }
-    ) {
+    ) && !is_rebuild
+    {
         anyhow::bail!(
-            "Goal is in {} state (must be running or finalizing to build draft)",
-            goal.state
+            "Goal {} is in {} state, which does not support building or rebuilding a draft.\n\
+            \n\
+            Draft build/rebuild only works from these states:\n\
+            - running / finalizing — the agent is actively working or just exited\n\
+            - pr_ready / approved — a draft already exists and can be rebuilt from staging\n\
+            \n\
+            This goal has moved past the rebuild window (e.g. applied, merged, completed, \
+            denied, or failed) — its staging workspace may no longer reflect anything \
+            reviewable. To make further changes, start a follow-up goal:\n\
+            ta run \"<title>\" --follow-up-goal {}",
+            goal_id,
+            goal.state,
+            goal_id
         );
     }
+
+    if is_rebuild && !goal.workspace_path.exists() {
+        anyhow::bail!(
+            "Goal {} is in {} state but its staging workspace ({}) no longer exists — \
+            nothing to rebuild. The goal genuinely finished its lifecycle and was torn \
+            down (this is different from a goal that could still support a rebuild but \
+            doesn't yet — that case proceeds automatically). To make further changes, \
+            start a follow-up goal:\n\
+            ta run \"<title>\" --follow-up-goal {}",
+            goal_id,
+            goal.state,
+            goal.workspace_path.display(),
+            goal_id
+        );
+    }
+
+    // v0.17.6.3.1: Trust-boundary marker — a rebuild's diff may contain edits a human
+    // reviewer made directly to staging (the agent process has already exited by the
+    // time a goal reaches pr_ready/approved), not just agent-authored changes. Recorded
+    // on the new draft so `ta draft view` never silently blends the two provenances.
+    let rebuild_provenance = if is_rebuild {
+        let previous_state = goal.state.to_string();
+        println!(
+            "[rebuild] Goal {} is in {} state — rebuilding draft from the existing staging \
+             workspace. This diff may include edits made directly to staging (e.g. by a \
+             reviewer), not just agent-authored changes.",
+            goal_id, previous_state
+        );
+        Some(RebuildProvenance {
+            previous_goal_state: previous_state,
+            superseded_draft_id: goal.pr_package_id,
+            rebuilt_at: Utc::now(),
+        })
+    } else {
+        None
+    };
 
     let source_dir_buf: std::path::PathBuf = goal
         .source_dir
@@ -2011,6 +2098,7 @@ pub(crate) fn build_package(
                 memory_entries,
                 source_dir,
                 summary,
+                rebuild_provenance,
             );
         }
 
@@ -2430,6 +2518,7 @@ pub(crate) fn build_package(
         draft_seq: 0,               // Set below with display_id (v0.14.7.3).
         plan_phase: goal.plan_phase.clone(), // Inherit from GoalRun (v0.15.15.2).
         plan_md_base: None,         // Set below if plan_base.md exists in staging (v0.15.24.5).
+        rebuilt_from: rebuild_provenance.clone(), // v0.17.6.3.1.
     };
 
     // v0.15.24.5: Capture PLAN.md base snapshot for 3-way merge on apply.
@@ -2797,6 +2886,11 @@ pub(crate) fn build_package(
     // Save the draft package.
     save_package(config, &pkg)?;
 
+    // v0.17.6.3.1: If this is a rebuild, mark the draft it supersedes so provenance
+    // is never silently blended — the old (agent-authored-only) draft record stays
+    // intact but visibly superseded by this (possibly reviewer-amended) one.
+    supersede_previous_draft_if_rebuild(config, &rebuild_provenance, package_id);
+
     // Update the goal run.
     let mut goal = goal;
     goal.pr_package_id = Some(package_id);
@@ -2833,6 +2927,44 @@ pub(crate) fn build_package(
     Ok(())
 }
 
+/// v0.17.6.3.1: When `rebuild_provenance` names a prior draft, mark that draft
+/// `Superseded` by the freshly-built one. Best-effort — a missing or already-terminal
+/// prior draft (already applied/closed/superseded) is left untouched, since only an
+/// unresolved draft record needs to be redirected to the rebuild.
+fn supersede_previous_draft_if_rebuild(
+    config: &GatewayConfig,
+    rebuild_provenance: &Option<RebuildProvenance>,
+    new_package_id: Uuid,
+) {
+    let Some(prov) = rebuild_provenance else {
+        return;
+    };
+    let Some(prev_id) = prov.superseded_draft_id else {
+        return;
+    };
+    let Ok(mut prev_pkg) = load_package(config, prev_id) else {
+        return;
+    };
+    if matches!(
+        prev_pkg.status,
+        DraftStatus::Superseded { .. } | DraftStatus::Applied { .. } | DraftStatus::Closed { .. }
+    ) {
+        return;
+    }
+    prev_pkg.status = DraftStatus::Superseded {
+        superseded_by: new_package_id,
+    };
+    if save_package(config, &prev_pkg).is_ok() {
+        println!(
+            "[rebuild] Previous draft {} superseded by this rebuild.",
+            prev_pkg
+                .display_id
+                .clone()
+                .unwrap_or_else(|| prev_id.to_string())
+        );
+    }
+}
+
 /// Build a draft package for a goal run that wrote memory entries but no file changes (v0.15.13.2).
 ///
 /// Called by `build_package` when the overlay diff is empty but memory entries were found
@@ -2846,6 +2978,7 @@ fn build_memory_only_draft(
     memory_entries: Vec<ta_memory::store::MemoryEntry>,
     source_dir: &std::path::Path,
     summary: &str,
+    rebuild_provenance: Option<RebuildProvenance>,
 ) -> anyhow::Result<()> {
     use ta_changeset::draft_package::{
         AgentIdentity, Changes, Goal, Iteration, Plan, Provenance, RequestedAction, ReviewRequests,
@@ -3020,6 +3153,7 @@ fn build_memory_only_draft(
         draft_seq: 0,
         plan_phase: None,
         plan_md_base: None,
+        rebuilt_from: rebuild_provenance.clone(), // v0.17.6.3.1.
     };
 
     // Set display_id and shortref/seq (mirrors build_package logic).
@@ -3037,6 +3171,7 @@ fn build_memory_only_draft(
     }
 
     save_package(config, &pkg)?;
+    supersede_previous_draft_if_rebuild(config, &rebuild_provenance, package_id);
 
     // Update goal: record memory entry IDs and transition to PrReady.
     let mut goal = goal;
@@ -12359,6 +12494,228 @@ fn run() {
         let updated_goal = goal_store.get(goal.goal_run_id).unwrap().unwrap();
         assert_eq!(updated_goal.state, GoalRunState::PrReady);
         assert!(updated_goal.pr_package_id.is_some());
+    }
+
+    /// v0.17.6.3.1: A goal that reaches `pr_ready`, gets a staging edit (simulating a
+    /// reviewer fixing a small issue by hand), and calls `ta draft build` again produces
+    /// an updated draft reflecting the edit — without requiring a new goal run.
+    #[test]
+    fn rebuild_draft_from_pr_ready_picks_up_staging_edit() {
+        let project = TempDir::new().unwrap();
+        std::fs::write(project.path().join("README.md"), "# Original\n").unwrap();
+
+        let config = GatewayConfig::for_project(project.path());
+        let goal_store = GoalRunStore::new(&config.goals_dir).unwrap();
+
+        super::super::goal::execute(
+            &super::super::goal::GoalCommands::Start {
+                title: "Test rebuild".to_string(),
+                source: Some(project.path().to_path_buf()),
+                objective: "Test draft rebuild from pr_ready".to_string(),
+                agent: "test-agent".to_string(),
+                phase: None,
+                follow_up: None,
+                objective_file: None,
+            },
+            &config,
+        )
+        .unwrap();
+
+        let goals = goal_store.list().unwrap();
+        let goal = &goals[0];
+        let goal_id = goal.goal_run_id.to_string();
+
+        // First build: agent-authored change, goal transitions Running -> PrReady.
+        std::fs::write(goal.workspace_path.join("README.md"), "# Agent Change\n").unwrap();
+        build_package(&config, &goal_id, "Agent's change", false).unwrap();
+
+        let after_first = goal_store.get(goal.goal_run_id).unwrap().unwrap();
+        assert_eq!(after_first.state, GoalRunState::PrReady);
+        let first_draft_id = after_first.pr_package_id.unwrap();
+
+        // Reviewer hand-edits staging directly (the agent process has already exited).
+        std::fs::write(
+            goal.workspace_path.join("README.md"),
+            "# Reviewer Fixed Change\n",
+        )
+        .unwrap();
+
+        // Rebuild — this must succeed even though the goal is not Running/Finalizing.
+        build_package(&config, &goal_id, "Reviewer's fix", false).unwrap();
+
+        // Goal stays in the pr_ready window after a rebuild (self-loop transition).
+        let after_rebuild = goal_store.get(goal.goal_run_id).unwrap().unwrap();
+        assert_eq!(after_rebuild.state, GoalRunState::PrReady);
+        let second_draft_id = after_rebuild.pr_package_id.unwrap();
+        assert_ne!(
+            first_draft_id, second_draft_id,
+            "rebuild must produce a new draft"
+        );
+
+        // New draft reflects the reviewer's edit, not the agent's original content.
+        let new_pkg = load_package(&config, second_draft_id).unwrap();
+        let diff = &new_pkg.changes.artifacts[0];
+        assert_eq!(diff.resource_uri, "fs://workspace/README.md");
+
+        // New draft records rebuild provenance pointing at the superseded draft.
+        let rebuilt_from = new_pkg.rebuilt_from.as_ref().expect("rebuild provenance");
+        assert_eq!(rebuilt_from.previous_goal_state, "pr_ready");
+        assert_eq!(rebuilt_from.superseded_draft_id, Some(first_draft_id));
+
+        // Old draft is marked superseded, not silently overwritten or left ambiguous.
+        let old_pkg = load_package(&config, first_draft_id).unwrap();
+        assert_eq!(
+            old_pkg.status,
+            DraftStatus::Superseded {
+                superseded_by: second_draft_id
+            }
+        );
+    }
+
+    /// v0.17.6.3.1: Rebuilding from `approved` is also allowed — the resulting draft
+    /// goes back to `pr_ready` since its diff is no longer exactly what was approved.
+    #[test]
+    fn rebuild_draft_from_approved_returns_to_pr_ready() {
+        let project = TempDir::new().unwrap();
+        std::fs::write(project.path().join("README.md"), "# Original\n").unwrap();
+
+        let config = GatewayConfig::for_project(project.path());
+        let goal_store = GoalRunStore::new(&config.goals_dir).unwrap();
+
+        super::super::goal::execute(
+            &super::super::goal::GoalCommands::Start {
+                title: "Test rebuild from approved".to_string(),
+                source: Some(project.path().to_path_buf()),
+                objective: "Test draft rebuild from approved".to_string(),
+                agent: "test-agent".to_string(),
+                phase: None,
+                follow_up: None,
+                objective_file: None,
+            },
+            &config,
+        )
+        .unwrap();
+
+        let goals = goal_store.list().unwrap();
+        let goal = &goals[0];
+        let goal_id = goal.goal_run_id.to_string();
+
+        std::fs::write(goal.workspace_path.join("README.md"), "# Change\n").unwrap();
+        build_package(&config, &goal_id, "Agent's change", false).unwrap();
+
+        goal_store
+            .transition(goal.goal_run_id, GoalRunState::UnderReview)
+            .unwrap();
+        goal_store
+            .transition(
+                goal.goal_run_id,
+                GoalRunState::Approved {
+                    approved_by: "reviewer@example.com".to_string(),
+                },
+            )
+            .unwrap();
+
+        std::fs::write(goal.workspace_path.join("README.md"), "# Amended\n").unwrap();
+        build_package(&config, &goal_id, "Reviewer's amendment", false).unwrap();
+
+        let after_rebuild = goal_store.get(goal.goal_run_id).unwrap().unwrap();
+        assert_eq!(after_rebuild.state, GoalRunState::PrReady);
+
+        let pkg = load_package(&config, after_rebuild.pr_package_id.unwrap()).unwrap();
+        let rebuilt_from = pkg.rebuilt_from.as_ref().expect("rebuild provenance");
+        assert_eq!(rebuilt_from.previous_goal_state, "approved");
+    }
+
+    /// v0.17.6.3.1 item 3: distinguish "goal genuinely finished/torn down, nothing to
+    /// rebuild" from "goal is in a state that could support a rebuild but doesn't yet".
+    /// This test covers the torn-down-workspace case.
+    #[test]
+    fn rebuild_fails_with_actionable_error_when_workspace_torn_down() {
+        let project = TempDir::new().unwrap();
+        std::fs::write(project.path().join("README.md"), "# Original\n").unwrap();
+
+        let config = GatewayConfig::for_project(project.path());
+        let goal_store = GoalRunStore::new(&config.goals_dir).unwrap();
+
+        super::super::goal::execute(
+            &super::super::goal::GoalCommands::Start {
+                title: "Test torn-down workspace".to_string(),
+                source: Some(project.path().to_path_buf()),
+                objective: "Test rebuild error on torn-down workspace".to_string(),
+                agent: "test-agent".to_string(),
+                phase: None,
+                follow_up: None,
+                objective_file: None,
+            },
+            &config,
+        )
+        .unwrap();
+
+        let goals = goal_store.list().unwrap();
+        let goal = &goals[0];
+        let goal_id = goal.goal_run_id.to_string();
+
+        std::fs::write(goal.workspace_path.join("README.md"), "# Change\n").unwrap();
+        build_package(&config, &goal_id, "Agent's change", false).unwrap();
+
+        // Simulate the staging workspace having been torn down after the goal finished.
+        std::fs::remove_dir_all(&goal.workspace_path).unwrap();
+
+        let err = build_package(&config, &goal_id, "Rebuild attempt", false).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no longer exists") && msg.contains("nothing to rebuild"),
+            "error should distinguish a torn-down workspace from a state that could \
+             still support rebuild, got: {}",
+            msg
+        );
+    }
+
+    /// v0.17.6.3.1 item 3: the other half of the same distinction — a goal that has
+    /// moved past the rebuild window entirely (e.g. `applied`) gets a different,
+    /// clearly-worded error than the torn-down-workspace case.
+    #[test]
+    fn build_fails_with_actionable_error_from_unsupported_state() {
+        let project = TempDir::new().unwrap();
+        std::fs::write(project.path().join("README.md"), "# Original\n").unwrap();
+
+        let config = GatewayConfig::for_project(project.path());
+        let goal_store = GoalRunStore::new(&config.goals_dir).unwrap();
+
+        super::super::goal::execute(
+            &super::super::goal::GoalCommands::Start {
+                title: "Test unsupported state".to_string(),
+                source: Some(project.path().to_path_buf()),
+                objective: "Test rebuild error from unsupported state".to_string(),
+                agent: "test-agent".to_string(),
+                phase: None,
+                follow_up: None,
+                objective_file: None,
+            },
+            &config,
+        )
+        .unwrap();
+
+        let goals = goal_store.list().unwrap();
+        let goal = &goals[0];
+        let goal_id = goal.goal_run_id.to_string();
+
+        std::fs::write(goal.workspace_path.join("README.md"), "# Change\n").unwrap();
+        build_package(&config, &goal_id, "Agent's change", false).unwrap();
+
+        goal_store
+            .transition(goal.goal_run_id, GoalRunState::Applied)
+            .unwrap();
+
+        let err = build_package(&config, &goal_id, "Rebuild attempt", false).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("does not support building or rebuilding")
+                && !msg.contains("no longer exists"),
+            "error should distinguish an unsupported state from a torn-down workspace, \
+             got: {}",
+            msg
+        );
     }
 
     #[test]

--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -9518,6 +9518,7 @@ pre_launch:
             draft_seq: 0,
             plan_phase: None,
             plan_md_base: None,
+            rebuilt_from: None,
         };
 
         // Save the draft package.
@@ -9686,6 +9687,7 @@ pre_launch:
             draft_seq: 0,
             plan_phase: None,
             plan_md_base: None,
+            rebuilt_from: None,
         };
 
         super::super::draft::save_package(&config, &parent_draft).unwrap();

--- a/crates/ta-changeset/src/draft_package.rs
+++ b/crates/ta-changeset/src/draft_package.rs
@@ -541,6 +541,26 @@ pub enum TrustLevel {
     Quarantined,
 }
 
+/// Records that a draft was produced by rebuilding from a goal state where the
+/// agent process had already exited (`pr_ready`/`approved`), rather than from a
+/// fresh `Running`/`Finalizing` build (v0.17.6.3.1 — Draft Rebuild Window).
+///
+/// This is the trust-boundary marker: a rebuild's diff may contain edits a human
+/// reviewer made directly to the staging workspace, not just agent-authored
+/// changes. `ta draft view` surfaces this distinctly so provenance is never
+/// silently blended between "agent wrote this" and "reviewer amended this".
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, schemars::JsonSchema)]
+pub struct RebuildProvenance {
+    /// The goal's lifecycle state at the moment `ta draft build` was re-run
+    /// (e.g. `"pr_ready"`, `"approved"`).
+    pub previous_goal_state: String,
+    /// The prior draft package this rebuild superseded, if one existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub superseded_draft_id: Option<Uuid>,
+    /// When the rebuild happened.
+    pub rebuilt_at: DateTime<Utc>,
+}
+
 // ---- Review Requests ----
 
 /// What approvals this PR needs.
@@ -738,6 +758,14 @@ pub struct DraftPackage {
     /// keeping source unchanged and logging a warning.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plan_md_base: Option<String>,
+
+    /// Rebuild provenance (v0.17.6.3.1).
+    ///
+    /// `Some` when this draft was produced by rebuilding from `pr_ready`/`approved`
+    /// (the agent process had already exited) rather than from a live `Running`/
+    /// `Finalizing` goal. `None` for a normal first build. See `RebuildProvenance`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rebuilt_from: Option<RebuildProvenance>,
 }
 
 /// VCS tracking information for post-apply lifecycle monitoring (v0.11.2.3).
@@ -1082,6 +1110,7 @@ pub fn make_test_pkg(goal_shortref: &str, draft_seq: u32) -> DraftPackage {
         draft_seq,
         plan_phase: None,
         plan_md_base: None,
+        rebuilt_from: None,
     }
 }
 
@@ -1235,6 +1264,7 @@ mod tests {
             draft_seq: 0,
             plan_phase: None,
             plan_md_base: None,
+            rebuilt_from: None,
         }
     }
 

--- a/crates/ta-changeset/src/output_renderers/html.rs
+++ b/crates/ta-changeset/src/output_renderers/html.rs
@@ -405,6 +405,7 @@ mod tests {
             draft_seq: 0,
             plan_phase: None,
             plan_md_base: None,
+            rebuilt_from: None,
         };
         pkg.status = DraftStatus::PendingReview;
 
@@ -522,6 +523,7 @@ mod tests {
             draft_seq: 0,
             plan_phase: None,
             plan_md_base: None,
+            rebuilt_from: None,
         };
 
         let adapter = HtmlRenderer::new();
@@ -635,6 +637,7 @@ mod tests {
             draft_seq: 0,
             plan_phase: None,
             plan_md_base: None,
+            rebuilt_from: None,
         };
         pkg.agent_decision_log = vec![DecisionLogEntry {
             decision: "Used Ed25519 over RSA".to_string(),

--- a/crates/ta-changeset/src/output_renderers/json.rs
+++ b/crates/ta-changeset/src/output_renderers/json.rs
@@ -122,6 +122,7 @@ mod tests {
             draft_seq: 0,
             plan_phase: None,
             plan_md_base: None,
+            rebuilt_from: None,
         };
 
         let adapter = JsonRenderer::new();

--- a/crates/ta-changeset/src/output_renderers/terminal.rs
+++ b/crates/ta-changeset/src/output_renderers/terminal.rs
@@ -140,11 +140,32 @@ impl TerminalRenderer {
             _ => pkg.package_id.to_string(),
         };
 
+        // v0.17.6.3.1: Rebuild provenance — never silently blend a rebuild (which may
+        // carry reviewer-made staging edits) with a normal agent-authored draft.
+        let rebuild_banner = if let Some(rb) = &pkg.rebuilt_from {
+            let warn_color = if self.color { "\x1b[33m" } else { "" };
+            let superseded = rb
+                .superseded_draft_id
+                .map(|id| format!(" (supersedes {})", id))
+                .unwrap_or_default();
+            format!(
+                "{warn_color}Rebuilt from: {} state at {}{}{reset} — this diff may include \
+                 edits made directly to staging, not just agent-authored changes.\n\n",
+                rb.previous_goal_state,
+                rb.rebuilt_at.format("%Y-%m-%d %H:%M:%S"),
+                superseded,
+                reset = reset
+            )
+        } else {
+            String::new()
+        };
+
         format!(
             "{bold}Draft: {}{reset}\n\
             Status: {}{}{reset}\n\
             Goal: {}\n\
             Created: {}\n\n\
+            {}\
             {bold}Summary:{reset}\n\
             {}\n\n\
             {bold}Why:{reset}\n\
@@ -156,6 +177,7 @@ impl TerminalRenderer {
             pkg.status,
             Self::strip_html(&pkg.goal.title),
             pkg.created_at.format("%Y-%m-%d %H:%M:%S"),
+            rebuild_banner,
             Self::strip_html(&pkg.summary.what_changed),
             Self::strip_html(&pkg.summary.why),
             Self::strip_html(&pkg.summary.impact),
@@ -1023,6 +1045,7 @@ mod tests {
             draft_seq: 0,
             plan_phase: None,
             plan_md_base: None,
+            rebuilt_from: None,
         }
     }
 

--- a/crates/ta-connectors/fs/src/connector.rs
+++ b/crates/ta-connectors/fs/src/connector.rs
@@ -315,6 +315,7 @@ impl<S: ChangeStore> FsConnector<S> {
             draft_seq: 0,
             plan_phase: None,
             plan_md_base: None,
+            rebuilt_from: None,
         };
 
         Ok(package)

--- a/crates/ta-goal/src/goal_run.rs
+++ b/crates/ta-goal/src/goal_run.rs
@@ -228,6 +228,14 @@ impl GoalRunState {
                 | (GoalRunState::DraftPending { .. }, GoalRunState::Finalizing { .. })
                 // DraftPending → Running (manual recovery / restart)
                 | (GoalRunState::DraftPending { .. }, GoalRunState::Running)
+                // v0.17.6.3.1: Draft Rebuild Window. `ta draft build` on a goal already
+                // at `pr_ready`/`approved` re-diffs the still-live staging workspace
+                // (e.g. after a reviewer hand-edits a small fix) instead of requiring a
+                // fresh agent run. PrReady → PrReady is a self-loop (rebuild produces
+                // another pr_ready draft); Approved → PrReady sends the new draft back
+                // through review since its diff is no longer exactly what was approved.
+                | (GoalRunState::PrReady, GoalRunState::PrReady)
+                | (GoalRunState::Approved { .. }, GoalRunState::PrReady)
         )
     }
 }
@@ -686,6 +694,48 @@ mod tests {
                 tag: "conflict_resolution".to_string()
             }
         );
+    }
+
+    /// v0.17.6.3.1: `ta draft build` rebuilding against a goal already at `pr_ready`
+    /// re-transitions PrReady -> PrReady (a self-loop, not a no-op skip).
+    #[test]
+    fn can_rebuild_self_loop_from_pr_ready() {
+        let mut gr = test_goal_run();
+        gr.transition(GoalRunState::Configured).unwrap();
+        gr.transition(GoalRunState::Running).unwrap();
+        gr.transition(GoalRunState::PrReady).unwrap();
+        gr.transition(GoalRunState::PrReady).unwrap();
+        assert_eq!(gr.state, GoalRunState::PrReady);
+    }
+
+    /// v0.17.6.3.1: rebuilding from `approved` sends the goal back to `pr_ready` —
+    /// the rebuilt draft's diff is no longer exactly what was approved.
+    #[test]
+    fn can_rebuild_from_approved_back_to_pr_ready() {
+        let mut gr = test_goal_run();
+        gr.transition(GoalRunState::Configured).unwrap();
+        gr.transition(GoalRunState::Running).unwrap();
+        gr.transition(GoalRunState::PrReady).unwrap();
+        gr.transition(GoalRunState::UnderReview).unwrap();
+        gr.transition(GoalRunState::Approved {
+            approved_by: "reviewer".to_string(),
+        })
+        .unwrap();
+        gr.transition(GoalRunState::PrReady).unwrap();
+        assert_eq!(gr.state, GoalRunState::PrReady);
+    }
+
+    /// A goal that has moved past the rebuild window (e.g. `applied`) must not accept
+    /// a rebuild transition back to `pr_ready` — only `pr_ready`/`approved` do.
+    #[test]
+    fn cannot_rebuild_from_applied() {
+        let mut gr = test_goal_run();
+        gr.transition(GoalRunState::Configured).unwrap();
+        gr.transition(GoalRunState::Running).unwrap();
+        gr.transition(GoalRunState::PrReady).unwrap();
+        gr.transition(GoalRunState::Applied).unwrap();
+        let result = gr.transition(GoalRunState::PrReady);
+        assert!(matches!(result, Err(GoalError::InvalidTransition { .. })));
     }
 
     #[test]

--- a/crates/ta-submit/tests/git_open_review.rs
+++ b/crates/ta-submit/tests/git_open_review.rs
@@ -167,6 +167,7 @@ fn make_draft_package() -> DraftPackage {
         draft_seq: 0,
         plan_phase: None,
         plan_md_base: None,
+        rebuilt_from: None,
     }
 }
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4295,6 +4295,38 @@ Checkpoints:
   [12:43] tests_pass — 847 tests passed
 ```
 
+### Rebuilding a Draft After Review
+
+Review happens after a goal reaches `pr_ready` — so what do you do when review turns up a small issue? You don't need a new goal run. As long as the goal's staging workspace still exists, you can fix it directly and rebuild:
+
+```bash
+# Draft is at pr_ready (or approved) and review found a small bug.
+cd <staging-workspace-path>       # shown by `ta goal status <goal-id>`
+# ...edit the file(s) that need fixing...
+
+ta draft build --goal <goal-id>   # or: ta draft build --latest
+```
+
+This re-diffs the staging workspace against the source directory and produces a new draft, exactly like the first build. The old draft is marked `superseded` rather than silently discarded, and the new draft records where it came from:
+
+```bash
+$ ta draft view <goal-id>
+Draft: a7b38384/2 · test-rebuild-01
+Status: pending_review
+Rebuilt from: pr_ready state at 2026-08-18 09:12:03 (supersedes a7b38384-...-first-draft-id)
+  — this diff may include edits made directly to staging, not just agent-authored changes.
+Goal: Fix auth bug
+...
+```
+
+That `Rebuilt from:` line is a trust-boundary marker, not a warning to ignore: it tells the reviewer this draft's diff may contain human edits to staging (yours), not only agent output, since the agent process had already exited by the time the goal reached `pr_ready`/`approved`. It never blends silently with a normal agent-authored draft.
+
+**What states support a rebuild:**
+- `running` / `finalizing` — the normal case (agent still working, or just exited).
+- `pr_ready` / `approved` — a draft already exists; rebuilding re-diffs the same staging workspace and supersedes the old draft. Rebuilding from `approved` sends the goal back to `pr_ready`, since the new diff is no longer exactly what was approved.
+
+**What doesn't:** a goal that has moved past the rebuild window (`applied`, `merged`, `completed`, `denied`, `failed`) gets a clear error explaining that further changes need a follow-up goal (`ta run --follow-up`) — distinct from the error you get if the staging workspace itself has been torn down (e.g. after `ta goal purge`), which tells you there's nothing left to rebuild from. Before this, both cases produced the same dead-end message ("must be running or finalizing to build draft"), and the only recovery was a manual `git worktree` copy-out entirely outside TA.
+
 ### Goal Purge
 
 Remove old goal records and their staging directories in bulk:

--- a/schema/draft.schema.json
+++ b/schema/draft.schema.json
@@ -1151,6 +1151,33 @@
       ],
       "type": "object"
     },
+    "RebuildProvenance": {
+      "description": "Records that a draft was produced by rebuilding from a goal state where the\nagent process had already exited (`pr_ready`/`approved`), rather than from a\nfresh `Running`/`Finalizing` build (v0.17.6.3.1 — Draft Rebuild Window).\n\nThis is the trust-boundary marker: a rebuild's diff may contain edits a human\nreviewer made directly to the staging workspace, not just agent-authored\nchanges. `ta draft view` surfaces this distinctly so provenance is never\nsilently blended between \"agent wrote this\" and \"reviewer amended this\".",
+      "properties": {
+        "previous_goal_state": {
+          "description": "The goal's lifecycle state at the moment `ta draft build` was re-run\n(e.g. `\"pr_ready\"`, `\"approved\"`).",
+          "type": "string"
+        },
+        "rebuilt_at": {
+          "description": "When the rebuild happened.",
+          "format": "date-time",
+          "type": "string"
+        },
+        "superseded_draft_id": {
+          "description": "The prior draft package this rebuild superseded, if one existed.",
+          "format": "uuid",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "previous_goal_state",
+        "rebuilt_at"
+      ],
+      "type": "object"
+    },
     "RequestedAction": {
       "properties": {
         "action": {
@@ -1676,6 +1703,17 @@
     },
     "provenance": {
       "$ref": "#/$defs/Provenance"
+    },
+    "rebuilt_from": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RebuildProvenance"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Rebuild provenance (v0.17.6.3.1).\n\n`Some` when this draft was produced by rebuilding from `pr_ready`/`approved`\n(the agent process had already exited) rather than from a live `Running`/\n`Finalizing` goal. `None` for a normal first build. See `RebuildProvenance`."
     },
     "review_requests": {
       "$ref": "#/$defs/ReviewRequests"


### PR DESCRIPTION
## Summary
- `ta draft build` can now rebuild from `pr_ready`/`approved` goal states (not just running/finalizing), enabling reviewer-driven fixes without leaving the tool
- New `RebuildProvenance` tracks supersession chain; prior draft marked `Superseded`
- New goal-state transitions: PrReady self-loop, Approved -> PrReady
- Actionable errors distinguish "can't rebuild, nothing to rebuild" from "workspace torn down"

## Test plan
- cargo build/test/clippy/fmt all pass (verified in isolated worktree)
- 4 new tests covering rebuild-from-pr_ready, rebuild-from-approved, torn-down-workspace error, unsupported-state error
- 3 new goal-state-transition tests

Manually finished via worktree bypass — `ta draft apply` hit a reproducible TA bug (rollback-on-verification-failure corrupts working-tree version strings across ~24 Cargo.toml files instead of restoring committed state). Draft content itself reviewed clean (supervisor PASS, 0.95 confidence); only needed a formatting fixup.