### PR TITLE
fix: three real bugs blocking custom local-model agent frameworks

### DIFF
--- a/apps/ta-cli/src/commands/agent.rs
+++ b/apps/ta-cli/src/commands/agent.rs
@@ -1094,7 +1094,7 @@ fn framework_new(
              description = \"Ollama agent using {model_name}\"\n\
              type        = \"process\"\n\
              command     = \"ta-agent-ollama\"\n\
-             args        = [\"--model\", \"{model_str}\", \"--base-url\", \"http://localhost:11434\"]\n\
+             args        = [\"--model\", \"{model_name}\", \"--base-url\", \"http://localhost:11434\"]\n\
              sentinel    = \"[goal started]\"\n\
              \n\
              context_file   = \"CLAUDE.md\"\n\
@@ -1119,7 +1119,10 @@ version     = "1.0.0"
 description = "Ollama-backed agent — set --model to your local model"
 type        = "process"
 command     = "ta-agent-ollama"
-args        = ["--model", "ollama/qwen2.5-coder:7b", "--base-url", "http://localhost:11434"]
+# Model name as Ollama itself knows it (no "ollama/" prefix — that prefix is
+# only TA's own `--model ollama/<name>` CLI shorthand, not part of the model
+# identifier Ollama's API expects).
+args        = ["--model", "qwen2.5-coder:7b", "--base-url", "http://localhost:11434"]
 sentinel    = "[goal started]"
 
 context_file   = "CLAUDE.md"
@@ -2325,6 +2328,36 @@ mod tests {
 
     fn test_config(dir: &TempDir) -> GatewayConfig {
         GatewayConfig::for_project(dir.path())
+    }
+
+    #[test]
+    fn framework_new_strips_ollama_prefix_from_model_arg() {
+        // Regression test for a real bug: the generated manifest's `args`
+        // passed the raw "ollama/<model>" shorthand straight through to
+        // ta-agent-ollama's --model flag, which forwards it verbatim to
+        // Ollama's own API — but Ollama's model names never have that
+        // prefix (it's only TA's own CLI shorthand for selecting the
+        // ollama framework). This caused every generated manifest to fail
+        // with a 404 "model not found" at actual run time.
+        let dir = TempDir::new().unwrap();
+        let config = test_config(&dir);
+        let output_path = dir.path().join("qwen3-14b.toml");
+        framework_new(
+            Some("ollama/qwen3:14b"),
+            None,
+            Some(&output_path),
+            &config,
+        )
+        .unwrap();
+        let content = std::fs::read_to_string(&output_path).unwrap();
+        assert!(
+            content.contains(r#"args        = ["--model", "qwen3:14b", "#),
+            "manifest args must use the bare model name, not the ollama/ shorthand: {content}"
+        );
+        assert!(
+            !content.contains(r#""ollama/qwen3:14b""#),
+            "manifest args must not contain the unstripped ollama/ prefix: {content}"
+        );
     }
 
     #[test]

--- a/apps/ta-cli/src/commands/agent.rs
+++ b/apps/ta-cli/src/commands/agent.rs
@@ -2342,13 +2342,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let config = test_config(&dir);
         let output_path = dir.path().join("qwen3-14b.toml");
-        framework_new(
-            Some("ollama/qwen3:14b"),
-            None,
-            Some(&output_path),
-            &config,
-        )
-        .unwrap();
+        framework_new(Some("ollama/qwen3:14b"), None, Some(&output_path), &config).unwrap();
         let content = std::fs::read_to_string(&output_path).unwrap();
         assert!(
             content.contains(r#"args        = ["--model", "qwen3:14b", "#),

--- a/apps/ta-cli/src/commands/run.rs
+++ b/apps/ta-cli/src/commands/run.rs
@@ -331,9 +331,21 @@ fn builtin_agent_config(agent_id: &str) -> AgentLaunchConfig {
 /// hardcoded `builtin_agent_config()` values which have richer headless_args etc.
 fn framework_to_launch_config(manifest: &ta_runtime::AgentFrameworkManifest) -> AgentLaunchConfig {
     use ta_runtime::ContextInjectMode;
-    // Append {prompt} placeholder after the manifest's fixed args.
     let mut args_template = manifest.args.clone();
-    args_template.push("{prompt}".to_string());
+    // Append {prompt} as a trailing positional only for frameworks that
+    // actually expect the goal text as a bare CLI argument (Prepend/None
+    // mode, e.g. claude-code, codex). Env/Arg-mode frameworks (e.g.
+    // ta-agent-ollama) receive the goal via $TA_GOAL_CONTEXT or an explicit
+    // --context flag instead — appending {prompt} here as well breaks any
+    // agent binary with a strict CLI parser that rejects unknown positionals
+    // (confirmed against ta-agent-ollama, whose clap parser only accepts
+    // --model/--base-url/--context-file/etc., no bare prompt argument).
+    if matches!(
+        manifest.context_inject,
+        ContextInjectMode::Prepend | ContextInjectMode::None
+    ) {
+        args_template.push("{prompt}".to_string());
+    }
     let injects_context_file = matches!(manifest.context_inject, ContextInjectMode::Prepend);
     AgentLaunchConfig {
         command: manifest.command.clone(),
@@ -2963,6 +2975,7 @@ pub fn execute(
             {
                 let context_text = build_goal_context_text(
                     title,
+                    objective,
                     &goal_id,
                     goal.plan_phase.as_deref(),
                     config,
@@ -7905,9 +7918,13 @@ fn count_changed_recursive(staging_root: &Path, dir: &Path, source_root: &Path) 
 // ── v0.13.8: Memory bridge helper functions ─────────────────────────────────
 
 /// Build a plain goal context text string for env/arg-mode injection.
-/// (Simpler than the full CLAUDE.md prepend — just goal ID, title, plan phase.)
+/// (Simpler than the full CLAUDE.md prepend — just goal ID, title, objective,
+/// plan phase.) Env/Arg-mode frameworks never receive `{prompt}` as a CLI
+/// argument (see `framework_to_launch_config`), so `objective` must be
+/// included here or that information is silently lost for those frameworks.
 fn build_goal_context_text(
     title: &str,
+    objective: &str,
     goal_id: &str,
     plan_phase: Option<&str>,
     config: &GatewayConfig,
@@ -7916,6 +7933,11 @@ fn build_goal_context_text(
     let phase_line = plan_phase
         .map(|p| format!("\n**Plan Phase:** {}", p))
         .unwrap_or_default();
+    let objective_line = if objective.is_empty() {
+        String::new()
+    } else {
+        format!("\n**Objective:** {}", objective)
+    };
     let memory_section = build_memory_context_section_for_inject(config, title, plan_phase);
     let community_section = if let Some(src) = source_dir {
         super::community::build_community_context_section(src)
@@ -7923,8 +7945,8 @@ fn build_goal_context_text(
         String::new()
     };
     format!(
-        "# TA Goal Context\n\n**Goal:** {}\n**Goal ID:** {}{}\n{}{}",
-        title, goal_id, phase_line, memory_section, community_section
+        "# TA Goal Context\n\n**Goal:** {}\n**Goal ID:** {}{}{}\n{}{}",
+        title, goal_id, phase_line, objective_line, memory_section, community_section
     )
 }
 
@@ -8615,6 +8637,91 @@ fn inject_compression_url(
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    // ── framework_to_launch_config / build_goal_context_text tests ─────────
+    //
+    // Regression coverage for a real bug found live: framework_to_launch_config
+    // unconditionally appended {prompt} as a trailing positional CLI argument
+    // for every custom framework, including Env/Arg-mode ones (e.g.
+    // ta-agent-ollama) whose binaries don't accept a bare prompt positional
+    // at all and reject it with a clap parse error. Env/Arg-mode frameworks
+    // must receive the goal via $TA_GOAL_CONTEXT / --context instead, and
+    // build_goal_context_text must include the objective text so it isn't
+    // silently dropped for those frameworks once {prompt} is no longer appended.
+
+    fn manifest_with_context_inject(mode_toml: &str) -> ta_runtime::AgentFrameworkManifest {
+        let toml = format!(
+            r#"
+name = "test-agent"
+command = "test-agent-bin"
+args = ["--model", "test-model"]
+context_inject = "{mode_toml}"
+"#
+        );
+        toml::from_str(&toml).unwrap()
+    }
+
+    #[test]
+    fn framework_to_launch_config_omits_prompt_arg_for_env_mode() {
+        let manifest = manifest_with_context_inject("env");
+        let config = framework_to_launch_config(&manifest);
+        assert_eq!(config.args_template, vec!["--model", "test-model"]);
+        assert!(
+            !config.args_template.contains(&"{prompt}".to_string()),
+            "Env-mode frameworks must not receive {{prompt}} as a positional arg: {:?}",
+            config.args_template
+        );
+    }
+
+    #[test]
+    fn framework_to_launch_config_omits_prompt_arg_for_arg_mode() {
+        let manifest = manifest_with_context_inject("arg");
+        let config = framework_to_launch_config(&manifest);
+        assert!(!config.args_template.contains(&"{prompt}".to_string()));
+    }
+
+    #[test]
+    fn framework_to_launch_config_keeps_prompt_arg_for_prepend_mode() {
+        let manifest = manifest_with_context_inject("prepend");
+        let config = framework_to_launch_config(&manifest);
+        assert_eq!(
+            config.args_template,
+            vec!["--model", "test-model", "{prompt}"]
+        );
+    }
+
+    #[test]
+    fn framework_to_launch_config_keeps_prompt_arg_for_none_mode() {
+        let manifest = manifest_with_context_inject("none");
+        let config = framework_to_launch_config(&manifest);
+        assert!(config.args_template.contains(&"{prompt}".to_string()));
+    }
+
+    #[test]
+    fn build_goal_context_text_includes_objective_when_present() {
+        let project = TempDir::new().unwrap();
+        let config = GatewayConfig::for_project(project.path());
+        let text = build_goal_context_text(
+            "Write hello.txt",
+            "Create a file named hello.txt containing the text hello",
+            "goal-123",
+            None,
+            &config,
+            None,
+        );
+        assert!(text.contains("**Goal:** Write hello.txt"));
+        assert!(
+            text.contains("**Objective:** Create a file named hello.txt containing the text hello")
+        );
+    }
+
+    #[test]
+    fn build_goal_context_text_omits_objective_line_when_empty() {
+        let project = TempDir::new().unwrap();
+        let config = GatewayConfig::for_project(project.path());
+        let text = build_goal_context_text("Write hello.txt", "", "goal-123", None, &config, None);
+        assert!(!text.contains("**Objective:**"));
+    }
 
     // ── v0.12.6 count_changed_files tests ───────────────────────
 

--- a/crates/ta-runtime/src/framework.rs
+++ b/crates/ta-runtime/src/framework.rs
@@ -432,6 +432,20 @@ impl AgentFrameworkManifest {
         None
     }
 
+    /// The user-level global agents directory: `<home>/.config/ta/agents`.
+    ///
+    /// Deliberately the literal `~/.config/ta` path, not the platform-native
+    /// `dirs::config_dir()` (which resolves to `~/Library/Application Support`
+    /// on macOS) — TA uses `~/.config/ta` as its established convention
+    /// everywhere else (docs, `ta_config_dir()` in `apps/ta-cli/src/commands/agent.rs`,
+    /// the config/secrets/workflows paths documented in USAGE.md). Using
+    /// `dirs::config_dir()` here previously orphaned every custom framework
+    /// manifest written to `~/.config/ta/agents/` on macOS — `ta agent
+    /// framework-new`'s own default output path was never found by `discover()`.
+    fn global_agents_dir(home: &Path) -> PathBuf {
+        home.join(".config").join("ta").join("agents")
+    }
+
     /// Discover custom framework manifests from well-known paths.
     ///
     /// Search order:
@@ -442,12 +456,22 @@ impl AgentFrameworkManifest {
     /// backwards compatibility with user-provided project-local manifests.
     /// When both `<name>.yaml` and `<name>.toml` exist, YAML takes precedence.
     pub fn discover(project_root: &Path) -> Vec<AgentFrameworkManifest> {
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+        Self::discover_with_global_dir(project_root, &Self::global_agents_dir(&home))
+    }
+
+    /// Same search/parse logic as [`discover`], but with the user-level
+    /// global agents directory passed explicitly rather than derived from
+    /// the real `$HOME` — lets tests isolate from whatever real manifests
+    /// happen to exist on the machine running the test suite.
+    fn discover_with_global_dir(
+        project_root: &Path,
+        global_agents_dir: &Path,
+    ) -> Vec<AgentFrameworkManifest> {
         let mut manifests = Vec::new();
         let search_dirs = [
             project_root.join(".ta/agents"),
-            dirs::config_dir()
-                .unwrap_or_else(|| PathBuf::from("~/.config"))
-                .join("ta/agents"),
+            global_agents_dir.to_path_buf(),
         ];
         for dir in &search_dirs {
             if let Ok(entries) = std::fs::read_dir(dir) {
@@ -742,8 +766,21 @@ mod tests {
     #[test]
     fn discover_empty_dir() {
         let dir = tempdir().unwrap();
-        let manifests = AgentFrameworkManifest::discover(dir.path());
+        let global = tempdir().unwrap();
+        let manifests = AgentFrameworkManifest::discover_with_global_dir(dir.path(), global.path());
         assert!(manifests.is_empty());
+    }
+
+    #[test]
+    fn global_agents_dir_uses_literal_dot_config_not_platform_native_dir() {
+        // Regression test: this must be `<home>/.config/ta/agents`, matching
+        // `ta_config_dir()` (apps/ta-cli/src/commands/agent.rs) and every path
+        // documented in USAGE.md — NOT `dirs::config_dir()`'s platform-native
+        // result, which on macOS is `~/Library/Application Support/ta/agents`
+        // and would silently never match what `framework-new` writes to.
+        let home = Path::new("/Users/example");
+        let dir = AgentFrameworkManifest::global_agents_dir(home);
+        assert_eq!(dir, Path::new("/Users/example/.config/ta/agents"));
     }
 
     #[test]
@@ -759,7 +796,9 @@ command = "my-agent-bin"
 args = ["--headless"]
 "#;
         std::fs::write(agents_dir.join("my-custom-agent.toml"), manifest_toml).unwrap();
-        let discovered = AgentFrameworkManifest::discover(dir.path());
+        let global = tempdir().unwrap();
+        let discovered =
+            AgentFrameworkManifest::discover_with_global_dir(dir.path(), global.path());
         assert_eq!(discovered.len(), 1);
         assert_eq!(discovered[0].name, "my-custom-agent");
         assert!(!discovered[0].builtin);
@@ -779,7 +818,9 @@ args:
   - "--headless"
 "#;
         std::fs::write(agents_dir.join("my-yaml-agent.yaml"), manifest_yaml).unwrap();
-        let discovered = AgentFrameworkManifest::discover(dir.path());
+        let global = tempdir().unwrap();
+        let discovered =
+            AgentFrameworkManifest::discover_with_global_dir(dir.path(), global.path());
         assert_eq!(discovered.len(), 1);
         assert_eq!(discovered[0].name, "my-yaml-agent");
         assert_eq!(discovered[0].command, "my-yaml-agent-bin");
@@ -796,7 +837,9 @@ args:
         let toml = "name = \"priority-agent\"\ncommand = \"from-toml\"\n";
         std::fs::write(agents_dir.join("priority-agent.yaml"), yaml).unwrap();
         std::fs::write(agents_dir.join("priority-agent.toml"), toml).unwrap();
-        let discovered = AgentFrameworkManifest::discover(dir.path());
+        let global = tempdir().unwrap();
+        let discovered =
+            AgentFrameworkManifest::discover_with_global_dir(dir.path(), global.path());
         // Should discover exactly one manifest (YAML wins).
         assert_eq!(discovered.len(), 1);
         assert_eq!(discovered[0].command, "from-yaml");


### PR DESCRIPTION
## Summary

Found and fixed while validating `ta-agent-ollama` end-to-end for the first time against a real virtual-team use case (local models on a 32GB M1 Max, ahead of a trip). All three independently broke any custom framework manifest (`ta agent framework-new`) somewhere on the path from creation to actually running a goal — verified all three by hitting each one live in sequence.

1. **`AgentFrameworkManifest::discover()` used the wrong config directory on macOS.** It searched `dirs::config_dir()`, which resolves to `~/Library/Application Support` on macOS — not the literal `~/.config/ta/agents` path that `framework-new`'s own default output, `ta_config_dir()`, and every path documented in USAGE.md actually use (123 references to the literal path vs. this one outlier). Every custom manifest was silently undiscoverable by `ta agent doctor`/`ta run --agent <name>` on macOS.

2. **`framework_to_launch_config()` unconditionally appended `{prompt}`** as a trailing positional CLI argument for every custom framework, including Env/Arg-mode ones. `ta-agent-ollama`'s clap parser has no positional argument at all (it reads the goal via `--context-file`/`$TA_GOAL_CONTEXT`) and rejected the extra argument outright. Now only appended for Prepend/None-mode frameworks, which actually expect it. `build_goal_context_text()` now also includes the objective text (previously only carried in the now-omitted `{prompt}` string), so Env/Arg-mode frameworks don't silently lose it.

3. **`ta agent framework-new --model ollama/<name>` generated manifests whose `args` passed the raw `"ollama/<name>"` shorthand straight through to `--model`**, which `ta-agent-ollama` forwards verbatim to Ollama's own API. Ollama's model names never carry that prefix — it's only TA's own CLI shorthand for selecting the ollama framework — so every generated manifest failed at runtime with a 404 "model not found". The stripped `model_name` was already computed for the description field; `args` just used the wrong variable.

Verified end-to-end after all three fixes: a generated `qwen3-14b` manifest correctly discovers, launches, calls native tools (`file_write`) against a real Ollama-served local model, and completes a real goal through TA's full draft/review/approve/apply pipeline.

## Test plan

- [x] `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check` — all clean
- [x] 9 new regression tests covering all three bugs (framework discovery path, prompt-arg omission per context_inject mode, objective inclusion, ollama/ prefix stripping)
- [x] Live end-to-end validation: `ta agent framework-new --model ollama/qwen3:14b` → `ta agent doctor` → `ta run --agent qwen3-14b --headless` → real tool call → draft → supervisor review → approve → apply, in a scratch project