### PR TITLE
TeamMember model_tier + handles_tags schema (v0.17.11.6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ All outcomes must be **observable** (with details and logging) and **actionable*
 
 ## Current State
 
-**Current version**: `0.17.11-alpha.5`
+**Current version**: `0.17.11-alpha.6`
 - See **PLAN.md** for the canonical development roadmap with per-phase status
 - `ta plan list` / `ta plan status` show current progress
 - Goals can link to plan phases: `ta run "title" --phase 4b`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "ta-actions"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "serde",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "ta-advisor"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "serde",
@@ -5103,7 +5103,7 @@ dependencies = [
 
 [[package]]
 name = "ta-agent-ollama"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "ta-agent-whiteboard"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5140,7 +5140,7 @@ dependencies = [
 
 [[package]]
 name = "ta-audit"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "ta-brain"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "schemars",
@@ -5176,7 +5176,7 @@ dependencies = [
 
 [[package]]
 name = "ta-build"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "reqwest",
  "serde",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "ta-changeset"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "ta-cli"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "arboard",
@@ -5270,7 +5270,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-comfyui"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "reqwest",
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-discord"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -5299,7 +5299,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-email"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-fs"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "serde",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-drive"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-mock-gmail"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-slack"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -5362,7 +5362,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unity"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "serde",
@@ -5375,7 +5375,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-unreal"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "serde",
@@ -5389,7 +5389,7 @@ dependencies = [
 
 [[package]]
 name = "ta-connector-web"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credential-broker"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "biscuit-auth",
  "chrono",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "ta-credentials"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "age",
  "chrono",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "ta-daemon"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5483,7 +5483,7 @@ dependencies = [
 
 [[package]]
 name = "ta-data-spec"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "schemars",
  "serde_json",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-overlay"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "serde",
@@ -5509,7 +5509,7 @@ dependencies = [
 
 [[package]]
 name = "ta-db-proxy"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "decision-gate",
@@ -5527,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "ta-events"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "ta-extension"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "ta-goal"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "ta-governed-paths"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "serde",
@@ -5593,7 +5593,7 @@ dependencies = [
 
 [[package]]
 name = "ta-init"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "ta-intake"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "regex",
@@ -5624,7 +5624,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mcp-gateway"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "decision-gate",
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "ta-mediation"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "serde",
@@ -5680,7 +5680,7 @@ dependencies = [
 
 [[package]]
 name = "ta-memory"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "glob",
@@ -5698,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "ta-output-schema"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -5710,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "ta-plan"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5729,7 +5729,7 @@ dependencies = [
 
 [[package]]
 name = "ta-plan-wayfinder"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5751,7 +5751,7 @@ dependencies = [
 
 [[package]]
 name = "ta-plugin"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "libc",
  "serde",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "ta-policy"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "glob",
@@ -5780,7 +5780,7 @@ dependencies = [
 
 [[package]]
 name = "ta-release"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "base64 0.22.1",
  "reqwest",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "ta-runtime"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5818,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "ta-sandbox"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -5831,7 +5831,7 @@ dependencies = [
 
 [[package]]
 name = "ta-session"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "decision-gate",
@@ -5851,7 +5851,7 @@ dependencies = [
 
 [[package]]
 name = "ta-submit"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "chrono",
  "decision-gate",
@@ -5871,7 +5871,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workflow"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "ta-workspace"
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ members = [
 # Single source of truth for all crate versions.
 # Each crate's Cargo.toml uses `version.workspace = true` to inherit this.
 [workspace.package]
-version = "0.17.11-alpha.5"
+version = "0.17.11-alpha.6"
 
 # Shared dependency versions — crate Cargo.tomls use `dep.workspace = true`
 # to inherit these versions, keeping everything in sync across all crates.

--- a/PLAN.md
+++ b/PLAN.md
@@ -10586,6 +10586,20 @@ While tracing this, an **undocumented earlier PLAN.md write site** was found tha
 
 #### Version: `0.17.11-alpha.5`
 
+### v0.17.11.6 — Virtual-Team `TeamMember` Model-Tier & Local-Tag Schema
+<!-- status: done -->
+**Depends on**: none
+
+**Goal**: Unblock the private `Trusted-Autonomy/ta-virtual-team` repo's Phase 0 (see its own `PLAN.md` and `docs/design/virtual-team-wayfinder-dispatch.md`), which needs two fields on `.ta/team.toml`'s `TeamMember` that don't exist yet: a portable model-tier policy (chief-of-staff role runs the user's highest-configured reasoning tier; other roles run whatever lower-cost tier fits their task) and a local tag vocabulary an orchestrator persona can consult when routing incoming work to a specific team member. Neither is Wayfinder-specific — both benefit any virtual team on their own merits.
+
+1. [x] **`TeamMember` schema** (`ta-session/src/agent_action.rs`): added `model_tier: Option<String>` and `handles_tags: Vec<String>`, both `#[serde(default)]` — backward compatible, existing `.ta/team.toml` files round-trip identically (regression-tested). Data-defined (plain string), not a closed Rust enum, matching `TeamRole`'s own newtype convention (TA-CONSTITUTION.md §1.6) so new tiers/tags never require a schema change.
+2. [x] **`TeamConfig.model_tiers: HashMap<String, String>`** (`ta-session/src/team.rs`): named tier -> concrete `agent_id`, e.g. `highest = "claude-opus-5"`. `TeamConfig::resolve_agent_id(&member)` resolves `member.model_tier` against it, falling back to `member.agent_id` when the tier is unset or not declared (a stale/typo'd tier doesn't block launching the role, just falls back — no hard error).
+3. [x] **Wired into actual execution, not just schema**: `ta-daemon/src/team_session.rs`'s `build_ta_run_args` now calls `team_config.resolve_agent_id(member)` instead of reading `member.agent_id` directly — `model_tier` demonstrably changes which model launches a role (unit-tested both the override and the fall-back-when-unresolvable cases), not a field that round-trips but is never consumed.
+4. [x] **`TeamConfig::find_by_tag(tag) -> Vec<&TeamMember>`**: local routing lookup mirroring `find_by_role`, for a virtual team's own orchestrator persona to consult — never called from TA core itself; `handles_tags` is purely a per-project routing hint carried in the schema.
+5. [x] **Tests**: round-trip (both fields present, and backward-compat with neither present), `resolve_agent_id` (tier hit / unset / declared-but-missing), `find_by_tag`, `assign()` defaults the new fields empty on a fresh member. All four verification gates (`build`/`test --workspace`/`clippy --workspace -- -D warnings`/`fmt --check`) clean at the full-workspace level, not just the touched crates.
+
+#### Version: `0.17.11-alpha.6`
+
 
 > **Focus**: Supervised Autonomy (SA) enterprise credential store, host-wide FUSE filesystem virtualization, and external process governance (ComfyUI, SimpleTuner, arbitrary daemons). This milestone is the foundation for deploying TA in regulated enterprise environments.
 ### v0.18.0 — SA Enterprise Credential Store Plugin

--- a/apps/ta-cli/Cargo.toml
+++ b/apps/ta-cli/Cargo.toml
@@ -52,36 +52,36 @@ which = { workspace = true }
 arboard = { workspace = true }
 
 # Internal crates — version kept in sync with workspace by bump-version.sh
-ta-audit = { path = "../../crates/ta-audit", version = "0.17.11-alpha.5" }
-ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.11-alpha.5" }
-ta-memory = { path = "../../crates/ta-memory", version = "0.17.11-alpha.5" }
-ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.11-alpha.5" }
-ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.11-alpha.5" }
-ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.11-alpha.5" }
-ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.11-alpha.5" }
-ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.11-alpha.5" }
-ta-goal = { path = "../../crates/ta-goal", version = "0.17.11-alpha.5" }
-ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.11-alpha.5" }
-ta-policy = { path = "../../crates/ta-policy", version = "0.17.11-alpha.5" }
-ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.11-alpha.5" }
-ta-session = { path = "../../crates/ta-session", version = "0.17.11-alpha.5" }
-ta-events = { path = "../../crates/ta-events", version = "0.17.11-alpha.5" }
-ta-submit = { path = "../../crates/ta-submit", version = "0.17.11-alpha.5" }
+ta-audit = { path = "../../crates/ta-audit", version = "0.17.11-alpha.6" }
+ta-credentials = { path = "../../crates/ta-credentials", version = "0.17.11-alpha.6" }
+ta-memory = { path = "../../crates/ta-memory", version = "0.17.11-alpha.6" }
+ta-changeset = { path = "../../crates/ta-changeset", version = "0.17.11-alpha.6" }
+ta-connector-fs = { path = "../../crates/ta-connectors/fs", version = "0.17.11-alpha.6" }
+ta-connector-unreal = { path = "../../crates/ta-connectors/unreal", version = "0.17.11-alpha.6" }
+ta-connector-comfyui = { path = "../../crates/ta-connectors/comfyui", version = "0.17.11-alpha.6" }
+ta-connector-unity = { path = "../../crates/ta-connectors/unity", version = "0.17.11-alpha.6" }
+ta-goal = { path = "../../crates/ta-goal", version = "0.17.11-alpha.6" }
+ta-mcp-gateway = { path = "../../crates/ta-mcp-gateway", version = "0.17.11-alpha.6" }
+ta-policy = { path = "../../crates/ta-policy", version = "0.17.11-alpha.6" }
+ta-mediation = { path = "../../crates/ta-mediation", version = "0.17.11-alpha.6" }
+ta-session = { path = "../../crates/ta-session", version = "0.17.11-alpha.6" }
+ta-events = { path = "../../crates/ta-events", version = "0.17.11-alpha.6" }
+ta-submit = { path = "../../crates/ta-submit", version = "0.17.11-alpha.6" }
 ta-decision = { git = "https://github.com/Trusted-Autonomy/decision-gate", tag = "v0.1.0", package = "decision-gate" }
-ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.11-alpha.5" }
-ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.11-alpha.5" }
-ta-plan = { path = "../../crates/ta-plan", version = "0.17.11-alpha.5" }
-ta-build = { path = "../../crates/ta-build", version = "0.17.11-alpha.5" }
-ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.11-alpha.5" }
-ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.11-alpha.5" }
-ta-init = { path = "../../crates/ta-init", version = "0.17.11-alpha.5" }
-ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.11-alpha.5" }
-ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.11-alpha.5" }
-ta-intake = { path = "../../crates/ta-intake", version = "0.17.11-alpha.5" }
-ta-brain = { path = "../../crates/ta-brain", version = "0.17.11-alpha.5" }
-ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.11-alpha.5" }
-ta-release = { path = "../../crates/ta-release", version = "0.17.11-alpha.5" }
-ta-credential-broker = { path = "../../crates/ta-credential-broker", version = "0.17.11-alpha.5" }
+ta-workspace = { path = "../../crates/ta-workspace", version = "0.17.11-alpha.6" }
+ta-workflow = { path = "../../crates/ta-workflow", version = "0.17.11-alpha.6" }
+ta-plan = { path = "../../crates/ta-plan", version = "0.17.11-alpha.6" }
+ta-build = { path = "../../crates/ta-build", version = "0.17.11-alpha.6" }
+ta-output-schema = { path = "../../crates/ta-output-schema", version = "0.17.11-alpha.6" }
+ta-runtime = { path = "../../crates/ta-runtime", version = "0.17.11-alpha.6" }
+ta-init = { path = "../../crates/ta-init", version = "0.17.11-alpha.6" }
+ta-governed-paths = { path = "../../crates/ta-governed-paths", version = "0.17.11-alpha.6" }
+ta-plugin = { path = "../../crates/ta-plugin", version = "0.17.11-alpha.6" }
+ta-intake = { path = "../../crates/ta-intake", version = "0.17.11-alpha.6" }
+ta-brain = { path = "../../crates/ta-brain", version = "0.17.11-alpha.6" }
+ta-advisor = { path = "../../crates/ta-advisor", version = "0.17.11-alpha.6" }
+ta-release = { path = "../../crates/ta-release", version = "0.17.11-alpha.6" }
+ta-credential-broker = { path = "../../crates/ta-credential-broker", version = "0.17.11-alpha.6" }
 
 
 [target.'cfg(windows)'.build-dependencies]

--- a/crates/ta-actions/Cargo.toml
+++ b/crates/ta-actions/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 toml = { workspace = true }
-ta-plugin = { path = "../ta-plugin", version = "0.17.11-alpha.5" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-advisor/Cargo.toml
+++ b/crates/ta-advisor/Cargo.toml
@@ -17,12 +17,12 @@ tracing = { workspace = true }
 
 # Reuses the existing heuristic classifier as the substrate for the new
 # 4-way taxonomy rather than duplicating keyword-matching logic.
-ta-session = { path = "../ta-session", version = "0.17.11-alpha.5" }
+ta-session = { path = "../ta-session", version = "0.17.11-alpha.6" }
 # Team-coordinator capability (v0.17.0.12.20): reuses ta-intake's TriggerEvent
 # and ta-brain's routing/prioritization rather than a new persistent role —
 # see crates/ta-advisor/src/coordinator.rs for the decision rationale.
-ta-intake = { path = "../ta-intake", version = "0.17.11-alpha.5" }
-ta-brain = { path = "../ta-brain", version = "0.17.11-alpha.5" }
+ta-intake = { path = "../ta-intake", version = "0.17.11-alpha.6" }
+ta-brain = { path = "../ta-brain", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-agent-whiteboard/Cargo.toml
+++ b/crates/ta-agent-whiteboard/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = "0.1"
 async-nats = "0.50"
 bytes = "1"
 futures-util = "0.3"
-ta-session = { path = "../ta-session", version = "0.17.11-alpha.5" }
+ta-session = { path = "../ta-session", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-brain/Cargo.toml
+++ b/crates/ta-brain/Cargo.toml
@@ -18,13 +18,13 @@ chrono = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
-ta-session = { path = "../ta-session", version = "0.17.11-alpha.5" }
-ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.5" }
-ta-intake = { path = "../ta-intake", version = "0.17.11-alpha.5" }
+ta-session = { path = "../ta-session", version = "0.17.11-alpha.6" }
+ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.6" }
+ta-intake = { path = "../ta-intake", version = "0.17.11-alpha.6" }
 # Folds ta-workflow's template-matching intent resolver in as one signal
 # route() consults (v0.17.0.12.23), rather than a second, parallel intent
 # system — see route.rs's resolve_workflow_template().
-ta-workflow = { path = "../ta-workflow", version = "0.17.11-alpha.5" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-brain/src/route.rs
+++ b/crates/ta-brain/src/route.rs
@@ -743,6 +743,8 @@ mod tests {
             agent_id: "claude-sonnet-4-6".to_string(),
             security: AdvisorSecurity::ReadOnly,
             persona: Some("careful-implementer".to_string()),
+            model_tier: None,
+            handles_tags: Vec::new(),
         });
         team_config.save(tmp.path()).unwrap();
         let decision = route(&explicit("Add a new dashboard widget"), tmp.path());
@@ -758,6 +760,8 @@ mod tests {
             agent_id: "claude-sonnet-4-6".to_string(),
             security: AdvisorSecurity::ReadOnly,
             persona: Some("careful-implementer".to_string()),
+            model_tier: None,
+            handles_tags: Vec::new(),
         });
         team_config.save(tmp.path()).unwrap();
         let mut req = ExplicitGoalRequest::new("Add a new dashboard widget");
@@ -839,6 +843,8 @@ mod tests {
             agent_id: "claude-sonnet-4-6".to_string(),
             security: AdvisorSecurity::Suggest,
             persona: None,
+            model_tier: None,
+            handles_tags: Vec::new(),
         });
         team_config.save(tmp.path()).unwrap();
         let decision = route(&explicit("Add a new dashboard widget"), tmp.path());

--- a/crates/ta-connectors/comfyui/Cargo.toml
+++ b/crates/ta-connectors/comfyui/Cargo.toml
@@ -17,7 +17,7 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
 reqwest = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.11-alpha.5" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-connectors/discord/Cargo.toml
+++ b/crates/ta-connectors/discord/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.11-alpha.5" }
+ta-events = { path = "../../ta-events", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/email/Cargo.toml
+++ b/crates/ta-connectors/email/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.11-alpha.5" }
+ta-events = { path = "../../ta-events", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/fs/Cargo.toml
+++ b/crates/ta-connectors/fs/Cargo.toml
@@ -16,9 +16,9 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.11-alpha.5" }
-ta-workspace = { path = "../../ta-workspace", version = "0.17.11-alpha.5" }
-ta-audit = { path = "../../ta-audit", version = "0.17.11-alpha.5" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.11-alpha.6" }
+ta-workspace = { path = "../../ta-workspace", version = "0.17.11-alpha.6" }
+ta-audit = { path = "../../ta-audit", version = "0.17.11-alpha.6" }
 [dev-dependencies]
 tempfile = { workspace = true }
-ta-policy = { path = "../../ta-policy", version = "0.17.11-alpha.5" }
+ta-policy = { path = "../../ta-policy", version = "0.17.11-alpha.6" }

--- a/crates/ta-connectors/slack/Cargo.toml
+++ b/crates/ta-connectors/slack/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true }
 async-trait = "0.1"
-ta-events = { path = "../../ta-events", version = "0.17.11-alpha.5" }
+ta-events = { path = "../../ta-events", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/ta-connectors/unreal/Cargo.toml
+++ b/crates/ta-connectors/unreal/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 toml = { workspace = true }
-ta-changeset = { path = "../../ta-changeset", version = "0.17.11-alpha.5" }
+ta-changeset = { path = "../../ta-changeset", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-credential-broker/Cargo.toml
+++ b/crates/ta-credential-broker/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
-ta-credentials = { path = "../ta-credentials", version = "0.17.11-alpha.5" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-daemon/Cargo.toml
+++ b/crates/ta-daemon/Cargo.toml
@@ -31,26 +31,26 @@ async-stream = { workspace = true }
 sha2 = { workspace = true }
 
 # Internal crates
-ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.11-alpha.5" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.11-alpha.5" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.5" }
-ta-memory = { path = "../ta-memory", version = "0.17.11-alpha.5" }
-ta-events = { path = "../ta-events", version = "0.17.11-alpha.5" }
-ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.5" }
-ta-plan = { path = "../ta-plan", version = "0.17.11-alpha.5" }
-ta-plan-wayfinder = { path = "../ta-plan-wayfinder", version = "0.17.11-alpha.5" }
-ta-runtime = { path = "../ta-runtime", version = "0.17.11-alpha.5" }
-ta-audit = { path = "../ta-audit", version = "0.17.11-alpha.5" }
-ta-policy = { path = "../ta-policy", version = "0.17.11-alpha.5" }
-ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.11-alpha.5" }
-ta-connector-email = { path = "../ta-connectors/email", version = "0.17.11-alpha.5" }
+ta-mcp-gateway = { path = "../ta-mcp-gateway", version = "0.17.11-alpha.6" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.11-alpha.6" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.6" }
+ta-memory = { path = "../ta-memory", version = "0.17.11-alpha.6" }
+ta-events = { path = "../ta-events", version = "0.17.11-alpha.6" }
+ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.6" }
+ta-plan = { path = "../ta-plan", version = "0.17.11-alpha.6" }
+ta-plan-wayfinder = { path = "../ta-plan-wayfinder", version = "0.17.11-alpha.6" }
+ta-runtime = { path = "../ta-runtime", version = "0.17.11-alpha.6" }
+ta-audit = { path = "../ta-audit", version = "0.17.11-alpha.6" }
+ta-policy = { path = "../ta-policy", version = "0.17.11-alpha.6" }
+ta-connector-slack = { path = "../ta-connectors/slack", version = "0.17.11-alpha.6" }
+ta-connector-email = { path = "../ta-connectors/email", version = "0.17.11-alpha.6" }
 reqwest = { workspace = true }
-ta-output-schema = { path = "../ta-output-schema", version = "0.17.11-alpha.5" }
-ta-extension = { path = "../ta-extension", version = "0.17.11-alpha.5" }
-ta-session = { path = "../ta-session", version = "0.17.11-alpha.5" }
-ta-advisor = { path = "../ta-advisor", version = "0.17.11-alpha.5" }
-ta-data-spec = { path = "../ta-data-spec", version = "0.17.11-alpha.5" }
-ta-init = { path = "../ta-init", version = "0.17.11-alpha.5" }
+ta-output-schema = { path = "../ta-output-schema", version = "0.17.11-alpha.6" }
+ta-extension = { path = "../ta-extension", version = "0.17.11-alpha.6" }
+ta-session = { path = "../ta-session", version = "0.17.11-alpha.6" }
+ta-advisor = { path = "../ta-advisor", version = "0.17.11-alpha.6" }
+ta-data-spec = { path = "../ta-data-spec", version = "0.17.11-alpha.6" }
+ta-init = { path = "../ta-init", version = "0.17.11-alpha.6" }
 which = "7"
 libc = { workspace = true }
 async-trait = "0.1"

--- a/crates/ta-daemon/src/team_session.rs
+++ b/crates/ta-daemon/src/team_session.rs
@@ -395,7 +395,11 @@ pub fn build_ta_run_args(
             args.push(persona.clone());
         }
         args.push("--agent".to_string());
-        args.push(member.agent_id.clone());
+        // Resolves `member.model_tier` against `team_config.model_tiers`
+        // when set, falling back to `member.agent_id` otherwise
+        // (v0.17.11.6) — this is the one place model_tier actually
+        // affects which model launches a role.
+        args.push(team_config.resolve_agent_id(member).to_string());
     }
     // A role with no `.ta/team.toml` assignment yet falls through to
     // `ta run`'s own default resolution chain (workflow.toml, daemon.toml,
@@ -1004,6 +1008,58 @@ mod tests {
         assert!(args.contains(&"auto".to_string()));
         assert!(args.contains(&"--persona".to_string()));
         assert!(args.contains(&"careful-analyst".to_string()));
+        assert!(args.contains(&"--agent".to_string()));
+        assert!(args.contains(&"claude-sonnet-4-6".to_string()));
+    }
+
+    #[test]
+    fn build_args_model_tier_overrides_agent_id_when_resolvable() {
+        // Proves model_tier actually affects which model launches a role
+        // (v0.17.11.6), not just that the field round-trips through TOML.
+        let dir = tempfile::tempdir().unwrap();
+        let state = TeamSessionState::new("sess-1".to_string(), sample_config(), sample_stages());
+        let stage = &state.stages[0];
+        let context_path = write_session_context(dir.path(), &state, &stage.name).unwrap();
+
+        let mut team_config = TeamConfig::default();
+        team_config.assign(
+            TeamRole::new("analyst"),
+            "claude-sonnet-4-6".to_string(),
+            ta_session::workflow_session::AdvisorSecurity::Auto,
+            None,
+        );
+        team_config
+            .model_tiers
+            .insert("highest".to_string(), "claude-opus-5".to_string());
+        team_config.members[0].model_tier = Some("highest".to_string());
+
+        let args = build_ta_run_args(&state, stage, "analyst", &team_config, &context_path);
+
+        assert!(args.contains(&"--agent".to_string()));
+        assert!(args.contains(&"claude-opus-5".to_string()));
+        assert!(!args.contains(&"claude-sonnet-4-6".to_string()));
+    }
+
+    #[test]
+    fn build_args_model_tier_falls_back_to_agent_id_when_tier_unresolvable() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = TeamSessionState::new("sess-1".to_string(), sample_config(), sample_stages());
+        let stage = &state.stages[0];
+        let context_path = write_session_context(dir.path(), &state, &stage.name).unwrap();
+
+        let mut team_config = TeamConfig::default();
+        team_config.assign(
+            TeamRole::new("analyst"),
+            "claude-sonnet-4-6".to_string(),
+            ta_session::workflow_session::AdvisorSecurity::Auto,
+            None,
+        );
+        // model_tier set, but not declared in [model_tiers] — should not
+        // block launching the role, just fall back to agent_id.
+        team_config.members[0].model_tier = Some("nonexistent-tier".to_string());
+
+        let args = build_ta_run_args(&state, stage, "analyst", &team_config, &context_path);
+
         assert!(args.contains(&"--agent".to_string()));
         assert!(args.contains(&"claude-sonnet-4-6".to_string()));
     }

--- a/crates/ta-data-spec/Cargo.toml
+++ b/crates/ta-data-spec/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 [dependencies]
 schemars = { workspace = true }
 serde_json = { workspace = true }
-ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.5" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.5" }
-ta-brain = { path = "../ta-brain", version = "0.17.11-alpha.5" }
-ta-intake = { path = "../ta-intake", version = "0.17.11-alpha.5" }
+ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.6" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.6" }
+ta-brain = { path = "../ta-brain", version = "0.17.11-alpha.6" }
+ta-intake = { path = "../ta-intake", version = "0.17.11-alpha.6" }

--- a/crates/ta-db-proxy/Cargo.toml
+++ b/crates/ta-db-proxy/Cargo.toml
@@ -17,10 +17,10 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
-ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.11-alpha.5" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.11-alpha.5" }
+ta-db-overlay = { path = "../ta-db-overlay", version = "0.17.11-alpha.6" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.11-alpha.6" }
 ta-decision = { git = "https://github.com/Trusted-Autonomy/decision-gate", tag = "v0.1.0", package = "decision-gate" }
-ta-actions = { path = "../ta-actions", version = "0.17.11-alpha.5" }
+ta-actions = { path = "../ta-actions", version = "0.17.11-alpha.6" }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ta-intake/Cargo.toml
+++ b/crates/ta-intake/Cargo.toml
@@ -19,8 +19,8 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 regex = { workspace = true }
-ta-submit = { path = "../ta-submit", version = "0.17.11-alpha.5" }
-ta-events = { path = "../ta-events", version = "0.17.11-alpha.5" }
+ta-submit = { path = "../ta-submit", version = "0.17.11-alpha.6" }
+ta-events = { path = "../ta-events", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-mcp-gateway/Cargo.toml
+++ b/crates/ta-mcp-gateway/Cargo.toml
@@ -25,27 +25,27 @@ which = { workspace = true }
 toml = { workspace = true }
 
 # Internal crates
-ta-audit = { path = "../ta-audit", version = "0.17.11-alpha.5" }
-ta-events = { path = "../ta-events", version = "0.17.11-alpha.5" }
-ta-memory = { path = "../ta-memory", version = "0.17.11-alpha.5" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.5" }
-ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.11-alpha.5" }
-ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.11-alpha.5" }
-ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.11-alpha.5" }
-ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.11-alpha.5" }
-ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.5" }
-ta-plan = { path = "../ta-plan", version = "0.17.11-alpha.5" }
-ta-plan-wayfinder = { path = "../ta-plan-wayfinder", version = "0.17.11-alpha.5" }
-ta-policy = { path = "../ta-policy", version = "0.17.11-alpha.5" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.11-alpha.5" }
-ta-workflow = { path = "../ta-workflow", version = "0.17.11-alpha.5" }
-ta-actions = { path = "../ta-actions", version = "0.17.11-alpha.5" }
-ta-submit = { path = "../ta-submit", version = "0.17.11-alpha.5" }
+ta-audit = { path = "../ta-audit", version = "0.17.11-alpha.6" }
+ta-events = { path = "../ta-events", version = "0.17.11-alpha.6" }
+ta-memory = { path = "../ta-memory", version = "0.17.11-alpha.6" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.6" }
+ta-connector-fs = { path = "../ta-connectors/fs", version = "0.17.11-alpha.6" }
+ta-connector-unreal = { path = "../ta-connectors/unreal", version = "0.17.11-alpha.6" }
+ta-connector-comfyui = { path = "../ta-connectors/comfyui", version = "0.17.11-alpha.6" }
+ta-connector-unity = { path = "../ta-connectors/unity", version = "0.17.11-alpha.6" }
+ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.6" }
+ta-plan = { path = "../ta-plan", version = "0.17.11-alpha.6" }
+ta-plan-wayfinder = { path = "../ta-plan-wayfinder", version = "0.17.11-alpha.6" }
+ta-policy = { path = "../ta-policy", version = "0.17.11-alpha.6" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.11-alpha.6" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.11-alpha.6" }
+ta-actions = { path = "../ta-actions", version = "0.17.11-alpha.6" }
+ta-submit = { path = "../ta-submit", version = "0.17.11-alpha.6" }
 ta-decision = { git = "https://github.com/Trusted-Autonomy/decision-gate", tag = "v0.1.0", package = "decision-gate" }
-ta-credentials = { path = "../ta-credentials", version = "0.17.11-alpha.5" }
-ta-session = { path = "../ta-session", version = "0.17.11-alpha.5" }
-ta-credential-broker = { path = "../ta-credential-broker", version = "0.17.11-alpha.5" }
-ta-agent-whiteboard = { path = "../ta-agent-whiteboard", version = "0.17.11-alpha.5" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.11-alpha.6" }
+ta-session = { path = "../ta-session", version = "0.17.11-alpha.6" }
+ta-credential-broker = { path = "../ta-credential-broker", version = "0.17.11-alpha.6" }
+ta-agent-whiteboard = { path = "../ta-agent-whiteboard", version = "0.17.11-alpha.6" }
 
 
 [dev-dependencies]

--- a/crates/ta-mediation/Cargo.toml
+++ b/crates/ta-mediation/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Workspace crates for FsMediator
-ta-workspace = { path = "../ta-workspace", version = "0.17.11-alpha.5" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.5" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.11-alpha.6" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-plan-wayfinder/Cargo.toml
+++ b/crates/ta-plan-wayfinder/Cargo.toml
@@ -19,10 +19,10 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 reqwest = { workspace = true }
 url = "2"
-ta-plan = { path = "../ta-plan", version = "0.17.11-alpha.5" }
-ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.5" }
-ta-submit = { path = "../ta-submit", version = "0.17.11-alpha.5" }
-ta-credentials = { path = "../ta-credentials", version = "0.17.11-alpha.5" }
+ta-plan = { path = "../ta-plan", version = "0.17.11-alpha.6" }
+ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.6" }
+ta-submit = { path = "../ta-submit", version = "0.17.11-alpha.6" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-plan/Cargo.toml
+++ b/crates/ta-plan/Cargo.toml
@@ -19,9 +19,9 @@ chrono = { workspace = true }
 sha2 = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
-ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.5" }
-ta-submit = { path = "../ta-submit", version = "0.17.11-alpha.5" }
-ta-workflow = { path = "../ta-workflow", version = "0.17.11-alpha.5" }
+ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.6" }
+ta-submit = { path = "../ta-submit", version = "0.17.11-alpha.6" }
+ta-workflow = { path = "../ta-workflow", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-release/Cargo.toml
+++ b/crates/ta-release/Cargo.toml
@@ -18,7 +18,7 @@ toml = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 reqwest = { workspace = true, features = ["multipart"] }
-ta-plugin = { path = "../ta-plugin", version = "0.17.11-alpha.5" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-runtime/Cargo.toml
+++ b/crates/ta-runtime/Cargo.toml
@@ -23,8 +23,8 @@ which = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
 
-ta-credentials = { path = "../ta-credentials", version = "0.17.11-alpha.5" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.11-alpha.5" }
+ta-credentials = { path = "../ta-credentials", version = "0.17.11-alpha.6" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.11-alpha.6" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/ta-sandbox/Cargo.toml
+++ b/crates/ta-sandbox/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sha2 = { workspace = true }
-ta-policy = { path = "../ta-policy", version = "0.17.11-alpha.5" }
+ta-policy = { path = "../ta-policy", version = "0.17.11-alpha.6" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ta-session/Cargo.toml
+++ b/crates/ta-session/Cargo.toml
@@ -25,8 +25,8 @@ notify = { workspace = true }
 toml = { workspace = true }
 
 # Workspace crates
-ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.5" }
-ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.5" }
+ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.6" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.6" }
 ta-decision = { git = "https://github.com/Trusted-Autonomy/decision-gate", tag = "v0.1.0", package = "decision-gate" }
 
 [dev-dependencies]

--- a/crates/ta-session/src/agent_action.rs
+++ b/crates/ta-session/src/agent_action.rs
@@ -89,6 +89,20 @@ pub struct TeamMember {
     pub security: crate::workflow_session::AdvisorSecurity,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub persona: Option<String>,
+    /// Named tier (e.g. `"highest"`, `"standard"`, `"economy"`) resolved
+    /// against `TeamConfig::model_tiers` to pick the concrete `agent_id` to
+    /// launch this role with (v0.17.11.6 — virtual-team model-tier policy).
+    /// Data-defined like `TeamRole` rather than a closed enum, so new tiers
+    /// don't require a schema change. `agent_id` remains the fallback when
+    /// unset or when the tier isn't found in `model_tiers`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_tier: Option<String>,
+    /// Local tags this role handles, consulted by a virtual team's own
+    /// orchestrator persona when routing incoming work — mirrors Wayfinder's
+    /// `TeamRole.handles_verbs` convention. Never sent externally; purely a
+    /// per-project routing hint (v0.17.11.6).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub handles_tags: Vec<String>,
 }
 
 // ── RoleRef ───────────────────────────────────────────────────────────────────

--- a/crates/ta-session/src/team.rs
+++ b/crates/ta-session/src/team.rs
@@ -1,16 +1,25 @@
-// team.rs — Virtual team configuration: team.toml schema, parser, and personas path (v0.17.0.3).
+// team.rs — Virtual team configuration: team.toml schema, parser, and personas path (v0.17.0.3, model_tier/handles_tags added v0.17.11.6).
 //
 // `.ta/team.toml` declares which agent ID fills each team role and at what security level.
+// `model_tier` (optional) overrides `agent_id` via a lookup in the top-level `[model_tiers]`
+// table; `handles_tags` (optional) is a local routing hint consulted only by a virtual
+// team's own orchestrator persona, never by TA core.
 //
 // Example:
 // ```toml
+// [model_tiers]
+// highest = "claude-opus-5"
+//
 // [[members]]
 // role = "reviewer"
 // agent_id = "claude-sonnet-4-6"
 // security = "auto"
 // persona = "strict-reviewer"
+// model_tier = "highest"
+// handles_tags = ["task-delegation"]
 // ```
 
+use std::collections::HashMap;
 use std::io;
 use std::path::Path;
 
@@ -36,6 +45,12 @@ pub enum TeamConfigError {
 pub struct TeamConfig {
     #[serde(default)]
     pub members: Vec<TeamMember>,
+    /// Named tier -> concrete `agent_id` (e.g. `highest = "claude-opus-5"`).
+    /// Looked up by `TeamMember.model_tier`; a member's `agent_id` remains
+    /// the fallback when its tier is unset or not present here
+    /// (v0.17.11.6).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub model_tiers: HashMap<String, String>,
 }
 
 impl TeamConfig {
@@ -68,10 +83,33 @@ impl TeamConfig {
         self.members.iter().find(|m| &m.role == role)
     }
 
+    /// All team members whose `handles_tags` includes `tag` — a local
+    /// routing lookup for a virtual team's own orchestrator persona
+    /// (v0.17.11.6); never consulted by TA core itself.
+    pub fn find_by_tag(&self, tag: &str) -> Vec<&TeamMember> {
+        self.members
+            .iter()
+            .filter(|m| m.handles_tags.iter().any(|t| t == tag))
+            .collect()
+    }
+
+    /// Resolve `member`'s `agent_id` against this config's `model_tiers` —
+    /// `member.model_tier` wins when set and present in `model_tiers`;
+    /// `member.agent_id` is the fallback otherwise (v0.17.11.6).
+    pub fn resolve_agent_id<'a>(&'a self, member: &'a TeamMember) -> &'a str {
+        member
+            .model_tier
+            .as_deref()
+            .and_then(|tier| self.model_tiers.get(tier))
+            .map(String::as_str)
+            .unwrap_or(&member.agent_id)
+    }
+
     /// Upsert a team member for the given role.
     ///
     /// If a member with `role` already exists, updates their fields.
-    /// Otherwise appends a new member. Returns `&mut Self` for chaining.
+    /// Otherwise appends a new member (with no tier/tags — set those via
+    /// direct field access). Returns `&mut Self` for chaining.
     pub fn assign(
         &mut self,
         role: TeamRole,
@@ -89,6 +127,8 @@ impl TeamConfig {
                 agent_id,
                 security,
                 persona,
+                model_tier: None,
+                handles_tags: Vec::new(),
             });
         }
         self
@@ -125,6 +165,8 @@ mod tests {
             agent_id: "claude-sonnet-4-6".to_string(),
             security: AdvisorSecurity::ReadOnly,
             persona: None,
+            model_tier: None,
+            handles_tags: Vec::new(),
         }
     }
 
@@ -144,6 +186,8 @@ mod tests {
             agent_id: "claude-sonnet-4-6".to_string(),
             security: AdvisorSecurity::Auto,
             persona: Some("strict-reviewer".to_string()),
+            model_tier: None,
+            handles_tags: Vec::new(),
         });
         config.save(tmp.path()).unwrap();
 
@@ -167,12 +211,16 @@ mod tests {
             agent_id: "claude-opus-4-8".to_string(),
             security: AdvisorSecurity::ReadOnly,
             persona: None,
+            model_tier: None,
+            handles_tags: Vec::new(),
         });
         config.members.push(TeamMember {
             role: TeamRole::reviewer(),
             agent_id: "claude-sonnet-4-6".to_string(),
             security: AdvisorSecurity::Auto,
             persona: Some("strict".to_string()),
+            model_tier: None,
+            handles_tags: Vec::new(),
         });
         config.save(tmp.path()).unwrap();
 
@@ -192,6 +240,8 @@ mod tests {
             agent_id: "claude-opus-4-8".to_string(),
             security: AdvisorSecurity::ReadOnly,
             persona: None,
+            model_tier: None,
+            handles_tags: Vec::new(),
         });
         config.save(tmp.path()).unwrap();
 
@@ -270,6 +320,128 @@ persona = "strict-reviewer"
         assert!(config.find_by_role(&TeamRole::reviewer()).is_some());
         assert!(config.find_by_role(&TeamRole::qa()).is_some());
         assert!(config.find_by_role(&TeamRole::architect()).is_none());
+    }
+
+    #[test]
+    fn team_toml_model_tier_and_handles_tags_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = TeamConfig::default();
+        config
+            .model_tiers
+            .insert("highest".to_string(), "claude-opus-5".to_string());
+        config.members.push(TeamMember {
+            role: TeamRole::new("chief-of-staff"),
+            agent_id: "claude-sonnet-5".to_string(),
+            security: AdvisorSecurity::Auto,
+            persona: None,
+            model_tier: Some("highest".to_string()),
+            handles_tags: vec![
+                "task-delegation".to_string(),
+                "research-request".to_string(),
+            ],
+        });
+        config.save(tmp.path()).unwrap();
+
+        let loaded = TeamConfig::load(tmp.path()).unwrap();
+        assert_eq!(loaded.members.len(), 1);
+        assert_eq!(loaded.members[0].model_tier, Some("highest".to_string()));
+        assert_eq!(
+            loaded.members[0].handles_tags,
+            vec![
+                "task-delegation".to_string(),
+                "research-request".to_string()
+            ]
+        );
+        assert_eq!(
+            loaded.model_tiers.get("highest"),
+            Some(&"claude-opus-5".to_string())
+        );
+    }
+
+    #[test]
+    fn team_toml_missing_model_tier_and_handles_tags_default_empty() {
+        // Backward compatibility: existing team.toml files with neither
+        // field must keep parsing identically (matches the well-known-roles
+        // regression guard above).
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".ta")).unwrap();
+        std::fs::write(
+            tmp.path().join(".ta").join("team.toml"),
+            r#"
+[[members]]
+role = "reviewer"
+agent_id = "claude-sonnet-4-6"
+security = "auto"
+"#,
+        )
+        .unwrap();
+
+        let loaded = TeamConfig::load(tmp.path()).unwrap();
+        assert_eq!(loaded.members.len(), 1);
+        assert_eq!(loaded.members[0].model_tier, None);
+        assert!(loaded.members[0].handles_tags.is_empty());
+        assert!(loaded.model_tiers.is_empty());
+    }
+
+    #[test]
+    fn resolve_agent_id_uses_tier_when_set_and_present() {
+        let mut config = TeamConfig::default();
+        config
+            .model_tiers
+            .insert("highest".to_string(), "claude-opus-5".to_string());
+        let mut member = make_member(TeamRole::reviewer());
+        member.model_tier = Some("highest".to_string());
+
+        assert_eq!(config.resolve_agent_id(&member), "claude-opus-5");
+    }
+
+    #[test]
+    fn resolve_agent_id_falls_back_to_agent_id_when_tier_unset() {
+        let config = TeamConfig::default();
+        let member = make_member(TeamRole::reviewer());
+
+        assert_eq!(config.resolve_agent_id(&member), "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn resolve_agent_id_falls_back_to_agent_id_when_tier_not_found() {
+        let config = TeamConfig::default();
+        let mut member = make_member(TeamRole::reviewer());
+        member.model_tier = Some("nonexistent-tier".to_string());
+
+        // The tier is set but not declared in `model_tiers` — fall back
+        // rather than error, since a stale/typo'd tier shouldn't break
+        // launching the role entirely.
+        assert_eq!(config.resolve_agent_id(&member), "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn find_by_tag_returns_matching_members_only() {
+        let mut config = TeamConfig::default();
+        let mut chief = make_member(TeamRole::new("chief-of-staff"));
+        chief.handles_tags = vec!["task-delegation".to_string()];
+        let mut worker = make_member(TeamRole::implementer());
+        worker.handles_tags = vec!["docs".to_string()];
+        config.members.push(chief);
+        config.members.push(worker);
+
+        let matches = config.find_by_tag("task-delegation");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].role, TeamRole::new("chief-of-staff"));
+        assert!(config.find_by_tag("nonexistent-tag").is_empty());
+    }
+
+    #[test]
+    fn assign_new_member_defaults_tier_and_tags_empty() {
+        let mut config = TeamConfig::default();
+        config.assign(
+            TeamRole::implementer(),
+            "claude-opus".to_string(),
+            AdvisorSecurity::ReadOnly,
+            None,
+        );
+        assert_eq!(config.members[0].model_tier, None);
+        assert!(config.members[0].handles_tags.is_empty());
     }
 
     #[test]

--- a/crates/ta-submit/Cargo.toml
+++ b/crates/ta-submit/Cargo.toml
@@ -16,10 +16,10 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.5" }
-ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.5" }
-ta-workspace = { path = "../ta-workspace", version = "0.17.11-alpha.5" }
-ta-plugin = { path = "../ta-plugin", version = "0.17.11-alpha.5" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.6" }
+ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.6" }
+ta-workspace = { path = "../ta-workspace", version = "0.17.11-alpha.6" }
+ta-plugin = { path = "../ta-plugin", version = "0.17.11-alpha.6" }
 ta-decision = { git = "https://github.com/Trusted-Autonomy/decision-gate", tag = "v0.1.0", package = "decision-gate" }
 toml = "0.8"
 

--- a/crates/ta-workflow/Cargo.toml
+++ b/crates/ta-workflow/Cargo.toml
@@ -21,12 +21,12 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.5" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.6" }
 task-graph = { git = "https://github.com/Trusted-Autonomy/task-graph", tag = "v0.1.0" }
 # Reused by graph::nodes::PolicyReviewer (v0.17.7.1) — wraps the existing
 # should_auto_approve_draft rule evaluation as one ReviewerNode, per
 # constitution §1.7 (reuse before reinventing). Leaf crate, no cycle risk.
-ta-policy = { path = "../ta-policy", version = "0.17.11-alpha.5" }
+ta-policy = { path = "../ta-policy", version = "0.17.11-alpha.6" }
 # Reused by graph::nodes::AdvisorConfidenceReviewer (v0.17.7.1) — wraps the
 # existing gate::decide() confidence check as one ReviewerNode. Leaf crate,
 # no cycle risk.

--- a/crates/ta-workspace/Cargo.toml
+++ b/crates/ta-workspace/Cargo.toml
@@ -21,8 +21,8 @@ reqwest = { workspace = true }
 anyhow = { workspace = true }
 sha2 = "0.10"
 base64 = { workspace = true }
-ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.5" }
-ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.5" }
+ta-changeset = { path = "../ta-changeset", version = "0.17.11-alpha.6" }
+ta-goal = { path = "../ta-goal", version = "0.17.11-alpha.6" }
 tempfile = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # Trusted Autonomy -- User Guide
 
-**Version**: 0.17.11-alpha.5
+**Version**: 0.17.11-alpha.6
 
 Trusted Autonomy (TA) is a governance wrapper for AI agents. It lets any agent work freely in an isolated workspace, then holds the proposed changes at a human review checkpoint before anything takes effect. You see what the agent wants to do, approve or reject each change, and maintain a complete audit trail.
 


### PR DESCRIPTION
## Summary
- Adds `model_tier: Option<String>` and `handles_tags: Vec<String>` to `TeamMember` (`ta-session`), both small, additive, `#[serde(default)]` — existing `.ta/team.toml` files round-trip identically.
- `TeamConfig` gains `model_tiers: HashMap<String, String>` (named tier -> concrete `agent_id`) and `resolve_agent_id(&member)`, which `team_session.rs`'s `build_ta_run_args` now calls instead of reading `member.agent_id` directly — `model_tier` actually changes which model launches a role, not just a field that round-trips unused.
- `TeamConfig::find_by_tag()` mirrors `find_by_role()` — a local routing lookup for a virtual team's own orchestrator persona, never consulted by TA core itself.
- Unblocks Phase 0 of the private `Trusted-Autonomy/ta-virtual-team` repo, which needs both fields before `.ta/team.toml` can express its model-tier policy or local routing tags. Neither field is Wayfinder-specific.
- PLAN.md: new `v0.17.11.6` phase, marked done. Version bumped `0.17.11-alpha.5` → `0.17.11-alpha.6` via `scripts/bump-version.sh`.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (all green, including new round-trip/resolution/backward-compat tests in `ta-session::team` and `ta-daemon::team_session`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`